### PR TITLE
Enable use of environment variables for DB connections

### DIFF
--- a/arp_aggloprogramme_pub/build.gradle
+++ b/arp_aggloprogramme_pub/build.gradle
@@ -6,8 +6,8 @@ apply plugin: 'ch.so.agi.gretl'
 defaultTasks 'transferArpAggloprogramme'
 
 task transferArpAggloprogramme(type: Db2Db){
-    sourceDb = [sogisDbUri, sourceDbUser, sourceDbPass]
-    targetDb = [pubDbUri, targetDbUser, targetDbPass]
+    sourceDb = [sogisDbUri, sogisDbUser, sogisDbPwd]
+    targetDb = [pubDbUri, pubDbUser, pubDbPwd]
     transferSets = [
             new TransferSet('arp_aggloprogramme_pub_agglomrtnsprgrmme_agglomerationsprogramm.sql',
                     'arp_aggloprogramme_pub.agglomrtnsprgrmme_agglomerationsprogramm', true),

--- a/arp_aggloprogramme_pub/build.gradle
+++ b/arp_aggloprogramme_pub/build.gradle
@@ -6,8 +6,8 @@ apply plugin: 'ch.so.agi.gretl'
 defaultTasks 'transferArpAggloprogramme'
 
 task transferArpAggloprogramme(type: Db2Db){
-    sourceDb = [sourceDbUrl, sourceDbUser, sourceDbPass]
-    targetDb = [targetDbUrl, targetDbUser, targetDbPass]
+    sourceDb = [sogisDbUri, sourceDbUser, sourceDbPass]
+    targetDb = [pubDbUri, targetDbUser, targetDbPass]
     transferSets = [
             new TransferSet('arp_aggloprogramme_pub_agglomrtnsprgrmme_agglomerationsprogramm.sql',
                     'arp_aggloprogramme_pub.agglomrtnsprgrmme_agglomerationsprogramm', true),

--- a/arp_aggloprogramme_pub/gretl-job.groovy
+++ b/arp_aggloprogramme_pub/gretl-job.groovy
@@ -8,11 +8,15 @@ properties([
 ])
 
 def sogisDbUri = ''
+def sogisDbCredentialName = ''
 def pubDbUri = ''
+def pubDbCredentialName = ''
 
 node("master") {
     sogisDbUri = "${env.sogisDbUri}"
+    sogisDbCredentialName = "${gretlDbCredential}"
     pubDbUri = "${env.pubDbUri}"
+    pubDbCredentialName = "${gretlDbCredential}"
 }
 
 node ("gretl") {
@@ -22,7 +26,9 @@ node ("gretl") {
         // show current location and content
         sh 'pwd && ls -la'
         // run job
-        sh "gradle --init-script /home/gradle/init.gradle -PsogisDbUri=${sogisDbUri} -PpubDbUri=${pubDbUri}"
+        withCredentials([usernamePassword(credentialsId: "${sogisDbCredentialName}", usernameVariable: 'sogisDbUser', passwordVariable: 'sogisDbPwd'), usernamePassword(credentialsId: "${pubDbCredentialName}", usernameVariable: 'pubDbUser', passwordVariable: 'pubDbPwd')]) {
+            sh "gradle --init-script /home/gradle/init.gradle -PsogisDbUri=${sogisDbUri} -PsogisDbUser=${sogisDbUser} -PsogisDbPwd=${sogisDbPwd} -PpubDbUri=${pubDbUri} -PpubDbUser=${pubDbUser} -PpubDbPwd=${pubDbPwd}"
+        }
     }
 }
 

--- a/arp_aggloprogramme_pub/gretl-job.groovy
+++ b/arp_aggloprogramme_pub/gretl-job.groovy
@@ -1,10 +1,10 @@
 properties([
-        // keep only the last 20 builds
-        buildDiscarder(logRotator(numToKeepStr: '20')),
-        // when to run job 
-        pipelineTriggers([
-                cron('H H(3-4) * * *')
-        ])
+    // keep only the last 20 builds
+    buildDiscarder(logRotator(numToKeepStr: '20')),
+    // when to run job 
+    pipelineTriggers([
+        cron('H H(3-4) * * *')
+    ])
 ])
 
 def sogisDbUri = ''

--- a/arp_aggloprogramme_pub/gretl-job.groovy
+++ b/arp_aggloprogramme_pub/gretl-job.groovy
@@ -7,6 +7,14 @@ properties([
         ])
 ])
 
+def sogisDbUri = ''
+def pubDbUri = ''
+
+node("master") {
+    sogisDbUri = "${env.sogisDbUri}"
+    pubDbUri = "${env.pubDbUri}"
+}
+
 node ("gretl") {
     git 'https://github.com/sogis/gretljobs.git'
     sh 'ls -la /home/gradle/libs'
@@ -14,7 +22,7 @@ node ("gretl") {
         // show current location and content
         sh 'pwd && ls -la'
         // run job
-        sh 'gradle --init-script /home/gradle/init.gradle'
+        sh "gradle --init-script /home/gradle/init.gradle -PsogisDbUri=${sogisDbUri} -PpubDbUri=${pubDbUri}"
     }
 }
 


### PR DESCRIPTION
Erstes Beispiel, wie die DB Connections mit Umgebungsvariablen und Variablen konfiguriert werden können. Damit das funktioniert, müssen in OpenShift bei der jenkins deployment configuration Umgebungsvariablen gesetzt werden. Weiter müssen gegenwärtig noch in Jenkins Credentials erfasst werden.