### PR TITLE
change lk verfuegbarkeit query

### DIFF
--- a/agi_leitungskataster_pub/agi_leitungskataster_pub_lk_verfuegbarkeit.sql
+++ b/agi_leitungskataster_pub/agi_leitungskataster_pub_lk_verfuegbarkeit.sql
@@ -1,9 +1,22 @@
 SELECT
-    ogc_fid AS t_id,
-    gem_bfs,
-    name,
-    infotext,
-    geometrie
+  t_id,
+  gem_bfs,
+  name,
+  infotext,
+  geometrie
 FROM
-    gemgis.qgis_community_not_participating_info_t
+(
+  SELECT
+    lk.ogc_fid,
+    gemeindegrenze.t_id,
+    gemeindegrenze.bfs_gemeindenummer AS gem_bfs,
+    gemeindegrenze.gemeindename AS name,
+    ''::varchar AS infotext,
+    gemeindegrenze.geometrie
+  FROM
+    agi_hoheitsgrenzen_pub.hoheitsgrenzen_gemeindegrenze AS gemeindegrenze
+    LEFT JOIN gemgis.qgis_community_not_participating_info_t AS lk
+    ON ST_Intersects(ST_PointOnSurface(gemeindegrenze.geometrie), lk.geometrie)
+) AS foo
+WHERE ogc_fid IS NULL
 ;


### PR DESCRIPTION
Neu wird das inverse kopiert: nicht die Geometrien von Gemeinden, wo keine LK verfügbar ist, sondern wo Daten vorhanden sind). Zwischenlösung bis man pro Medium eine Tabelle hat.