### PR TITLE
Set specific trigger times

### DIFF
--- a/agi_mopublic_pub/job.properties
+++ b/agi_mopublic_pub/job.properties
@@ -1,2 +1,2 @@
 logRotator.numToKeep=30
-triggers.cron=H H(1-3) * * *
+triggers.cron=45 1 * * *

--- a/agi_wmts_hetzner_seeder/job.properties
+++ b/agi_wmts_hetzner_seeder/job.properties
@@ -1,2 +1,2 @@
 logRotator.numToKeep=30
-triggers.cron=H H(1-3) * * *
+triggers.cron=0 2 * * *


### PR DESCRIPTION
Der DB-Import-Teil des AV-Import NG ist um ca. 02:30 Uhr Lokalzeit fertig. _agi_mopublic_pub_ soll also um 02:45 Lokalzeit starten, also um _01:45 UTC_.
Während der Sommerzeit bedeutet 01:45 UTC allerdings 03:45 Lokalzeit. D.h. zwischen Ende AV-Import und Start _agi_mopublic_pub_ liegt eine Stunde "brach", die wir in Kauf nehmen müssen.

_agi_mopublic_pub_ dauert ca. 7 Minuten. agi_wmts_hetzner_seeder soll deshalb um _02:00 UTC_ starten. Es dauert ca. 7h30min und ist also um ca. 9:30 UTC fertig, das ist während der Sommerzeit 11:30 Uhr Lokalzeit.

Gut möglich, dass nach der Ablösung der AV-Imports der AV-Import früher gestartet wird/werden kann. Dann könnten auch diese beiden Jobs füher gestartet werden.

In Jenkins gibt es übrigens auch das Feature "Starte Build, nachdem andere Projekte gebaut wurden"; wir können dieses im Moment noch nicht benutzen, aber das wäre eine Überlegung wert.