### PR TITLE
Set specific trigger time

### DIFF
--- a/agi_grundbuchplan_pub/job.properties
+++ b/agi_grundbuchplan_pub/job.properties
@@ -1,2 +1,2 @@
 logRotator.numToKeep=30
-triggers.cron=H H(1-3) * * *
+triggers.cron=46 1 * * *


### PR DESCRIPTION
_agi_grundbuchplan_pub_ soll (praktisch) gleichzeitig mit _agi_mopublic_pub_ gestartet werden; dadurch sollten diese beiden Jobs vor 2:00 Uhr abgeschlossen sein. Zu diesem Zeitpunkt startet nämlich _agi_wmts_hetzner_seeder_, der die von diesen beiden Jobs importierten Daten benötigt.