### PR TITLE
Feature: Allow checking out a specific branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/ada_adagisa_pub/gretl-job.groovy
+++ b/ada_adagisa_pub/gretl-job.groovy
@@ -13,7 +13,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/ada_adagisd_pub/gretl-job.groovy
+++ b/ada_adagisd_pub/gretl-job.groovy
@@ -13,7 +13,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/afu_abbaustellen_pub/gretl-job.groovy
+++ b/afu_abbaustellen_pub/gretl-job.groovy
@@ -13,7 +13,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/afu_abwasser_pub/gretl-job.groovy
+++ b/afu_abwasser_pub/gretl-job.groovy
@@ -13,7 +13,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/afu_altlasten_pub/gretl-job.groovy
+++ b/afu_altlasten_pub/gretl-job.groovy
@@ -17,7 +17,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub'), usernamePassword(credentialsId: "${dbCredentialNameAltlast4web}", usernameVariable: 'dbUserAltlast4web', passwordVariable: 'dbPwdAltlast4web')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/afu_baugk_pub/gretl-job.groovy
+++ b/afu_baugk_pub/gretl-job.groovy
@@ -13,7 +13,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/afu_baugrundklassen_pub/gretl-job.groovy
+++ b/afu_baugrundklassen_pub/gretl-job.groovy
@@ -13,7 +13,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/afu_ekat2005_pub/gretl-job.groovy
+++ b/afu_ekat2005_pub/gretl-job.groovy
@@ -13,7 +13,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/afu_ekat2010_pub/gretl-job.groovy
+++ b/afu_ekat2010_pub/gretl-job.groovy
@@ -13,7 +13,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/afu_erdwaerme_pub/gretl-job.groovy
+++ b/afu_erdwaerme_pub/gretl-job.groovy
@@ -13,7 +13,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/afu_geologie_pub/gretl-job.groovy
+++ b/afu_geologie_pub/gretl-job.groovy
@@ -13,7 +13,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/afu_gewaesserschutz_pub/gretl-job.groovy
+++ b/afu_gewaesserschutz_pub/gretl-job.groovy
@@ -13,7 +13,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/afu_gewisso_pub/gretl-job.groovy
+++ b/afu_gewisso_pub/gretl-job.groovy
@@ -13,7 +13,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/afu_grundwasserbewirtschaftung_pub/gretl-job.groovy
+++ b/afu_grundwasserbewirtschaftung_pub/gretl-job.groovy
@@ -13,7 +13,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/afu_immissionskarten_pub/gretl-job.groovy
+++ b/afu_immissionskarten_pub/gretl-job.groovy
@@ -13,7 +13,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/afu_ingeso_pub/gretl-job.groovy
+++ b/afu_ingeso_pub/gretl-job.groovy
@@ -13,7 +13,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/afu_isboden_pub/gretl-job.groovy
+++ b/afu_isboden_pub/gretl-job.groovy
@@ -13,7 +13,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/afu_naturgefahren_pub/gretl-job.groovy
+++ b/afu_naturgefahren_pub/gretl-job.groovy
@@ -13,7 +13,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/afu_schadendienst_pub/gretl-job.groovy
+++ b/afu_schadendienst_pub/gretl-job.groovy
@@ -13,7 +13,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/afu_sorkas_pub/gretl-job.groovy
+++ b/afu_sorkas_pub/gretl-job.groovy
@@ -13,7 +13,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/afu_uplus_pub/gretl-job.groovy
+++ b/afu_uplus_pub/gretl-job.groovy
@@ -13,7 +13,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/afu_vegas_pub/gretl-job.groovy
+++ b/afu_vegas_pub/gretl-job.groovy
@@ -13,7 +13,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/afu_vsb_pub/gretl-job.groovy
+++ b/afu_vsb_pub/gretl-job.groovy
@@ -13,7 +13,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/afu_wasserbewirtschaftung_pub/gretl-job.groovy
+++ b/afu_wasserbewirtschaftung_pub/gretl-job.groovy
@@ -13,7 +13,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/agi_adressen_pub/gretl-job.groovy
+++ b/agi_adressen_pub/gretl-job.groovy
@@ -13,7 +13,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/agi_av_gb_abgleich_pub/gretl-job.groovy
+++ b/agi_av_gb_abgleich_pub/gretl-job.groovy
@@ -17,7 +17,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub'), usernamePassword(credentialsId: "${dbCredentialNameCapitastra}", usernameVariable: 'dbUserCapitastra', passwordVariable: 'dbPwdCapitastra')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/agi_av_gb_administrative_einteilungen_pub/gretl-job.groovy
+++ b/agi_av_gb_administrative_einteilungen_pub/gretl-job.groovy
@@ -13,7 +13,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/agi_av_kaso_abgleich_pub/gretl-job.groovy
+++ b/agi_av_kaso_abgleich_pub/gretl-job.groovy
@@ -17,7 +17,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub'), usernamePassword(credentialsId: "${dbCredentialNameKaso}", usernameVariable: 'dbUserKaso', passwordVariable: 'dbPwdKaso')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/agi_av_mocheckso_pub/gretl-job.groovy
+++ b/agi_av_mocheckso_pub/gretl-job.groovy
@@ -13,7 +13,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/agi_av_nachfuehrung_pub/gretl-job.groovy
+++ b/agi_av_nachfuehrung_pub/gretl-job.groovy
@@ -13,7 +13,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/agi_baulinien_pub/gretl-job.groovy
+++ b/agi_baulinien_pub/gretl-job.groovy
@@ -13,7 +13,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/agi_ch_gemeinden/gretl-job.groovy
+++ b/agi_ch_gemeinden/gretl-job.groovy
@@ -13,7 +13,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/agi_check_ili_export/gretl-job.groovy
+++ b/agi_check_ili_export/gretl-job.groovy
@@ -13,7 +13,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/agi_grundbuchplan_pub/gretl-job.groovy
+++ b/agi_grundbuchplan_pub/gretl-job.groovy
@@ -13,7 +13,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/agi_hoehen_2001_pub/gretl-job.groovy
+++ b/agi_hoehen_2001_pub/gretl-job.groovy
@@ -13,7 +13,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/agi_hoehen_2014_pub/gretl-job.groovy
+++ b/agi_hoehen_2014_pub/gretl-job.groovy
@@ -13,7 +13,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/agi_hoheitsgrenzen_pub/gretl-job.groovy
+++ b/agi_hoheitsgrenzen_pub/gretl-job.groovy
@@ -13,7 +13,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/agi_hoheitsgrenzsteine_pub/gretl-job.groovy
+++ b/agi_hoheitsgrenzsteine_pub/gretl-job.groovy
@@ -13,7 +13,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/agi_leitungskataster_pub/gretl-job.groovy
+++ b/agi_leitungskataster_pub/gretl-job.groovy
@@ -13,7 +13,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/agi_mopublic_pub/gretl-job.groovy
+++ b/agi_mopublic_pub/gretl-job.groovy
@@ -13,7 +13,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/agi_plz_ortschaften_pub/gretl-job.groovy
+++ b/agi_plz_ortschaften_pub/gretl-job.groovy
@@ -13,7 +13,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/agi_wmts_hetzner_seeder/gretl-job.groovy
+++ b/agi_wmts_hetzner_seeder/gretl-job.groovy
@@ -18,7 +18,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub'), usernamePassword(credentialsId: "${dbCredentialNameHetznerWmts}", usernameVariable: 'dbUserHetznerWmts', passwordVariable: 'dbPwdHetznerWmts'), sshUserPrivateKey(credentialsId: "${hetznerWmtsServerCredential}", keyFileVariable: 'sshKeyFilePathHetznerWmts')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/alw_gelan_pub/gretl-job.groovy
+++ b/alw_gelan_pub/gretl-job.groovy
@@ -13,7 +13,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/alw_grundlagen_pub/gretl-job.groovy
+++ b/alw_grundlagen_pub/gretl-job.groovy
@@ -13,7 +13,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/alw_neophyten_pub/gretl-job.groovy
+++ b/alw_neophyten_pub/gretl-job.groovy
@@ -13,7 +13,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/alw_vernetzung_pub_sogis/gretl-job.groovy
+++ b/alw_vernetzung_pub_sogis/gretl-job.groovy
@@ -13,7 +13,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/amb_notfallplanung_kkw_pub/gretl-job.groovy
+++ b/amb_notfallplanung_kkw_pub/gretl-job.groovy
@@ -13,7 +13,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/amb_notfalltreffpunkte_pub/gretl-job.groovy
+++ b/amb_notfalltreffpunkte_pub/gretl-job.groovy
@@ -13,7 +13,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/amb_sirenenplanung_pub/gretl-job.groovy
+++ b/amb_sirenenplanung_pub/gretl-job.groovy
@@ -13,7 +13,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/amb_zivilschutz_adressen_export/gretl-job.groovy
+++ b/amb_zivilschutz_adressen_export/gretl-job.groovy
@@ -13,7 +13,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${ftpCredentialNameZivilschutz}", usernameVariable: 'ftpUserZivilschutz', passwordVariable: 'ftpPwdZivilschutz')]) {
             sh "gradle --init-script /home/gradle/init.gradle -PdbUriSogis='${dbUriSogis}' -PdbUserSogis='${dbUserSogis}' -PdbPwdSogis='${dbPwdSogis}' -PftpServerZivilschutz='${ftpServerZivilschutz}' -PftpUserZivilschutz='${ftpUserZivilschutz}' -PftpPwdZivilschutz='${ftpPwdZivilschutz}'"

--- a/arp_aggloprogramme_pub/gretl-job.groovy
+++ b/arp_aggloprogramme_pub/gretl-job.groovy
@@ -13,7 +13,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/arp_aggloprogramme_pub_sogis/gretl-job.groovy
+++ b/arp_aggloprogramme_pub_sogis/gretl-job.groovy
@@ -13,7 +13,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/arp_ivs_pub/gretl-job.groovy
+++ b/arp_ivs_pub/gretl-job.groovy
@@ -13,7 +13,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/arp_mjpnatur_pub/gretl-job.groovy
+++ b/arp_mjpnatur_pub/gretl-job.groovy
@@ -13,7 +13,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/arp_naturreservate_pub/gretl-job.groovy
+++ b/arp_naturreservate_pub/gretl-job.groovy
@@ -13,7 +13,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/arp_naturschutz_pub/gretl-job.groovy
+++ b/arp_naturschutz_pub/gretl-job.groovy
@@ -13,7 +13,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/arp_npl_export_ai/gretl-job.groovy
+++ b/arp_npl_export_ai/gretl-job.groovy
@@ -13,7 +13,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${aiCredentialName}", usernameVariable: 'aiUser', passwordVariable: 'aiPwd')]) {
             sh "gradle --init-script /home/gradle/init.gradle -PdbUriSogis='${dbUriSogis}' -PdbUserSogis='${dbUserSogis}' -PdbPwdSogis='${dbPwdSogis}' -PaiServer='${aiServer}' -PaiUser='${aiUser}' -PaiPwd='${aiPwd}'"

--- a/arp_npl_pub/gretl-job.groovy
+++ b/arp_npl_pub/gretl-job.groovy
@@ -13,7 +13,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/arp_nutzungsvereinbarung_pub/gretl-job.groovy
+++ b/arp_nutzungsvereinbarung_pub/gretl-job.groovy
@@ -13,7 +13,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/arp_nutzungsvereinbarung_pub_sogis/gretl-job.groovy
+++ b/arp_nutzungsvereinbarung_pub_sogis/gretl-job.groovy
@@ -13,7 +13,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/arp_oev_guete_pub/gretl-job.groovy
+++ b/arp_oev_guete_pub/gretl-job.groovy
@@ -13,7 +13,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/arp_richtplan_2017_pub/gretl-job.groovy
+++ b/arp_richtplan_2017_pub/gretl-job.groovy
@@ -13,7 +13,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/arp_veriso_nplso_grundlagendaten/gretl-job.groovy
+++ b/arp_veriso_nplso_grundlagendaten/gretl-job.groovy
@@ -13,7 +13,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNameVerisoNplso}", usernameVariable: 'dbUserVerisoNplso', passwordVariable: 'dbPwdVerisoNplso')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/arp_wanderwege_pub/gretl-job.groovy
+++ b/arp_wanderwege_pub/gretl-job.groovy
@@ -13,7 +13,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/arp_zonenplan_pub/gretl-job.groovy
+++ b/arp_zonenplan_pub/gretl-job.groovy
@@ -13,7 +13,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/avt_gesamtverkehrsmodell2010_pub/gretl-job.groovy
+++ b/avt_gesamtverkehrsmodell2010_pub/gretl-job.groovy
@@ -13,7 +13,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/avt_gesamtverkehrsmodell2015_pub/gretl-job.groovy
+++ b/avt_gesamtverkehrsmodell2015_pub/gretl-job.groovy
@@ -13,7 +13,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/avt_kantonsstrassen_pub/gretl-job.groovy
+++ b/avt_kantonsstrassen_pub/gretl-job.groovy
@@ -13,7 +13,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/avt_oeffentlicher_verkehr_pub/gretl-job.groovy
+++ b/avt_oeffentlicher_verkehr_pub/gretl-job.groovy
@@ -13,7 +13,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/avt_verkehrszaehlung_pub/gretl-job.groovy
+++ b/avt_verkehrszaehlung_pub/gretl-job.groovy
@@ -13,7 +13,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/awa_netzbetreiber_strom_pub/gretl-job.groovy
+++ b/awa_netzbetreiber_strom_pub/gretl-job.groovy
@@ -13,7 +13,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/awjf_biotopbaeume_pub/gretl-job.groovy
+++ b/awjf_biotopbaeume_pub/gretl-job.groovy
@@ -13,7 +13,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/awjf_forstreviere_pub/gretl-job.groovy
+++ b/awjf_forstreviere_pub/gretl-job.groovy
@@ -13,7 +13,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/awjf_jagd_pub/gretl-job.groovy
+++ b/awjf_jagd_pub/gretl-job.groovy
@@ -13,7 +13,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/awjf_wald_pub/gretl-job.groovy
+++ b/awjf_wald_pub/gretl-job.groovy
@@ -13,7 +13,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub')]) {
             sh "gradle --init-script /home/gradle/init.gradle \

--- a/awjf_wegsanierungen_pub/gretl-job.groovy
+++ b/awjf_wegsanierungen_pub/gretl-job.groovy
@@ -13,7 +13,8 @@ node("master") {
 }
 
 node ("gretl") {
-    git "${gretljobsRepo}"
+    gitBranch = "${params.BRANCH ?: 'master'}"
+    git url: "${gretljobsRepo}", branch: gitBranch
     dir(env.JOB_BASE_NAME) {
         withCredentials([usernamePassword(credentialsId: "${dbCredentialNameSogis}", usernameVariable: 'dbUserSogis', passwordVariable: 'dbPwdSogis'), usernamePassword(credentialsId: "${dbCredentialNamePub}", usernameVariable: 'dbUserPub', passwordVariable: 'dbPwdPub')]) {
             sh "gradle --init-script /home/gradle/init.gradle \


### PR DESCRIPTION
Mit dieser Änderung kann man angeben, dass der GRETL-Job einen bestimmten Branch statt dem master-Branch auschecken soll. Diese Funktionalität wird gemäss https://github.com/sogis/openshift-jenkins/blob/12c09f19db4e680c9ee79f1dcbff533bc922c036/configuration/jobs/gretl-job-generator/config.xml#L74 aber nur in der Test- und der Integrationsumgebung aktiviert.