### PR TITLE
[arp_npl_pub] fix recursive cte (again)

### DIFF
--- a/arp_npl_pub/transform_arp_npl_pub_erschliessung_flaechenobjekt_json_dokumente.sql
+++ b/arp_npl_pub/transform_arp_npl_pub_erschliessung_flaechenobjekt_json_dokumente.sql
@@ -26,6 +26,8 @@ WITH RECURSIVE x(ursprung, hinweis, parents, last_ursprung, depth) AS
     ON (last_ursprung = t1.ursprung)
   WHERE 
     t1.hinweis IS NOT NULL
+  AND
+    x.ursprung != t1.hinweis
 )
 , 
 doc_doc_references_all AS 

--- a/arp_npl_pub/transform_arp_npl_pub_erschliessung_linienobjekt_json_dokumente.sql
+++ b/arp_npl_pub/transform_arp_npl_pub_erschliessung_linienobjekt_json_dokumente.sql
@@ -26,6 +26,8 @@ WITH RECURSIVE x(ursprung, hinweis, parents, last_ursprung, depth) AS
     ON (last_ursprung = t1.ursprung)
   WHERE 
     t1.hinweis IS NOT NULL
+  AND
+    x.ursprung != t1.hinweis
 )
 , 
 doc_doc_references_all AS 

--- a/arp_npl_pub/transform_arp_npl_pub_nutzungsplanung_grundnutzung_json_dokumente.sql
+++ b/arp_npl_pub/transform_arp_npl_pub_nutzungsplanung_grundnutzung_json_dokumente.sql
@@ -61,6 +61,8 @@ WITH RECURSIVE x(ursprung, hinweis, parents, last_ursprung, depth) AS
     ON (last_ursprung = t1.ursprung)
   WHERE 
     t1.hinweis IS NOT NULL
+  AND
+    x.ursprung != t1.hinweis
 )
 , 
 doc_doc_references_all AS 

--- a/arp_npl_pub/transform_arp_npl_pub_nutzungsplanung_ueberlagernd_flaeche_json_dokumente.sql
+++ b/arp_npl_pub/transform_arp_npl_pub_nutzungsplanung_ueberlagernd_flaeche_json_dokumente.sql
@@ -26,6 +26,8 @@ WITH RECURSIVE x(ursprung, hinweis, parents, last_ursprung, depth) AS
     ON (last_ursprung = t1.ursprung)
   WHERE 
     t1.hinweis IS NOT NULL
+  AND
+    x.ursprung != t1.hinweis
 )
 , 
 doc_doc_references_all AS 

--- a/arp_npl_pub/transform_arp_npl_pub_nutzungsplanung_ueberlagernd_linie_json_dokumente.sql
+++ b/arp_npl_pub/transform_arp_npl_pub_nutzungsplanung_ueberlagernd_linie_json_dokumente.sql
@@ -26,6 +26,8 @@ WITH RECURSIVE x(ursprung, hinweis, parents, last_ursprung, depth) AS
     ON (last_ursprung = t1.ursprung)
   WHERE 
     t1.hinweis IS NOT NULL
+  AND
+    x.ursprung != t1.hinweis
 )
 , 
 doc_doc_references_all AS 

--- a/arp_npl_pub/transform_arp_npl_pub_nutzungsplanung_ueberlagernd_punkt_json_dokumente.sql
+++ b/arp_npl_pub/transform_arp_npl_pub_nutzungsplanung_ueberlagernd_punkt_json_dokumente.sql
@@ -26,6 +26,8 @@ WITH RECURSIVE x(ursprung, hinweis, parents, last_ursprung, depth) AS
     ON (last_ursprung = t1.ursprung)
   WHERE 
     t1.hinweis IS NOT NULL
+  AND
+    x.ursprung != t1.hinweis
 )
 , 
 doc_doc_references_all AS 


### PR DESCRIPTION
Die rekursive CTE verursachte immer noch Probleme bei Selbstreferenzen, d.h. Dokument A zeigt auf Dokument A. Sollte jetzt gelöst sein. Es bleibt eine kleine Unsicherheit, da die Query langsam einen Stand erreicht hat, wo ich nicht mehr alles verstehe... Auch nicht toll. 

Ein Refactoring der gesamten Query wäre sicher nicht falsch.

Was (noch) nicht abgefangen wird, sind indirekte Selbstreferenzen: Dokument A zeigt auf Dokument B. Dokument B zeigt auf Dokument A. Ob man das in einer Query unterbringt, weiss ich nicht. Auch weil man sich ja für eine Referenz entscheiden müsste.

