### PR TITLE
[alw_gelan_pub] 2 Parameter für Publikationsjahr hinzugefügt

### DIFF
--- a/alw_gelan_pub/alw_gelan_pub_bienenstandorte.sql
+++ b/alw_gelan_pub/alw_gelan_pub_bienenstandorte.sql
@@ -21,4 +21,6 @@ SELECT
     ort
 FROM
     gelan.bienen_stao_v
+WHERE
+    jahr = ${publikationsjahr_wechsel_herbst}
 ;

--- a/alw_gelan_pub/alw_gelan_pub_feuerbrand_schutzobjekte.sql
+++ b/alw_gelan_pub/alw_gelan_pub_feuerbrand_schutzobjekte.sql
@@ -8,4 +8,6 @@ FROM
     gelan.feba_schobj
 WHERE
     archive = 0
+    AND
+    jahr = ${publikationsjahr_wechsel_herbst}
 ;

--- a/alw_gelan_pub/alw_gelan_pub_feuerbrand_schutzperimeter.sql
+++ b/alw_gelan_pub/alw_gelan_pub_feuerbrand_schutzperimeter.sql
@@ -7,4 +7,6 @@ FROM
     gelan.feba_schper
 WHERE
     archive = 0
+    AND
+    jahr = ${publikationsjahr_wechsel_herbst}
 ;

--- a/alw_gelan_pub/build.gradle
+++ b/alw_gelan_pub/build.gradle
@@ -8,6 +8,11 @@ defaultTasks 'transferAlwGelan'
 task transferAlwGelan(type: Db2Db){
     sourceDb = [dbUriSogis, dbUserSogis, dbPwdSogis]
     targetDb = [dbUriPub, dbUserPub, dbPwdPub]
+    // Bei den folgenden Parametern bedeutet z.B. "publikationsjahr_wechsel_herbst:2019":
+    // Von den Datensätzen, bei denen jeweils im Herbst die Daten des neuen Jahres aufgeschaltet werden,
+    // soll gegenwärtig der Stand 2019 publiziert werden.
+    // Die Umstellung dieser Werte wird jeweils auf Verlangen des ALW zum gewünschten Zeitpunkt umgesetzt.
+    sqlParameters = [publikationsjahr_wechsel_fruehling:'2019', publikationsjahr_wechsel_herbst:'2019']
     transferSets = [
             new TransferSet('alw_gelan_pub_bienenstandorte.sql', 'alw_gelan_pub.bienenstandorte', true),
             new TransferSet('alw_gelan_pub_feuerbrand_schutzobjekte.sql', 'alw_gelan_pub.feuerbrand_schutzobjekte',


### PR DESCRIPTION
Dies funktioniert so: In den GELAN-Tabellen sind seit einiger Zeit jeweils mehrere Datenstände enthalten, identifizierbar durch das Attribut _jahr_. Es soll jeweils aber nur der Stand eines bestimmten Jahres publiziert werden. Ab welchem Zeitpunkt welcher Stand publiziert werden soll, ist aber nicht ganz fix. Es gibt Datensätze, bei denen irgendwann im Frühling der neue Stand publiziert werden soll, und solche, bei denen das irgendwann im Herbst der Fall ist.
Mit dem SQL-Parameter `publikationsjahr_wechsel_fruehling` im `build.gradle` kann nun eingestellt werden, welchen Jahresstand die Daten, die jeweils im Frühling umgestellt werden, abbilden sollen.
Mit dem SQL-Parameter `publikationsjahr_wechsel_herbst` kann eingestellt werden, welchen Jahresstand die Daten, die jeweils im Herbst umgestellt werden, abbilden sollen.

Ob ein Datensatz im Frühling oder Herbst umgestellt wird, definiert das ALW. Umgesetzt wird es, indem im entsprechenden SQL-Skript die Variable `publikationsjahr_wechsel_fruehling` oder eben `publikationsjahr_wechsel_herbst` benutzt wird.
Wenn ein Publikationsjahr umgestellt werden soll, teilt uns dies jeweils das ALW zum gewünschten Zeitpunkt mit.