### PR TITLE
[agi_check_ili_export] Model Aggloprogramme deaktiviert

### DIFF
--- a/agi_check_ili_export/build.gradle
+++ b/agi_check_ili_export/build.gradle
@@ -22,9 +22,9 @@ ext {
     dbSogis = [dbUriSogis, dbUserSogis, dbPwdSogis]
     dbEdit = [dbUriEdit, dbUserEdit, dbPwdEdit]
     models = []
-    models.add(["SO_Agglomerationsprogramme_20170512",
+    /*models.add(["SO_Agglomerationsprogramme_20170512",
                 "arp_aggloprogramme",
-                dbSogis])
+                dbSogis])*/
     models.add(["SO_ARP_Nutzungsvereinbarung_20170512",
                 "arp_nutzungsvereinbarung",
                 dbSogis ])


### PR DESCRIPTION
Infolge Fehler in den Daten das Model SO_Agglomerationsprogramme_20170512 deaktiviert. Wird wieder aktiviert sobald die Daten bereinigt sind.