### PR TITLE
[arp_zonenplan_pub] Select auf Schema arp_npl geändert

### DIFF
--- a/arp_zonenplan_pub/arp_zonenplan_pub_digitalisierter_zonenplan.sql
+++ b/arp_zonenplan_pub/arp_zonenplan_pub_digitalisierter_zonenplan.sql
@@ -13,5 +13,5 @@ FROM
 WHERE
     archive = 0
 AND 
-    gem_bfs NOT IN (SELECT DISTINCT t_datasetname::integer FROM arp_npl.nutzungsplanung_grundnutzung) --Jene Gemeinden ausschliessen, welche die Nutzungsplanung schon abgeschlossen haben! 
+    gem_bfs NOT IN (2405,2408,2457,2473,2474,2476,2498,2501,2502,2580,2613,2614,2615)
 ;


### PR DESCRIPTION
(SELECT DISTINCT t_datasetname::integer FROM arp_npl.nutzungsplanung_grundnutzung) ersetzt durch (2405,2408,2457,2473,2474,2476,2498,2501,2502,2580,2613,2614,2615)
=> Schema arp_npl gibt es auf Sogis DB nicht mehr!