### PR TITLE
Add nodeLabel property

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,10 +1,10 @@
 def gretljobsRepo = ''
 
-node("master") {
+node('master') {
     gretljobsRepo = "${env.GRETL_JOB_REPO_URL}"
 }
 
-node ("gretl") {
+node (params.nodeLabel ?: 'gretl') {
     try {
         gitBranch = "${params.BRANCH ?: 'master'}"
         git url: "${gretljobsRepo}", branch: gitBranch, changelog: false

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ parameters.fileParam=filename.xtf
 parameters.stringParam=parameterName;default value;parameter description
 triggers.upstream=other_job_name
 authorization.permissions=gretl-users-barpa
+nodeLabel=gretl-ili2pg4
 ```
 
 Mit `logRotator.numToKeep` kann eingestellt werden, wieviele Ausführungen des Jobs aufbewahrt werden sollen, d.h. für wieviele Ausführungen beispielsweise das Logfile vorgehalten wird. Standardwert ist 15. Wenn man diese Einstellung weglässt, werden also die 15 letzten Ausführungen aufbewahrt.
@@ -92,6 +93,15 @@ Folgende GRETL-spezifischen Benutzergruppen stehen im Moment zur Verfügung:
 * gretl-users-vlwaa
 
 Allerdings können auch diejenigen Benutzer oder Gruppen, welche durch globale Berechtigungseinstellungen in Jenkins dazu bereichtigt sind, den Job starten. Wenn man diese Einstellung weglässt, ist es von den globalen Berechtigungseinstellungen abhängig, wer den Job manuell starten darf.
+
+Mit `nodeLabel` kann bestimmt werden,
+auf welchem Node der Job ausgeführt werden soll.
+Erlaubt ist hier einzig der Wert `gretl-ili2pg4`;
+so wird der Job auf einem Jenkins Agent
+mit dem Label `gretl-ili2pg4` ausgeführt.
+Lässt man diese Property weg,
+wird der Job auf einem Jenkins Agent
+mit dem Label `gretl` ausgeführt (der Standard).
 
 
 ## GRETL Runtime Docker Image verwenden

--- a/gretl_job_generator.groovy
+++ b/gretl_job_generator.groovy
@@ -103,6 +103,11 @@ for (jobFile in jobFiles) {
         cron(properties.getProperty('triggers.cron'))
       }
     }
+    if (properties.getProperty('nodeLabel') != null) {
+      parameters {
+        choiceParam('nodeLabel', [properties.getProperty('nodeLabel')], 'Label of the node that must run the job')
+      }
+    }
     definition {
       cps {
         script(pipelineScript)


### PR DESCRIPTION
Dies erlaubt es, durch Hinzufügen der Property `nodeLabel=gretl-ili2pg4` zur Datei `job.properties` den Job auf einem Jenkins Agent mit dem Label `gretl-ili2pg4` auszuführen. Wenn man das Property weglässt, wird er standardmässig auf einem Jenkins Agent mit dem Label `gretl` ausgeführt.

### Wichtiger Hinweis:
Diese Variante ist suboptimal, weil sie beim manuellen Start des Jobs den Benutzern einen Parameter anzeigt, was sie möglicherweise verunsichert. Zudem (aber irgendewie auch zur Vereinfachung) haben sie keine Möglichkeit, den Parameter umzustellen (es steht nur eine Option zur Auswahl). Deshalb **noch warten mit mergen dieses Pull Requests**. Vielleicht finde ich ja noch heraus, wie ich das über eine Umgebungsvariable statt über einen Parameter lösen kann.