### PR TITLE
Start agi_mopublic_pub earlier

### DIFF
--- a/agi_grundbuchplan_pub/job.properties
+++ b/agi_grundbuchplan_pub/job.properties
@@ -1,2 +1,2 @@
 logRotator.numToKeep=30
-triggers.cron=46 1 * * *
+triggers.cron=30 1 * * *

--- a/agi_mopublic_pub/job.properties
+++ b/agi_mopublic_pub/job.properties
@@ -1,2 +1,2 @@
 logRotator.numToKeep=30
-triggers.cron=45 1 * * *
+triggers.cron=15 0 * * *


### PR DESCRIPTION
Nun bezieht _agi_mopublic_pub_ die Daten aus der Edit-DB. Dort ist der AV-Import um ca. 23:20 Lokalzeit fertig. Also kann _agi_mopublic_pub_ neu früher starten als bisher. Es könnte noch früher als 0:15, weil Jenkins in UTC funktioniert, aber das müsste ich nochmal genauer überdenken. Der Job muss auch früher starten, weil er seit der Umstellung auf segmentierte Kreisbogen ca. 1:10 dauert und sonst erst nach dem Seeder fertig ist. (Der Seeder muss evtl. zusätzlich noch später starten, weil dieser wieder in Lokalzeit funktioniert.)

Und _agi_grundbuchplan_pub_ soll starten, nachdem _agi_mopublic_pub_ fertig ist, weil es irgendwo auf agi_mopublic_pub.mopublic_gemeindegrenze zugreift, insbesondere auch um das Lieferdatum zu ermitteln: https://github.com/sogis/gretljobs/blob/4269f7eea37e89e3ee3467c796e8f082e9096d81/agi_grundbuchplan_pub/agi_grundbuchplan_pub_grundbuchplan_grundbuchplanauszug.sql#L47-L53