### PR TITLE
[afu_erdwaermesonden_pub] triggers.cron entfernt

### DIFF
--- a/afu_erdwaermesonden_pub/job.properties
+++ b/afu_erdwaermesonden_pub/job.properties
@@ -1,2 +1,1 @@
 logRotator.numToKeep=30
-triggers.cron=H H(1-3) * * *


### PR DESCRIPTION
triggers.cron temporär aus job.properties entfernt