### PR TITLE
[avt_ausnahmetransportrouten_export_ai] Uploaded file now always has xtf extension

### DIFF
--- a/avt_ausnahmetransportrouten_export_ai/Jenkinsfile
+++ b/avt_ausnahmetransportrouten_export_ai/Jenkinsfile
@@ -3,7 +3,7 @@ node('master') {
     stage('Prepare') {
         gretlJobRepoUrl = env.GRETL_JOB_REPO_URL
         uploadDirName = 'upload'
-        uploadFileName = 'data'
+        uploadFileName = 'data.xtf'
         // By default the uploaded file is stored in the following directory:
         buildDir = "$JENKINS_HOME/jobs/$JOB_BASE_NAME/builds/$BUILD_NUMBER"
         // Create a subdirectory for the uploaded file:

--- a/avt_ausnahmetransportrouten_export_ai/build.gradle
+++ b/avt_ausnahmetransportrouten_export_ai/build.gradle
@@ -2,9 +2,6 @@
 Publiziert die AVT Ausnahmetransportrouten nach geodienste.ch
 */
 
-import ch.so.agi.gretl.tasks.*
-import ch.so.agi.gretl.api.TransferSet
-
 import java.nio.file.Files
 import java.nio.file.Paths
 import java.io.File

--- a/avt_ausnahmetransportrouten_export_ai/build.gradle
+++ b/avt_ausnahmetransportrouten_export_ai/build.gradle
@@ -14,23 +14,17 @@ defaultTasks 'uploadMgdm'
 /*
 Package and upload to the KKGEO AI
 */
-def exportFileName = 'data'
+def exportFileName = 'data.xtf'
 def pathToUploadFolder = 'upload'
 def zipName = 'iliexport.zip'
+def pathToTempFolder = System.getProperty("java.io.tmpdir")
 
 
-task addXtfSuffixToData(type: Copy) {
-    from pathToUploadFolder + "/data"
-    into pathToUploadFolder + "/xtf"
-
-    rename '(.*)', '$1.xtf'
-}
-
-task zipMgdm(type: Zip, dependsOn: addXtfSuffixToData) {
+task zipMgdm(type: Zip) {
     archiveName = zipName
-    destinationDir = file(pathToUploadFolder)
+    destinationDir = file(pathToTempFolder)
 
-    from pathToUploadFolder + "/xtf"
+    from Paths.get(pathToUploadFolder)
 }
 
 task uploadMgdm (dependsOn: zipMgdm) {
@@ -38,7 +32,7 @@ task uploadMgdm (dependsOn: zipMgdm) {
 
     def aiLogin = aiUser + ":" + aiPwd
     def serverUrl = "https://" + aiServer + "/data_agg/interlis/import"
-    def zipFilePath = Paths.get(pathToUploadFolder.toString(), zipName)
+    def zipFilePath = Paths.get(pathToTempFolder, zipName)
 
     doLast {    
         def response = ["curl", "-u", aiLogin, "-F", "topic=kantonale_ausnahmetransportrouten", "-F",

--- a/avt_ausnahmetransportrouten_export_ai/job.properties
+++ b/avt_ausnahmetransportrouten_export_ai/job.properties
@@ -1,1 +1,1 @@
-authorization.permissions=gretl-users-bdavt
+authorization.permissions=gretl-users-bvtaa

--- a/start-gretl.sh
+++ b/start-gretl.sh
@@ -52,6 +52,9 @@ echo "Gradle options: ${gradle_options[@]}"
 echo "gretl_cmd: $gretl_cmd"
 echo "======================================================="
 
+# Create a directory that is going to be mounted as the "GRETL share"
+mkdir -p /tmp/gretl-share
+
 # special run configuration for jenkins-slave based image:
 # 1. use a shell as entry point
 # 2. mount job directory as volume
@@ -68,7 +71,7 @@ echo "======================================================="
 docker run -i --rm \
     --entrypoint="/bin/sh" \
     -v "$job_directory":/home/gradle/project \
-    -v /tmp:/tmp/gretl-share \
+    -v /tmp/gretl-share:/tmp/gretl-share \
      ${envvars_string} \
     --user $UID \
     ${network_string} \


### PR DESCRIPTION
Das hochgeladene File hat nun bereits die Endung xtf. Dadurch konnte der Job vereinfacht werden. Neu wird auch das Zip im java.io.tmpdir erzeugt.