### PR TITLE
[arp_npl_import] File Upload ermöglichen

### DIFF
--- a/arp_npl_import/Jenkinsfile
+++ b/arp_npl_import/Jenkinsfile
@@ -1,0 +1,45 @@
+// Start with a scripted pipeline part
+node('master') {
+    stage('Prepare') {
+        gretlJobRepoUrl = env.GRETL_JOB_REPO_URL
+        uploadDirName = 'upload'
+        uploadFileName = 'data.xtf'
+        // By default the uploaded file is stored in the following directory:
+        buildDir = "$JENKINS_HOME/jobs/$JOB_BASE_NAME/builds/$BUILD_NUMBER"
+        // Create a subdirectory for the uploaded file:
+        sh "mkdir $buildDir/$uploadDirName"
+        inputFile = input message: 'Datei hochladen', parameters: [file(name: "$uploadDirName/$uploadFileName", description: 'Hochzuladende Datei auswählen'), string(name: 'bfsNr', defaultValue: '', description: 'BFS-Nummer der hochgeladenen Gemeinde')]
+        // Rename file
+        sh "mv $buildDir/$uploadDirName/$uploadFileName $buildDir/$uploadDirName/${inputFile.bfsNr}.xtf"
+        dir(buildDir) {
+            stash name: 'uploadDir', includes: "upload/**"
+        }
+        sh "rm -r $buildDir/$uploadDirName"
+    }
+}
+
+// Declarative pipeline starts here
+pipeline {
+    agent { label params.nodeLabel ?: 'gretl' }
+    stages {
+        stage('Run GRETL-Job') {
+            steps {
+                git url: gretlJobRepoUrl, branch: "${params.BRANCH ?: 'master'}", changelog: false
+                dir(env.JOB_BASE_NAME) {
+                    unstash name: 'uploadDir'
+                    sh "gretl -Dorg.gradle.jvmargs=-Xmx2G -Pxtf=$uploadDirName/${inputFile.bfsNr}.xtf"
+                }
+            }
+        }
+    }
+    post {
+        unsuccessful {
+            emailext (
+                to: '${DEFAULT_RECIPIENTS}',
+                recipientProviders: [requestor()],
+                subject: "GRETL-Job ${JOB_NAME} (${BUILD_DISPLAY_NAME}) ist fehlgeschlagen",
+                body: "Die Ausführung des GRETL-Jobs ${JOB_NAME} (${BUILD_DISPLAY_NAME}) war nicht erfolgreich. Details dazu finden Sie in den Log-Meldungen unter ${RUN_DISPLAY_URL}."
+            )
+        }
+    }
+}

--- a/arp_npl_import/job.properties
+++ b/arp_npl_import/job.properties
@@ -1,0 +1,1 @@
+nodeLabel=gretl-ili2pg4


### PR DESCRIPTION
Mit diesen Änderungen ist es möglich, Dateien zum Importieren hochzuladen. Gleichzeitig mit der Auswahl der Datei muss man die BFS-Nummer der Gemeinde angeben, damit das richtige Dataset ersetzt wird.

Mir stellen sich noch folgende Fragen:

1. Die Datei arp_npl_import/init.gradle braucht es aus meiner Sicht nicht mehr. Kann ich diese löschen?

1. In arp_npl_import/build.gradle steht https://github.com/sogis/gretljobs/blob/015df1d6661f72e59213b89e782865f2319a377e/arp_npl_import/build.gradle#L3
Im Moment findet das aber offenbar in einem separaten Job arp_npl_pub statt. Belibt das vorläufig so? Dann entferne ich diesen Teil des Kommentars noch.

1. Ah, und auch die folgenden paar Zeilen beziehen sich auf den Umbau ins Publikationsmodell. Kann ich sie ebenfalls entfernen? https://github.com/sogis/gretljobs/blob/015df1d6661f72e59213b89e782865f2319a377e/arp_npl_import/build.gradle#L5-L12

Was ich noch nicht implementiert habe ist das Ablegen der hochgeladenen Datei, so dass sie danach öffentlich heruntergeladen werden kann. Ich sehe hier zwei bis drei Varianten:
* Einerseits gibt es hierfür das "gretl-jenkins-share", das ich für solche Zwecke vorgesehen habe. GRETL kann auf dieses schreiben. Dann müssten wir dieses irgendwie am API-Gateway anhängen, denn im Moment kann er ja nur auf "sogis_pic/geodata/". Mir ist noch nicht klar, wie wir den nginx konfigurieren müssen, damit das gut kommt, aber es wird wohl schon irgendwie gehen.
* Die andere Variante, die mir vorschwebt, ist, dass GRETL die Dateien z.B. per SFTP auf den geoutil-Server kopiert. Dieser kann auf "sogis_pic/geodata" schreiben, und so wären die Dateien weiterhin an ihrem angestammten Ort. Unschön ist hier aber, dass weiterhin auf die alte Serverinfrastruktur zurückgegriffen wird. Plus wir müssten wahrscheinlich etwas auf der Firewall freischalten lassen.
* Und die dritte Variante ist, dass @bjsvwcur die Dateien weiterhin manuell unter "sogis_pic/geodata" platziert. Denn vorläufig muss weiterhin @bjsvwcur diese Uploads/Imports durchführen; den Upload/Import an sich könnte das ARP schon selber machen, aber mit jeder Gemeinde, die hinzukommt, muss @bjsvwcur Anpassungen an anderen GRETL-Jobs machen, damit diese die Daten für die neue Gemeinde nicht mehr aus der sogis-DB holen, sondern aus der edit-DB.

Die erste Variante ist wohl die beste. Aber in dieses Thema spielt ja immer auch noch die "Object Storage" hinein, die vielleicht irgendwann mal kommt. Deshalb wäre ich noch froh um eine Einschätzung von @edigonzales.