### PR TITLE
Faster agi_mopublic_pub

### DIFF
--- a/agi_mopublic_pub/agi_mopublic_pub_mopublic_bodenbedeckung.sql
+++ b/agi_mopublic_pub/agi_mopublic_pub_mopublic_bodenbedeckung.sql
@@ -1,11 +1,11 @@
 WITH aimport AS
 (
-	SELECT
-		max(importdate) AS importdate, dataset
-	FROM
-		agi_dm01avso24.t_ili2db_import
-	GROUP BY
-		dataset 
+    SELECT
+        max(importdate) AS importdate, dataset
+    FROM
+        agi_dm01avso24.t_ili2db_import
+    GROUP BY
+        dataset 
 )
 SELECT
     CASE 
@@ -27,7 +27,7 @@ FROM
     LEFT JOIN agi_dm01avso24.bodenbedeckung_bbnachfuehrung AS nachfuehrung
         ON bodenbedeckung.entstehung = nachfuehrung.t_id
     LEFT JOIN agi_dm01avso24.t_ili2db_basket AS basket
-    	ON bodenbedeckung.t_basket = basket.t_id
+        ON bodenbedeckung.t_basket = basket.t_id
     LEFT JOIN aimport
         ON basket.dataset = aimport.dataset    
 ;

--- a/agi_mopublic_pub/agi_mopublic_pub_mopublic_bodenbedeckung.sql
+++ b/agi_mopublic_pub/agi_mopublic_pub_mopublic_bodenbedeckung.sql
@@ -1,3 +1,12 @@
+WITH aimport AS
+(
+	SELECT
+		max(importdate) AS importdate, dataset
+	FROM
+		agi_dm01avso24.t_ili2db_import
+	GROUP BY
+		dataset 
+)
 SELECT
     CASE 
         WHEN split_part(bodenbedeckung.art,'.', array_upper(string_to_array(bodenbedeckung.art, '.'), 1))='fliessendes' 
@@ -19,14 +28,6 @@ FROM
         ON bodenbedeckung.entstehung = nachfuehrung.t_id
     LEFT JOIN agi_dm01avso24.t_ili2db_basket AS basket
     	ON bodenbedeckung.t_basket = basket.t_id
-    LEFT JOIN 
-    (
-    	SELECT
-			max(importdate) AS importdate, dataset
-		FROM
-			agi_dm01avso24.t_ili2db_import
-		GROUP BY
-			dataset 
-    ) AS  aimport
-    	ON basket.dataset = aimport.dataset        
-; 
+    LEFT JOIN aimport
+        ON basket.dataset = aimport.dataset    
+;

--- a/agi_mopublic_pub/agi_mopublic_pub_mopublic_bodenbedeckung_proj.sql
+++ b/agi_mopublic_pub/agi_mopublic_pub_mopublic_bodenbedeckung_proj.sql
@@ -1,3 +1,12 @@
+WITH aimport AS
+(
+	SELECT
+		max(importdate) AS importdate, dataset
+	FROM
+		agi_dm01avso24.t_ili2db_import
+	GROUP BY
+		dataset 
+)
 SELECT
     CASE 
         WHEN split_part(bodenbedeckung.art,'.', array_upper(string_to_array(bodenbedeckung.art, '.'), 1))='fliessendes' 
@@ -19,14 +28,6 @@ FROM
         ON bodenbedeckung.entstehung = nachfuehrung.t_id
     LEFT JOIN agi_dm01avso24.t_ili2db_basket AS basket
     	ON bodenbedeckung.t_basket = basket.t_id
-    LEFT JOIN 
-    (
-    	SELECT
-			max(importdate) AS importdate, dataset
-		FROM
-			agi_dm01avso24.t_ili2db_import
-		GROUP BY
-			dataset 
-    ) AS  aimport
-    	ON basket.dataset = aimport.dataset
+    LEFT JOIN aimport
+        ON basket.dataset = aimport.dataset    
 ; 

--- a/agi_mopublic_pub/agi_mopublic_pub_mopublic_bodenbedeckung_proj.sql
+++ b/agi_mopublic_pub/agi_mopublic_pub_mopublic_bodenbedeckung_proj.sql
@@ -1,11 +1,11 @@
 WITH aimport AS
 (
-	SELECT
-		max(importdate) AS importdate, dataset
-	FROM
-		agi_dm01avso24.t_ili2db_import
-	GROUP BY
-		dataset 
+    SELECT
+        max(importdate) AS importdate, dataset
+    FROM
+        agi_dm01avso24.t_ili2db_import
+    GROUP BY
+        dataset 
 )
 SELECT
     CASE 
@@ -27,7 +27,7 @@ FROM
     LEFT JOIN agi_dm01avso24.bodenbedeckung_bbnachfuehrung AS nachfuehrung
         ON bodenbedeckung.entstehung = nachfuehrung.t_id
     LEFT JOIN agi_dm01avso24.t_ili2db_basket AS basket
-    	ON bodenbedeckung.t_basket = basket.t_id
+        ON bodenbedeckung.t_basket = basket.t_id
     LEFT JOIN aimport
         ON basket.dataset = aimport.dataset    
 ; 

--- a/agi_mopublic_pub/agi_mopublic_pub_mopublic_einzelobjekt_flaeche.sql
+++ b/agi_mopublic_pub/agi_mopublic_pub_mopublic_einzelobjekt_flaeche.sql
@@ -1,11 +1,11 @@
 WITH aimport AS
 (
-	SELECT
-		max(importdate) AS importdate, dataset
-	FROM
-		agi_dm01avso24.t_ili2db_import
-	GROUP BY
-		dataset 
+    SELECT
+        max(importdate) AS importdate, dataset
+    FROM
+        agi_dm01avso24.t_ili2db_import
+    GROUP BY
+        dataset 
 )
 SELECT
     split_part(einzelobjekt.art,'.',array_upper(string_to_array(einzelobjekt.art,'.'), 1)) AS art_txt,
@@ -23,7 +23,7 @@ FROM
     LEFT JOIN agi_dm01avso24.einzelobjekte_eonachfuehrung AS nachfuehrung
         ON nachfuehrung.t_id = einzelobjekt.entstehung
     LEFT JOIN agi_dm01avso24.t_ili2db_basket AS basket
-    	ON einzelobjekt.t_basket = basket.t_id
+        ON einzelobjekt.t_basket = basket.t_id
     LEFT JOIN aimport
         ON basket.dataset = aimport.dataset    
 ;

--- a/agi_mopublic_pub/agi_mopublic_pub_mopublic_einzelobjekt_flaeche.sql
+++ b/agi_mopublic_pub/agi_mopublic_pub_mopublic_einzelobjekt_flaeche.sql
@@ -1,3 +1,12 @@
+WITH aimport AS
+(
+	SELECT
+		max(importdate) AS importdate, dataset
+	FROM
+		agi_dm01avso24.t_ili2db_import
+	GROUP BY
+		dataset 
+)
 SELECT
     split_part(einzelobjekt.art,'.',array_upper(string_to_array(einzelobjekt.art,'.'), 1)) AS art_txt,
     CAST(einzelobjekt.t_datasetname AS INT) AS bfs_nr,    
@@ -15,14 +24,6 @@ FROM
         ON nachfuehrung.t_id = einzelobjekt.entstehung
     LEFT JOIN agi_dm01avso24.t_ili2db_basket AS basket
     	ON einzelobjekt.t_basket = basket.t_id
-    LEFT JOIN 
-    (
-    	SELECT
-			max(importdate) AS importdate, dataset
-		FROM
-			agi_dm01avso24.t_ili2db_import
-		GROUP BY
-			dataset 
-    ) AS  aimport
-    	ON basket.dataset = aimport.dataset        
+    LEFT JOIN aimport
+        ON basket.dataset = aimport.dataset    
 ;

--- a/agi_mopublic_pub/agi_mopublic_pub_mopublic_einzelobjekt_linie.sql
+++ b/agi_mopublic_pub/agi_mopublic_pub_mopublic_einzelobjekt_linie.sql
@@ -1,11 +1,11 @@
 WITH aimport AS
 (
-	SELECT
-		max(importdate) AS importdate, dataset
-	FROM
-		agi_dm01avso24.t_ili2db_import
-	GROUP BY
-		dataset 
+    SELECT
+        max(importdate) AS importdate, dataset
+    FROM
+        agi_dm01avso24.t_ili2db_import
+    GROUP BY
+        dataset 
 )
 SELECT
     split_part(einzelobjekt.art,'.',array_upper(string_to_array(einzelobjekt.art,'.'), 1)) AS art_txt,
@@ -20,7 +20,7 @@ FROM
     LEFT JOIN agi_dm01avso24.einzelobjekte_eonachfuehrung AS nachfuehrung
         ON nachfuehrung.t_id = einzelobjekt.entstehung
     LEFT JOIN agi_dm01avso24.t_ili2db_basket AS basket
-    	ON einzelobjekt.t_basket = basket.t_id
+        ON einzelobjekt.t_basket = basket.t_id
     LEFT JOIN aimport
         ON basket.dataset = aimport.dataset    
 ;

--- a/agi_mopublic_pub/agi_mopublic_pub_mopublic_einzelobjekt_linie.sql
+++ b/agi_mopublic_pub/agi_mopublic_pub_mopublic_einzelobjekt_linie.sql
@@ -1,3 +1,12 @@
+WITH aimport AS
+(
+	SELECT
+		max(importdate) AS importdate, dataset
+	FROM
+		agi_dm01avso24.t_ili2db_import
+	GROUP BY
+		dataset 
+)
 SELECT
     split_part(einzelobjekt.art,'.',array_upper(string_to_array(einzelobjekt.art,'.'), 1)) AS art_txt,
     CAST(einzelobjekt.t_datasetname AS INT) AS bfs_nr,    
@@ -12,14 +21,6 @@ FROM
         ON nachfuehrung.t_id = einzelobjekt.entstehung
     LEFT JOIN agi_dm01avso24.t_ili2db_basket AS basket
     	ON einzelobjekt.t_basket = basket.t_id
-    LEFT JOIN 
-    (
-    	SELECT
-			max(importdate) AS importdate, dataset
-		FROM
-			agi_dm01avso24.t_ili2db_import
-		GROUP BY
-			dataset 
-    ) AS  aimport
-    	ON basket.dataset = aimport.dataset             
+    LEFT JOIN aimport
+        ON basket.dataset = aimport.dataset    
 ;

--- a/agi_mopublic_pub/agi_mopublic_pub_mopublic_einzelobjekt_punkt.sql
+++ b/agi_mopublic_pub/agi_mopublic_pub_mopublic_einzelobjekt_punkt.sql
@@ -1,3 +1,12 @@
+WITH aimport AS
+(
+	SELECT
+		max(importdate) AS importdate, dataset
+	FROM
+		agi_dm01avso24.t_ili2db_import
+	GROUP BY
+		dataset 
+)
 SELECT
     split_part(einzelobjekt.art,'.',array_upper(string_to_array(einzelobjekt.art,'.'), 1)) AS art_txt,
     CASE 
@@ -17,14 +26,6 @@ FROM
         ON nachfuehrung.t_id = einzelobjekt.entstehung
     LEFT JOIN agi_dm01avso24.t_ili2db_basket AS basket
     	ON einzelobjekt.t_basket = basket.t_id
-    LEFT JOIN 
-    (
-    	SELECT
-			max(importdate) AS importdate, dataset
-		FROM
-			agi_dm01avso24.t_ili2db_import
-		GROUP BY
-			dataset 
-    ) AS  aimport
-    	ON basket.dataset = aimport.dataset
+    LEFT JOIN aimport
+        ON basket.dataset = aimport.dataset    
 ;

--- a/agi_mopublic_pub/agi_mopublic_pub_mopublic_einzelobjekt_punkt.sql
+++ b/agi_mopublic_pub/agi_mopublic_pub_mopublic_einzelobjekt_punkt.sql
@@ -1,11 +1,11 @@
 WITH aimport AS
 (
-	SELECT
-		max(importdate) AS importdate, dataset
-	FROM
-		agi_dm01avso24.t_ili2db_import
-	GROUP BY
-		dataset 
+    SELECT
+        max(importdate) AS importdate, dataset
+    FROM
+        agi_dm01avso24.t_ili2db_import
+    GROUP BY
+        dataset 
 )
 SELECT
     split_part(einzelobjekt.art,'.',array_upper(string_to_array(einzelobjekt.art,'.'), 1)) AS art_txt,
@@ -25,7 +25,7 @@ FROM
     LEFT JOIN agi_dm01avso24.einzelobjekte_eonachfuehrung AS nachfuehrung
         ON nachfuehrung.t_id = einzelobjekt.entstehung
     LEFT JOIN agi_dm01avso24.t_ili2db_basket AS basket
-    	ON einzelobjekt.t_basket = basket.t_id
+        ON einzelobjekt.t_basket = basket.t_id
     LEFT JOIN aimport
         ON basket.dataset = aimport.dataset    
 ;

--- a/agi_mopublic_pub/agi_mopublic_pub_mopublic_fixpunkt.sql
+++ b/agi_mopublic_pub/agi_mopublic_pub_mopublic_fixpunkt.sql
@@ -1,11 +1,11 @@
 WITH aimport AS
 (
-	SELECT
-		max(importdate) AS importdate, dataset
-	FROM
-		agi_dm01avso24.t_ili2db_import
-	GROUP BY
-		dataset 
+    SELECT
+        max(importdate) AS importdate, dataset
+    FROM
+        agi_dm01avso24.t_ili2db_import
+    GROUP BY
+        dataset 
 )
 SELECT
     'LFP1' AS typ_txt,
@@ -47,7 +47,7 @@ FROM
     LEFT JOIN agi_dm01avso24.fixpunktekatgrie1_lfp1nachfuehrung AS nachfuehrung
         ON lagefixpunkt.entstehung = nachfuehrung.t_id
     LEFT JOIN agi_dm01avso24.t_ili2db_basket AS basket
-    	ON lagefixpunkt.t_basket = basket.t_id
+        ON lagefixpunkt.t_basket = basket.t_id
     LEFT JOIN aimport
         ON basket.dataset = aimport.dataset    
         
@@ -93,7 +93,7 @@ FROM
     LEFT JOIN agi_dm01avso24.fixpunktekatgrie2_lfp2nachfuehrung AS nachfuehrung
         ON lagefixpunkt.entstehung = nachfuehrung.t_id
     LEFT JOIN agi_dm01avso24.t_ili2db_basket AS basket
-    	ON lagefixpunkt.t_basket = basket.t_id
+        ON lagefixpunkt.t_basket = basket.t_id
     LEFT JOIN aimport
         ON basket.dataset = aimport.dataset    
 
@@ -139,7 +139,7 @@ FROM
     LEFT JOIN agi_dm01avso24.fixpunktekatgrie3_lfp3nachfuehrung AS nachfuehrung
         ON lagefixpunkt.entstehung = nachfuehrung.t_id
     LEFT JOIN agi_dm01avso24.t_ili2db_basket AS basket
-    	ON lagefixpunkt.t_basket = basket.t_id
+        ON lagefixpunkt.t_basket = basket.t_id
     LEFT JOIN aimport
         ON basket.dataset = aimport.dataset    
 
@@ -181,7 +181,7 @@ FROM
     LEFT JOIN agi_dm01avso24.fixpunktekatgrie1_hfp1nachfuehrung AS nachfuehrung
         ON hoehenfixpunkt.entstehung = nachfuehrung.t_id
     LEFT JOIN agi_dm01avso24.t_ili2db_basket AS basket
-    	ON hoehenfixpunkt.t_basket = basket.t_id
+        ON hoehenfixpunkt.t_basket = basket.t_id
     LEFT JOIN aimport
         ON basket.dataset = aimport.dataset    
 
@@ -223,7 +223,7 @@ FROM
     LEFT JOIN agi_dm01avso24.fixpunktekatgrie2_hfp2nachfuehrung AS nachfuehrung
         ON hoehenfixpunkt.entstehung = nachfuehrung.t_id
     LEFT JOIN agi_dm01avso24.t_ili2db_basket AS basket
-    	ON hoehenfixpunkt.t_basket = basket.t_id
+        ON hoehenfixpunkt.t_basket = basket.t_id
     LEFT JOIN aimport
         ON basket.dataset = aimport.dataset    
 
@@ -265,7 +265,7 @@ FROM
     LEFT JOIN agi_dm01avso24.fixpunktekatgrie3_hfp3nachfuehrung AS nachfuehrung
         ON hoehenfixpunkt.entstehung = nachfuehrung.t_id
     LEFT JOIN agi_dm01avso24.t_ili2db_basket AS basket
-    	ON hoehenfixpunkt.t_basket = basket.t_id
+        ON hoehenfixpunkt.t_basket = basket.t_id
     LEFT JOIN aimport
         ON basket.dataset = aimport.dataset    
 ;

--- a/agi_mopublic_pub/agi_mopublic_pub_mopublic_fixpunkt.sql
+++ b/agi_mopublic_pub/agi_mopublic_pub_mopublic_fixpunkt.sql
@@ -1,3 +1,12 @@
+WITH aimport AS
+(
+	SELECT
+		max(importdate) AS importdate, dataset
+	FROM
+		agi_dm01avso24.t_ili2db_import
+	GROUP BY
+		dataset 
+)
 SELECT
     'LFP1' AS typ_txt,
     lagefixpunkt.nbident, 
@@ -39,16 +48,8 @@ FROM
         ON lagefixpunkt.entstehung = nachfuehrung.t_id
     LEFT JOIN agi_dm01avso24.t_ili2db_basket AS basket
     	ON lagefixpunkt.t_basket = basket.t_id
-    LEFT JOIN 
-    (
-    	SELECT
-			max(importdate) AS importdate, dataset
-		FROM
-			agi_dm01avso24.t_ili2db_import
-		GROUP BY
-			dataset 
-    ) AS  aimport
-    	ON basket.dataset = aimport.dataset
+    LEFT JOIN aimport
+        ON basket.dataset = aimport.dataset    
         
 UNION ALL
 
@@ -93,16 +94,8 @@ FROM
         ON lagefixpunkt.entstehung = nachfuehrung.t_id
     LEFT JOIN agi_dm01avso24.t_ili2db_basket AS basket
     	ON lagefixpunkt.t_basket = basket.t_id
-    LEFT JOIN 
-    (
-    	SELECT
-			max(importdate) AS importdate, dataset
-		FROM
-			agi_dm01avso24.t_ili2db_import
-		GROUP BY
-			dataset 
-    ) AS  aimport
-    	ON basket.dataset = aimport.dataset        
+    LEFT JOIN aimport
+        ON basket.dataset = aimport.dataset    
 
 UNION ALL
 
@@ -147,16 +140,8 @@ FROM
         ON lagefixpunkt.entstehung = nachfuehrung.t_id
     LEFT JOIN agi_dm01avso24.t_ili2db_basket AS basket
     	ON lagefixpunkt.t_basket = basket.t_id
-    LEFT JOIN 
-    (
-    	SELECT
-			max(importdate) AS importdate, dataset
-		FROM
-			agi_dm01avso24.t_ili2db_import
-		GROUP BY
-			dataset 
-    ) AS  aimport
-    	ON basket.dataset = aimport.dataset
+    LEFT JOIN aimport
+        ON basket.dataset = aimport.dataset    
 
 UNION ALL
 
@@ -197,16 +182,8 @@ FROM
         ON hoehenfixpunkt.entstehung = nachfuehrung.t_id
     LEFT JOIN agi_dm01avso24.t_ili2db_basket AS basket
     	ON hoehenfixpunkt.t_basket = basket.t_id
-    LEFT JOIN 
-    (
-    	SELECT
-			max(importdate) AS importdate, dataset
-		FROM
-			agi_dm01avso24.t_ili2db_import
-		GROUP BY
-			dataset 
-    ) AS  aimport
-    	ON basket.dataset = aimport.dataset
+    LEFT JOIN aimport
+        ON basket.dataset = aimport.dataset    
 
 UNION ALL
 
@@ -247,16 +224,8 @@ FROM
         ON hoehenfixpunkt.entstehung = nachfuehrung.t_id
     LEFT JOIN agi_dm01avso24.t_ili2db_basket AS basket
     	ON hoehenfixpunkt.t_basket = basket.t_id
-    LEFT JOIN 
-    (
-    	SELECT
-			max(importdate) AS importdate, dataset
-		FROM
-			agi_dm01avso24.t_ili2db_import
-		GROUP BY
-			dataset 
-    ) AS  aimport
-    	ON basket.dataset = aimport.dataset
+    LEFT JOIN aimport
+        ON basket.dataset = aimport.dataset    
 
 UNION ALL
     
@@ -297,14 +266,6 @@ FROM
         ON hoehenfixpunkt.entstehung = nachfuehrung.t_id
     LEFT JOIN agi_dm01avso24.t_ili2db_basket AS basket
     	ON hoehenfixpunkt.t_basket = basket.t_id
-    LEFT JOIN 
-    (
-    	SELECT
-			max(importdate) AS importdate, dataset
-		FROM
-			agi_dm01avso24.t_ili2db_import
-		GROUP BY
-			dataset 
-    ) AS  aimport
-    	ON basket.dataset = aimport.dataset        
+    LEFT JOIN aimport
+        ON basket.dataset = aimport.dataset    
 ;

--- a/agi_mopublic_pub/agi_mopublic_pub_mopublic_flurname.sql
+++ b/agi_mopublic_pub/agi_mopublic_pub_mopublic_flurname.sql
@@ -12,6 +12,15 @@ WITH pos AS
        agi_dm01avso24.nomenklatur_flurnamepos AS pos
        LEFT JOIN agi_dm01avso24.gemeindegrenzen_gemeinde AS gemeinde
        ON gemeinde.bfsnr = CAST(pos.t_datasetname AS integer)
+),
+aimport AS
+(
+	SELECT
+		max(importdate) AS importdate, dataset
+	FROM
+		agi_dm01avso24.t_ili2db_import
+	GROUP BY
+		dataset 
 )
 SELECT
     flurname.aname AS flurname,
@@ -43,14 +52,6 @@ FROM
         ON flurname.entstehung = nachfuehrung.t_id
     LEFT JOIN agi_dm01avso24.t_ili2db_basket AS basket
         ON flurname.t_basket = basket.t_id
-    LEFT JOIN 
-    (
-        SELECT
-            max(importdate) AS importdate, dataset
-        FROM
-            agi_dm01avso24.t_ili2db_import
-        GROUP BY
-            dataset 
-    ) AS  aimport
-        ON basket.dataset = aimport.dataset        
+    LEFT JOIN aimport
+        ON basket.dataset = aimport.dataset    
 ;

--- a/agi_mopublic_pub/agi_mopublic_pub_mopublic_flurname.sql
+++ b/agi_mopublic_pub/agi_mopublic_pub_mopublic_flurname.sql
@@ -9,18 +9,18 @@ WITH pos AS
         pos,
         gemeinde.aname AS gemeinde
     FROM
-       agi_dm01avso24.nomenklatur_flurnamepos AS pos
-       LEFT JOIN agi_dm01avso24.gemeindegrenzen_gemeinde AS gemeinde
-       ON gemeinde.bfsnr = CAST(pos.t_datasetname AS integer)
+    agi_dm01avso24.nomenklatur_flurnamepos AS pos
+    LEFT JOIN agi_dm01avso24.gemeindegrenzen_gemeinde AS gemeinde
+    ON gemeinde.bfsnr = CAST(pos.t_datasetname AS integer)
 ),
 aimport AS
 (
-	SELECT
-		max(importdate) AS importdate, dataset
-	FROM
-		agi_dm01avso24.t_ili2db_import
-	GROUP BY
-		dataset 
+    SELECT
+        max(importdate) AS importdate, dataset
+    FROM
+        agi_dm01avso24.t_ili2db_import
+    GROUP BY
+        dataset 
 )
 SELECT
     flurname.aname AS flurname,

--- a/agi_mopublic_pub/agi_mopublic_pub_mopublic_gebaeudeadresse.sql
+++ b/agi_mopublic_pub/agi_mopublic_pub_mopublic_gebaeudeadresse.sql
@@ -1,24 +1,24 @@
 WITH strassenname AS (
-  SELECT 
+SELECT 
     lokalisation.t_id AS lok_t_id,
     lokalisationsname.atext AS strassenname
-  FROM
+FROM
     agi_dm01avso24.gebaeudeadressen_lokalisation AS lokalisation
     LEFT JOIN agi_dm01avso24.gebaeudeadressen_lokalisationsname AS lokalisationsname
     ON lokalisationsname.benannte = lokalisation.t_id
-  WHERE lokalisation.istoffiziellebezeichnung = 'ja'
+WHERE lokalisation.istoffiziellebezeichnung = 'ja'
 ),
 aimport AS
 (
-	SELECT
-		max(importdate) AS importdate, dataset
-	FROM
-		agi_dm01avso24.t_ili2db_import
-	GROUP BY
-		dataset 
+    SELECT
+        max(importdate) AS importdate, dataset
+    FROM
+        agi_dm01avso24.t_ili2db_import
+    GROUP BY
+        dataset 
 ),
 gebaeudeeingang AS (
-  SELECT
+SELECT
     gebauedeeingang.gebaeudeeingang_von AS lok_t_id,
     gebauedeeingang.hoehenlage,
     gebauedeeingang.lage,
@@ -27,26 +27,26 @@ gebaeudeeingang AS (
     gebauedeeingang.gwr_edid AS edid,
     gebauedeeingang.astatus AS astatus,
     CASE 
-      WHEN istoffiziellebezeichnung = 'ja' 
+    WHEN istoffiziellebezeichnung = 'ja' 
         THEN TRUE
-      ELSE FALSE 
+    ELSE FALSE 
     END AS ist_offizielle_bezeichnung,
     aname.atext AS gebaeudename, -- always empty?
     CAST(gebauedeeingang.t_datasetname AS INT) AS bfs_nr,    
     CASE
-      WHEN hausnummer.ori IS NULL 
+    WHEN hausnummer.ori IS NULL 
         THEN (100 - 100) * 0.9
-      ELSE (100 - hausnummer.ori) * 0.9 
+    ELSE (100 - hausnummer.ori) * 0.9 
     END AS orientierung,
     CASE 
-      WHEN hausnummer.hali IS NULL 
+    WHEN hausnummer.hali IS NULL 
         THEN 'Center'
-      ELSE hausnummer.hali
+    ELSE hausnummer.hali
     END AS hali,
     CASE 
-      WHEN hausnummer.vali IS NULL 
+    WHEN hausnummer.vali IS NULL 
         THEN 'Half'
-      ELSE hausnummer.vali
+    ELSE hausnummer.vali
     END AS vali,
     aimport.importdate AS importdatum,
     nachfuehrung.gueltigereintrag AS nachfuehrung,
@@ -66,7 +66,7 @@ FROM
 ),
 gebaeudeeingang_strassenname AS
 (
-  SELECT
+SELECT
     strassenname.lok_t_id, 
     strassenname.strassenname, 
     gebaeudeeingang.hoehenlage, 
@@ -84,14 +84,14 @@ gebaeudeeingang_strassenname AS
     gebaeudeeingang.importdatum,
     gebaeudeeingang.nachfuehrung,
     gebaeudeeingang.pos
-  FROM
+FROM
     strassenname
     RIGHT JOIN gebaeudeeingang
     ON strassenname.lok_t_id = gebaeudeeingang.lok_t_id
 ),
 gebaeudeeingang_strassenname_plz_ortschaft AS 
 (
-  SELECT
+SELECT
     gebaeudeeingang_strassenname.lok_t_id, 
     gebaeudeeingang_strassenname.strassenname, 
     gebaeudeeingang_strassenname.hoehenlage, 
@@ -111,7 +111,7 @@ gebaeudeeingang_strassenname_plz_ortschaft AS
     gebaeudeeingang_strassenname.pos,
     plz.plz,
     ortschaftsname.atext AS ortschaft
-  FROM
+FROM
     gebaeudeeingang_strassenname
     LEFT JOIN agi_plz_ortschaften.plzortschaft_plz6 AS plz
     ON ST_Intersects(gebaeudeeingang_strassenname.lage, plz.flaeche)
@@ -120,34 +120,34 @@ gebaeudeeingang_strassenname_plz_ortschaft AS
     LEFT JOIN agi_plz_ortschaften.plzortschaft_ortschaftsname AS ortschaftsname
     ON ortschaftsname.ortschaftsname_von = ortschaft.t_id
     WHERE 
-      plz.status != 'vergangen'
-      AND
-      ortschaft.status != 'vergangen'
-      AND 
-      strassenname IS NOT NULL
-      AND
-      hausnummer IS NOT NULL
+    plz.status != 'vergangen'
+    AND
+    ortschaft.status != 'vergangen'
+    AND 
+    strassenname IS NOT NULL
+    AND
+    hausnummer IS NOT NULL
 )
 SELECT
-  gebaeudeeingang_strassenname_plz_ortschaft.strassenname,
-  gebaeudeeingang_strassenname_plz_ortschaft.hausnummer,
-  gebaeudeeingang_strassenname_plz_ortschaft.egid,
-  gebaeudeeingang_strassenname_plz_ortschaft.edid,
-  gebaeudeeingang_strassenname_plz_ortschaft.plz,
-  gebaeudeeingang_strassenname_plz_ortschaft.ortschaft,
-  gebaeudeeingang_strassenname_plz_ortschaft.astatus AS astatus,
-  gebaeudeeingang_strassenname_plz_ortschaft.ist_offizielle_bezeichnung,
-  gebaeudeeingang_strassenname_plz_ortschaft.hoehenlage,
-  gebaeudeeingang_strassenname_plz_ortschaft.gebaeudename,
-  gebaeudeeingang_strassenname_plz_ortschaft.bfs_nr,
-  gebaeudeeingang_strassenname_plz_ortschaft.orientierung,
-  gebaeudeeingang_strassenname_plz_ortschaft.hali,
-  gebaeudeeingang_strassenname_plz_ortschaft.vali,
-  gebaeudeeingang_strassenname_plz_ortschaft.importdatum,
-  gebaeudeeingang_strassenname_plz_ortschaft.nachfuehrung,
-  gebaeudeeingang_strassenname_plz_ortschaft.lage,
-  gebaeudeeingang_strassenname_plz_ortschaft.pos
+gebaeudeeingang_strassenname_plz_ortschaft.strassenname,
+gebaeudeeingang_strassenname_plz_ortschaft.hausnummer,
+gebaeudeeingang_strassenname_plz_ortschaft.egid,
+gebaeudeeingang_strassenname_plz_ortschaft.edid,
+gebaeudeeingang_strassenname_plz_ortschaft.plz,
+gebaeudeeingang_strassenname_plz_ortschaft.ortschaft,
+gebaeudeeingang_strassenname_plz_ortschaft.astatus AS astatus,
+gebaeudeeingang_strassenname_plz_ortschaft.ist_offizielle_bezeichnung,
+gebaeudeeingang_strassenname_plz_ortschaft.hoehenlage,
+gebaeudeeingang_strassenname_plz_ortschaft.gebaeudename,
+gebaeudeeingang_strassenname_plz_ortschaft.bfs_nr,
+gebaeudeeingang_strassenname_plz_ortschaft.orientierung,
+gebaeudeeingang_strassenname_plz_ortschaft.hali,
+gebaeudeeingang_strassenname_plz_ortschaft.vali,
+gebaeudeeingang_strassenname_plz_ortschaft.importdatum,
+gebaeudeeingang_strassenname_plz_ortschaft.nachfuehrung,
+gebaeudeeingang_strassenname_plz_ortschaft.lage,
+gebaeudeeingang_strassenname_plz_ortschaft.pos
 
 FROM
-  gebaeudeeingang_strassenname_plz_ortschaft
+gebaeudeeingang_strassenname_plz_ortschaft
 ;

--- a/agi_mopublic_pub/agi_mopublic_pub_mopublic_gebaeudeadresse.sql
+++ b/agi_mopublic_pub/agi_mopublic_pub_mopublic_gebaeudeadresse.sql
@@ -8,6 +8,15 @@ WITH strassenname AS (
     ON lokalisationsname.benannte = lokalisation.t_id
   WHERE lokalisation.istoffiziellebezeichnung = 'ja'
 ),
+aimport AS
+(
+	SELECT
+		max(importdate) AS importdate, dataset
+	FROM
+		agi_dm01avso24.t_ili2db_import
+	GROUP BY
+		dataset 
+),
 gebaeudeeingang AS (
   SELECT
     gebauedeeingang.gebaeudeeingang_von AS lok_t_id,
@@ -52,16 +61,8 @@ FROM
     ON aname.gebaeudename_von = gebauedeeingang.t_id
     LEFT JOIN agi_dm01avso24.t_ili2db_basket AS basket
     ON gebauedeeingang.t_basket = basket.t_id
-    LEFT JOIN 
-    (
-    	SELECT
-			max(importdate) AS importdate, dataset
-		FROM
-			agi_dm01avso24.t_ili2db_import
-		GROUP BY
-			dataset 
-    ) AS  aimport
-    ON basket.dataset = aimport.dataset
+    LEFT JOIN aimport
+        ON basket.dataset = aimport.dataset    
 ),
 gebaeudeeingang_strassenname AS
 (
@@ -115,7 +116,7 @@ gebaeudeeingang_strassenname_plz_ortschaft AS
     LEFT JOIN agi_plz_ortschaften.plzortschaft_plz6 AS plz
     ON ST_Intersects(gebaeudeeingang_strassenname.lage, plz.flaeche)
     LEFT JOIN agi_plz_ortschaften.plzortschaft_ortschaft AS ortschaft
-    ON ST_Intersects(gebaeudeeingang_strassenname.lage, ortschaft.flaeche)
+    ON plz.plz6_von = ortschaft.t_id
     LEFT JOIN agi_plz_ortschaften.plzortschaft_ortschaftsname AS ortschaftsname
     ON ortschaftsname.ortschaftsname_von = ortschaft.t_id
     WHERE 

--- a/agi_mopublic_pub/agi_mopublic_pub_mopublic_gelaendename.sql
+++ b/agi_mopublic_pub/agi_mopublic_pub_mopublic_gelaendename.sql
@@ -1,11 +1,11 @@
 WITH aimport AS
 (
-	SELECT
-		max(importdate) AS importdate, dataset
-	FROM
-		agi_dm01avso24.t_ili2db_import
-	GROUP BY
-		dataset 
+    SELECT
+        max(importdate) AS importdate, dataset
+    FROM
+        agi_dm01avso24.t_ili2db_import
+    GROUP BY
+        dataset 
 )
 SELECT
     gelaendename.aname AS gelaendename,

--- a/agi_mopublic_pub/agi_mopublic_pub_mopublic_gelaendename.sql
+++ b/agi_mopublic_pub/agi_mopublic_pub_mopublic_gelaendename.sql
@@ -1,3 +1,12 @@
+WITH aimport AS
+(
+	SELECT
+		max(importdate) AS importdate, dataset
+	FROM
+		agi_dm01avso24.t_ili2db_import
+	GROUP BY
+		dataset 
+)
 SELECT
     gelaendename.aname AS gelaendename,
     CAST(gelaendename.t_datasetname AS INT) AS bfs_nr,    
@@ -30,14 +39,6 @@ FROM
         ON gelaendename.entstehung = nachfuehrung.t_id
     LEFT JOIN agi_dm01avso24.t_ili2db_basket AS basket
         ON gelaendename.t_basket = basket.t_id
-    LEFT JOIN 
-    (
-        SELECT
-            max(importdate) AS importdate, dataset
-        FROM
-            agi_dm01avso24.t_ili2db_import
-        GROUP BY
-            dataset 
-    ) AS  aimport
-        ON basket.dataset = aimport.dataset      
+    LEFT JOIN aimport
+        ON basket.dataset = aimport.dataset    
 ;

--- a/agi_mopublic_pub/agi_mopublic_pub_mopublic_gemeindegrenze.sql
+++ b/agi_mopublic_pub/agi_mopublic_pub_mopublic_gemeindegrenze.sql
@@ -1,11 +1,11 @@
 WITH aimport AS
 (
-	SELECT
-		max(importdate) AS importdate, dataset
-	FROM
-		agi_dm01avso24.t_ili2db_import
-	GROUP BY
-		dataset 
+    SELECT
+        max(importdate) AS importdate, dataset
+    FROM
+        agi_dm01avso24.t_ili2db_import
+    GROUP BY
+        dataset 
 )
 SELECT
     gemeinde.aname AS gemeindename,

--- a/agi_mopublic_pub/agi_mopublic_pub_mopublic_gemeindegrenze.sql
+++ b/agi_mopublic_pub/agi_mopublic_pub_mopublic_gemeindegrenze.sql
@@ -1,3 +1,12 @@
+WITH aimport AS
+(
+	SELECT
+		max(importdate) AS importdate, dataset
+	FROM
+		agi_dm01avso24.t_ili2db_import
+	GROUP BY
+		dataset 
+)
 SELECT
     gemeinde.aname AS gemeindename,
     CAST(gemeinde.t_datasetname AS INT) AS bfs_nr,    
@@ -12,14 +21,6 @@ FROM
         ON nachfuehrung.t_id = grenze.entstehung
     LEFT JOIN agi_dm01avso24.t_ili2db_basket AS basket
         ON gemeinde.t_basket = basket.t_id    
-    LEFT JOIN 
-    (
-        SELECT
-            max(importdate) AS importdate, dataset
-        FROM
-            agi_dm01avso24.t_ili2db_import
-        GROUP BY
-            dataset 
-    ) AS  aimport
-        ON basket.dataset = aimport.dataset          
+    LEFT JOIN aimport
+        ON basket.dataset = aimport.dataset    
 ;

--- a/agi_mopublic_pub/agi_mopublic_pub_mopublic_gemeindegrenze_proj.sql
+++ b/agi_mopublic_pub/agi_mopublic_pub_mopublic_gemeindegrenze_proj.sql
@@ -1,3 +1,12 @@
+WITH aimport AS
+(
+	SELECT
+		max(importdate) AS importdate, dataset
+	FROM
+		agi_dm01avso24.t_ili2db_import
+	GROUP BY
+		dataset 
+)
 SELECT
     gemeinde.aname AS gemeindename,
     CAST(gemeinde.t_datasetname AS INT) AS bfs_nr,    
@@ -12,14 +21,6 @@ FROM
         ON nachfuehrung.t_id = grenze.entstehung
     LEFT JOIN agi_dm01avso24.t_ili2db_basket AS basket
         ON gemeinde.t_basket = basket.t_id    
-    LEFT JOIN 
-    (
-        SELECT
-            max(importdate) AS importdate, dataset
-        FROM
-            agi_dm01avso24.t_ili2db_import
-        GROUP BY
-            dataset 
-    ) AS  aimport
+    LEFT JOIN aimport
         ON basket.dataset = aimport.dataset    
 ;

--- a/agi_mopublic_pub/agi_mopublic_pub_mopublic_gemeindegrenze_proj.sql
+++ b/agi_mopublic_pub/agi_mopublic_pub_mopublic_gemeindegrenze_proj.sql
@@ -1,11 +1,11 @@
 WITH aimport AS
 (
-	SELECT
-		max(importdate) AS importdate, dataset
-	FROM
-		agi_dm01avso24.t_ili2db_import
-	GROUP BY
-		dataset 
+    SELECT
+        max(importdate) AS importdate, dataset
+    FROM
+        agi_dm01avso24.t_ili2db_import
+    GROUP BY
+        dataset 
 )
 SELECT
     gemeinde.aname AS gemeindename,

--- a/agi_mopublic_pub/agi_mopublic_pub_mopublic_grenzpunkt.sql
+++ b/agi_mopublic_pub/agi_mopublic_pub_mopublic_grenzpunkt.sql
@@ -1,11 +1,11 @@
 WITH aimport AS
 (
-	SELECT
-		max(importdate) AS importdate, dataset
-	FROM
-		agi_dm01avso24.t_ili2db_import
-	GROUP BY
-		dataset 
+    SELECT
+        max(importdate) AS importdate, dataset
+    FROM
+        agi_dm01avso24.t_ili2db_import
+    GROUP BY
+        dataset 
 )
 SELECT
     grenzpunkt.geometrie,

--- a/agi_mopublic_pub/agi_mopublic_pub_mopublic_grenzpunkt.sql
+++ b/agi_mopublic_pub/agi_mopublic_pub_mopublic_grenzpunkt.sql
@@ -1,3 +1,12 @@
+WITH aimport AS
+(
+	SELECT
+		max(importdate) AS importdate, dataset
+	FROM
+		agi_dm01avso24.t_ili2db_import
+	GROUP BY
+		dataset 
+)
 SELECT
     grenzpunkt.geometrie,
     grenzpunkt.lagegen AS lagegenauigkeit,
@@ -26,14 +35,6 @@ FROM
         ON grenzpunkt.entstehung = nachfuehrung.t_id
     LEFT JOIN agi_dm01avso24.t_ili2db_basket AS basket
         ON grenzpunkt.t_basket = basket.t_id    
-    LEFT JOIN 
-    (
-        SELECT
-            max(importdate) AS importdate, dataset
-        FROM
-            agi_dm01avso24.t_ili2db_import
-        GROUP BY
-            dataset 
-    ) AS  aimport
+    LEFT JOIN aimport
         ON basket.dataset = aimport.dataset    
 ;

--- a/agi_mopublic_pub/agi_mopublic_pub_mopublic_grundstueck.sql
+++ b/agi_mopublic_pub/agi_mopublic_pub_mopublic_grundstueck.sql
@@ -32,12 +32,12 @@ pos AS
 ),
 aimport AS
 (
-	SELECT
-		max(importdate) AS importdate, dataset
-	FROM
-		agi_dm01avso24.t_ili2db_import
-	GROUP BY
-		dataset 
+    SELECT
+        max(importdate) AS importdate, dataset
+    FROM
+        agi_dm01avso24.t_ili2db_import
+    GROUP BY
+        dataset 
 ),
 -- Grundstuecke
 grundstueck AS
@@ -55,7 +55,7 @@ grundstueck AS
         aimport.importdate AS importdatum,
         nachfuehrung.gueltigereintrag AS nachfuehrung,
         liegenschaft.geometrie AS geometrie,    
-	    ST_PointOnSurface(ST_MakeValid(liegenschaft.geometrie)) AS point_on_surface,
+        ST_PointOnSurface(ST_MakeValid(liegenschaft.geometrie)) AS point_on_surface,
         pos.pos
     FROM
         agi_dm01avso24.liegenschaften_grundstueck AS grundstueck
@@ -88,7 +88,7 @@ grundstueck AS
         aimport.importdate AS importdatum,
         nachfuehrung.gueltigereintrag AS nachfuehrung,
         selbstrecht.geometrie AS geometrie,
-	    ST_PointOnSurface(ST_MakeValid(selbstrecht.geometrie)) AS point_on_surface,
+        ST_PointOnSurface(ST_MakeValid(selbstrecht.geometrie)) AS point_on_surface,
         pos.pos
     FROM
         agi_dm01avso24.liegenschaften_grundstueck AS grundstueck
@@ -111,30 +111,30 @@ aimport
 grundbuchkreis AS 
 (
     SELECT
-      kreis.aname AS aname,
-      nummerierungsbereich.geometrie
+    kreis.aname AS aname,
+    nummerierungsbereich.geometrie
     FROM
-      agi_av_gb_admin_einteilung.grundbuchkreise_grundbuchkreis AS kreis
-      LEFT JOIN agi_av_gb_admin_einteilung.grundbuchkreise_grundbuchamt AS amt
-      ON kreis.r_grundbuchamt = amt.t_id
-      LEFT JOIN 
-      (
-          SELECT
+    agi_av_gb_admin_einteilung.grundbuchkreise_grundbuchkreis AS kreis
+    LEFT JOIN agi_av_gb_admin_einteilung.grundbuchkreise_grundbuchamt AS amt
+    ON kreis.r_grundbuchamt = amt.t_id
+    LEFT JOIN 
+    (
+        SELECT
             nbgeometrie.t_datasetname,
             nbbereich.kt || nbbereich.nbnummer AS nbident,
             ST_Multi(ST_Union(nbgeometrie.geometrie)) AS geometrie
-          FROM
+        FROM
             agi_dm01avso24.nummerierngsbrche_nbgeometrie AS nbgeometrie
             LEFT JOIN agi_dm01avso24.nummerierngsbrche_nummerierungsbereich AS nbbereich
             ON nbgeometrie.nbgeometrie_von = nbbereich.t_id
-          WHERE
+        WHERE
             nbbereich.kt =  'SO'
-          GROUP BY
+        GROUP BY
             nbgeometrie.t_datasetname,
             nbbereich.kt,
             nbbereich.nbnummer
-      ) AS nummerierungsbereich
-      ON CAST(nummerierungsbereich.t_datasetname AS integer) = kreis.bfsnr AND nummerierungsbereich.nbident = kreis.nbident
+    ) AS nummerierungsbereich
+    ON CAST(nummerierungsbereich.t_datasetname AS integer) = kreis.bfsnr AND nummerierungsbereich.nbident = kreis.nbident
 )
 -- Main query
 SELECT 
@@ -154,11 +154,11 @@ SELECT
     gemeinde.aname AS gemeinde,
     grundbuchkreis.aname AS grundbuch
 FROM 
- grundstueck
+grundstueck
 LEFT JOIN gemeinde 
-  ON gemeinde.bfsnr = grundstueck.bfs_nr
+ON gemeinde.bfsnr = grundstueck.bfs_nr
 LEFT JOIN grundbuchkreis 
-  --ON ST_Intersects(ST_PointOnSurface(ST_Buffer(grundstueck.geometrie,0)), grundbuchkreis.geometrie)
-  --Aenderung vom 04.12.2019, sc: ST_Buffer ersetzt durch ST_MakeValid (ST_Buffer hat nicht auf allen Liegenschaften den Grundbuchkreis abgefüllt)
-  ON ST_Intersects(grundstueck.point_on_surface, grundbuchkreis.geometrie)
+--ON ST_Intersects(ST_PointOnSurface(ST_Buffer(grundstueck.geometrie,0)), grundbuchkreis.geometrie)
+--Aenderung vom 04.12.2019, sc: ST_Buffer ersetzt durch ST_MakeValid (ST_Buffer hat nicht auf allen Liegenschaften den Grundbuchkreis abgefüllt)
+ON ST_Intersects(grundstueck.point_on_surface, grundbuchkreis.geometrie)
 ;

--- a/agi_mopublic_pub/agi_mopublic_pub_mopublic_grundstueck_proj.sql
+++ b/agi_mopublic_pub/agi_mopublic_pub_mopublic_grundstueck_proj.sql
@@ -32,12 +32,12 @@ pos AS
 ),
 aimport AS
 (
-	SELECT
-		max(importdate) AS importdate, dataset
-	FROM
-		agi_dm01avso24.t_ili2db_import
-	GROUP BY
-		dataset 
+    SELECT
+        max(importdate) AS importdate, dataset
+    FROM
+        agi_dm01avso24.t_ili2db_import
+    GROUP BY
+        dataset 
 ),
 -- Grundstuecke
 grundstueck AS
@@ -55,7 +55,7 @@ grundstueck AS
         aimport.importdate AS importdatum,
         nachfuehrung.gueltigereintrag AS nachfuehrung,
         liegenschaft.geometrie AS geometrie,    
-	    ST_PointOnSurface(ST_MakeValid(liegenschaft.geometrie)) AS point_on_surface,
+        ST_PointOnSurface(ST_MakeValid(liegenschaft.geometrie)) AS point_on_surface,
         pos.pos
     FROM
         agi_dm01avso24.liegenschaften_grundstueck AS grundstueck
@@ -88,7 +88,7 @@ grundstueck AS
         aimport.importdate AS importdatum,
         nachfuehrung.gueltigereintrag AS nachfuehrung,
         selbstrecht.geometrie AS geometrie,
-	    ST_PointOnSurface(ST_MakeValid(selbstrecht.geometrie)) AS point_on_surface,
+        ST_PointOnSurface(ST_MakeValid(selbstrecht.geometrie)) AS point_on_surface,
         pos.pos
     FROM
         agi_dm01avso24.liegenschaften_grundstueck AS grundstueck
@@ -111,30 +111,30 @@ aimport
 grundbuchkreis AS 
 (
     SELECT
-      kreis.aname AS aname,
-      nummerierungsbereich.geometrie
+    kreis.aname AS aname,
+    nummerierungsbereich.geometrie
     FROM
-      agi_av_gb_admin_einteilung.grundbuchkreise_grundbuchkreis AS kreis
-      LEFT JOIN agi_av_gb_admin_einteilung.grundbuchkreise_grundbuchamt AS amt
-      ON kreis.r_grundbuchamt = amt.t_id
-      LEFT JOIN 
-      (
-          SELECT
+    agi_av_gb_admin_einteilung.grundbuchkreise_grundbuchkreis AS kreis
+    LEFT JOIN agi_av_gb_admin_einteilung.grundbuchkreise_grundbuchamt AS amt
+    ON kreis.r_grundbuchamt = amt.t_id
+    LEFT JOIN 
+    (
+        SELECT
             nbgeometrie.t_datasetname,
             nbbereich.kt || nbbereich.nbnummer AS nbident,
             ST_Multi(ST_Union(nbgeometrie.geometrie)) AS geometrie
-          FROM
+        FROM
             agi_dm01avso24.nummerierngsbrche_nbgeometrie AS nbgeometrie
             LEFT JOIN agi_dm01avso24.nummerierngsbrche_nummerierungsbereich AS nbbereich
             ON nbgeometrie.nbgeometrie_von = nbbereich.t_id
-          WHERE
+        WHERE
             nbbereich.kt =  'SO'
-          GROUP BY
+        GROUP BY
             nbgeometrie.t_datasetname,
             nbbereich.kt,
             nbbereich.nbnummer
-      ) AS nummerierungsbereich
-      ON CAST(nummerierungsbereich.t_datasetname AS integer) = kreis.bfsnr AND nummerierungsbereich.nbident = kreis.nbident
+    ) AS nummerierungsbereich
+    ON CAST(nummerierungsbereich.t_datasetname AS integer) = kreis.bfsnr AND nummerierungsbereich.nbident = kreis.nbident
 )
 -- Main query
 SELECT 
@@ -154,11 +154,11 @@ SELECT
     gemeinde.aname AS gemeinde,
     grundbuchkreis.aname AS grundbuch
 FROM 
- grundstueck
+grundstueck
 LEFT JOIN gemeinde 
-  ON gemeinde.bfsnr = grundstueck.bfs_nr
+ON gemeinde.bfsnr = grundstueck.bfs_nr
 LEFT JOIN grundbuchkreis 
-  --ON ST_Intersects(ST_PointOnSurface(ST_Buffer(grundstueck.geometrie,0)), grundbuchkreis.geometrie)
-  --Aenderung vom 04.12.2019, sc: ST_Buffer ersetzt durch ST_MakeValid (ST_Buffer hat nicht auf allen Liegenschaften den Grundbuchkreis abgefüllt)
-  ON ST_Intersects(grundstueck.point_on_surface, grundbuchkreis.geometrie)
+--ON ST_Intersects(ST_PointOnSurface(ST_Buffer(grundstueck.geometrie,0)), grundbuchkreis.geometrie)
+--Aenderung vom 04.12.2019, sc: ST_Buffer ersetzt durch ST_MakeValid (ST_Buffer hat nicht auf allen Liegenschaften den Grundbuchkreis abgefüllt)
+ON ST_Intersects(grundstueck.point_on_surface, grundbuchkreis.geometrie)
 ;

--- a/agi_mopublic_pub/agi_mopublic_pub_mopublic_grundstueck_proj.sql
+++ b/agi_mopublic_pub/agi_mopublic_pub_mopublic_grundstueck_proj.sql
@@ -1,33 +1,4 @@
-WITH nummerierungsbereich AS
-(
-  SELECT
-    nbgeometrie.t_datasetname,
-    nbbereich.kt || nbbereich.nbnummer AS nbident,
-    ST_Multi(ST_Union(nbgeometrie.geometrie)) AS geometrie
-  FROM
-    agi_dm01avso24.nummerierngsbrche_nbgeometrie AS nbgeometrie
-    LEFT JOIN agi_dm01avso24.nummerierngsbrche_nummerierungsbereich AS nbbereich
-    ON nbgeometrie.nbgeometrie_von = nbbereich.t_id
-  WHERE
-    nbbereich.kt =  'SO'
-  GROUP BY
-    nbgeometrie.t_datasetname,
-    nbbereich.kt,
-    nbbereich.nbnummer
-),
-grundbuchkreis AS 
-(
-    SELECT
-      kreis.aname AS aname,
-      nummerierungsbereich.geometrie
-    FROM
-      agi_av_gb_admin_einteilung.grundbuchkreise_grundbuchkreis AS kreis
-      LEFT JOIN agi_av_gb_admin_einteilung.grundbuchkreise_grundbuchamt AS amt
-      ON kreis.r_grundbuchamt = amt.t_id
-      LEFT JOIN nummerierungsbereich
-      ON CAST(nummerierungsbereich.t_datasetname AS integer) = kreis.bfsnr AND nummerierungsbereich.nbident = kreis.nbident
-),
-gemeinde AS
+WITH gemeinde AS
 (
     SELECT 
         aname, bfsnr
@@ -38,8 +9,8 @@ pos AS
 (
     SELECT
         -- one pos per parcel
-        DISTINCT ON (projgrundstueckpos_von)
-        projgrundstueckpos_von,
+        DISTINCT ON (grundstueckpos_von)
+        grundstueckpos_von,
         CASE 
             WHEN ori IS NULL 
                 THEN (100 - 100) * 0.9
@@ -57,25 +28,19 @@ pos AS
         END AS vali,
         pos
     FROM 
-        agi_dm01avso24.liegenschaften_projgrundstueckpos
-)
-SELECT 
-    nbident,
-    nummer,
-    art_txt,
-    flaechenmass,
-    egrid,
-    bfs_nr,    
-    orientierung,
-    hali,
-    vali,
-    importdatum,
-    nachfuehrung,
-    foo.geometrie,  
-    pos,  
-    gemeinde.aname AS gemeinde,
-    grundbuchkreis.aname AS grundbuch
-FROM 
+        agi_dm01avso24.liegenschaften_grundstueckpos
+),
+aimport AS
+(
+	SELECT
+		max(importdate) AS importdate, dataset
+	FROM
+		agi_dm01avso24.t_ili2db_import
+	GROUP BY
+		dataset 
+),
+-- Grundstuecke
+grundstueck AS
 (
     SELECT
         grundstueck.nbident,
@@ -90,33 +55,26 @@ FROM
         aimport.importdate AS importdatum,
         nachfuehrung.gueltigereintrag AS nachfuehrung,
         liegenschaft.geometrie AS geometrie,    
+	    ST_PointOnSurface(ST_MakeValid(liegenschaft.geometrie)) AS point_on_surface,
         pos.pos
     FROM
-        agi_dm01avso24.liegenschaften_projgrundstueck AS grundstueck
-        LEFT JOIN agi_dm01avso24.liegenschaften_projliegenschaft AS liegenschaft
-            ON liegenschaft.projliegenschaft_von = grundstueck.t_id
+        agi_dm01avso24.liegenschaften_grundstueck AS grundstueck
+        LEFT JOIN agi_dm01avso24.liegenschaften_liegenschaft AS liegenschaft
+            ON liegenschaft.liegenschaft_von = grundstueck.t_id
         LEFT JOIN pos
-            ON pos.projgrundstueckpos_von = grundstueck.t_id
+            ON pos.grundstueckpos_von = grundstueck.t_id
         LEFT JOIN agi_dm01avso24.liegenschaften_lsnachfuehrung AS nachfuehrung
             ON grundstueck.entstehung = nachfuehrung.t_id
         LEFT JOIN agi_dm01avso24.t_ili2db_basket AS basket
             ON grundstueck.t_basket = basket.t_id    
-        LEFT JOIN 
-        (
-            SELECT
-                max(importdate) AS importdate, dataset
-            FROM
-                agi_dm01avso24.t_ili2db_import
-            GROUP BY
-                dataset 
-        ) AS aimport
+        LEFT JOIN aimport
             ON basket.dataset = aimport.dataset    
         
     WHERE 
         liegenschaft.geometrie IS NOT NULL
-    
+
     UNION ALL
-    
+
     SELECT
         grundstueck.nbident,
         grundstueck.nummer,
@@ -129,35 +87,28 @@ FROM
         pos.vali,
         aimport.importdate AS importdatum,
         nachfuehrung.gueltigereintrag AS nachfuehrung,
-        selbstrecht.geometrie AS geometrie,    
+        selbstrecht.geometrie AS geometrie,
+	    ST_PointOnSurface(ST_MakeValid(selbstrecht.geometrie)) AS point_on_surface,
         pos.pos
     FROM
-        agi_dm01avso24.liegenschaften_projgrundstueck AS grundstueck
-        LEFT JOIN agi_dm01avso24.liegenschaften_projselbstrecht AS selbstrecht 
-            ON selbstrecht.projselbstrecht_von = grundstueck.t_id
+        agi_dm01avso24.liegenschaften_grundstueck AS grundstueck
+        LEFT JOIN agi_dm01avso24.liegenschaften_selbstrecht AS selbstrecht 
+            ON selbstrecht.selbstrecht_von = grundstueck.t_id
         LEFT JOIN pos
-            ON pos.projgrundstueckpos_von = grundstueck.t_id
+            ON pos.grundstueckpos_von = grundstueck.t_id
         LEFT JOIN agi_dm01avso24.liegenschaften_lsnachfuehrung AS nachfuehrung
             ON grundstueck.entstehung = nachfuehrung.t_id
         LEFT JOIN agi_dm01avso24.t_ili2db_basket AS basket
             ON grundstueck.t_basket = basket.t_id    
         LEFT JOIN 
-        (
-            SELECT
-                max(importdate) AS importdate, dataset
-            FROM
-                agi_dm01avso24.t_ili2db_import
-            GROUP BY
-                dataset 
-        ) AS aimport
+aimport
             ON basket.dataset = aimport.dataset    
         
     WHERE 
         selbstrecht.geometrie IS NOT NULL
-) AS foo
-LEFT JOIN gemeinde 
-ON gemeinde.bfsnr = foo.bfs_nr
-LEFT JOIN 
+),
+-- grundbuchkreise
+grundbuchkreis AS 
 (
     SELECT
       kreis.aname AS aname,
@@ -184,8 +135,30 @@ LEFT JOIN
             nbbereich.nbnummer
       ) AS nummerierungsbereich
       ON CAST(nummerierungsbereich.t_datasetname AS integer) = kreis.bfsnr AND nummerierungsbereich.nbident = kreis.nbident
-) AS grundbuchkreis  
---ON ST_Intersects(ST_PointOnSurface(ST_Buffer(foo.geometrie, 0)), grundbuchkreis.geometrie)
---änderung vom 04.12.2019, sc: ST_Buffer ersetzt durch ST_MakeValid 
-ON ST_Intersects(ST_PointOnSurface(ST_MakeValid(foo.geometrie)), grundbuchkreis.geometrie)
+)
+-- Main query
+SELECT 
+    nbident,
+    nummer,
+    art_txt,
+    flaechenmass,
+    egrid,
+    bfs_nr,    
+    orientierung,
+    hali,
+    vali,
+    importdatum,
+    nachfuehrung,
+    grundstueck.geometrie,  
+    pos,  
+    gemeinde.aname AS gemeinde,
+    grundbuchkreis.aname AS grundbuch
+FROM 
+ grundstueck
+LEFT JOIN gemeinde 
+  ON gemeinde.bfsnr = grundstueck.bfs_nr
+LEFT JOIN grundbuchkreis 
+  --ON ST_Intersects(ST_PointOnSurface(ST_Buffer(grundstueck.geometrie,0)), grundbuchkreis.geometrie)
+  --Aenderung vom 04.12.2019, sc: ST_Buffer ersetzt durch ST_MakeValid (ST_Buffer hat nicht auf allen Liegenschaften den Grundbuchkreis abgefüllt)
+  ON ST_Intersects(grundstueck.point_on_surface, grundbuchkreis.geometrie)
 ;

--- a/agi_mopublic_pub/agi_mopublic_pub_mopublic_hoheitsgrenzpunkt.sql
+++ b/agi_mopublic_pub/agi_mopublic_pub_mopublic_hoheitsgrenzpunkt.sql
@@ -1,11 +1,11 @@
 WITH aimport AS
 (
-	SELECT
-		max(importdate) AS importdate, dataset
-	FROM
-		agi_dm01avso24.t_ili2db_import
-	GROUP BY
-		dataset 
+    SELECT
+        max(importdate) AS importdate, dataset
+    FROM
+        agi_dm01avso24.t_ili2db_import
+    GROUP BY
+        dataset 
 )
 SELECT 
     hoheitsgrenzpunkt.identifikator AS nummer,

--- a/agi_mopublic_pub/agi_mopublic_pub_mopublic_hoheitsgrenzpunkt.sql
+++ b/agi_mopublic_pub/agi_mopublic_pub_mopublic_hoheitsgrenzpunkt.sql
@@ -1,3 +1,12 @@
+WITH aimport AS
+(
+	SELECT
+		max(importdate) AS importdate, dataset
+	FROM
+		agi_dm01avso24.t_ili2db_import
+	GROUP BY
+		dataset 
+)
 SELECT 
     hoheitsgrenzpunkt.identifikator AS nummer,
     hoheitsgrenzpunkt.punktzeichen AS punktzeichen_txt,
@@ -42,14 +51,6 @@ FROM
         ON hoheitsgrenzpunkt.entstehung = nachfuehrung.t_id
     LEFT JOIN agi_dm01avso24.t_ili2db_basket AS basket
         ON hoheitsgrenzpunkt.t_basket = basket.t_id    
-    LEFT JOIN 
-    (
-        SELECT
-            max(importdate) AS importdate, dataset
-        FROM
-            agi_dm01avso24.t_ili2db_import
-        GROUP BY
-            dataset 
-    ) AS aimport
+    LEFT JOIN aimport
         ON basket.dataset = aimport.dataset    
 ;

--- a/agi_mopublic_pub/agi_mopublic_pub_mopublic_objektname_pos.sql
+++ b/agi_mopublic_pub/agi_mopublic_pub_mopublic_objektname_pos.sql
@@ -5,7 +5,7 @@ WITH einzelobjekt_flaeche AS
         einzelobjekt.t_id,
         einzelobjekt.entstehung,
         split_part(einzelobjekt.art,'.',array_upper(string_to_array(einzelobjekt.art,'.'), 1)) AS art_txt,
-    	nachfuehrung.gueltigereintrag AS nachfuehrung
+        nachfuehrung.gueltigereintrag AS nachfuehrung
     FROM
         agi_dm01avso24.einzelobjekte_flaechenelement AS flaeche
         LEFT JOIN agi_dm01avso24.einzelobjekte_einzelobjekt AS einzelobjekt
@@ -20,7 +20,7 @@ einzelobjekt_linie AS
         einzelobjekt.t_id,
         einzelobjekt.entstehung,
         split_part(einzelobjekt.art,'.',array_upper(string_to_array(einzelobjekt.art,'.'), 1)) AS art_txt,
-    	nachfuehrung.gueltigereintrag AS nachfuehrung
+        nachfuehrung.gueltigereintrag AS nachfuehrung
     FROM
         agi_dm01avso24.einzelobjekte_linienelement AS linie
         LEFT JOIN agi_dm01avso24.einzelobjekte_einzelobjekt AS einzelobjekt
@@ -35,7 +35,7 @@ einzelobjekt_punkt AS
         einzelobjekt.t_id,
         einzelobjekt.entstehung,
         split_part(einzelobjekt.art,'.',array_upper(string_to_array(einzelobjekt.art,'.'), 1)) AS art_txt,
-    	nachfuehrung.gueltigereintrag AS nachfuehrung
+        nachfuehrung.gueltigereintrag AS nachfuehrung
     FROM
         agi_dm01avso24.einzelobjekte_punktelement AS punkt
         LEFT JOIN agi_dm01avso24.einzelobjekte_einzelobjekt AS einzelobjekt
@@ -70,10 +70,10 @@ einzelobjekt_position AS
         agi_dm01avso24.einzelobjekte_objektname AS objekt
         INNER JOIN agi_dm01avso24.einzelobjekte_objektnamepos AS pos
             ON pos.objektnamepos_von = objekt.t_id
-	    LEFT JOIN agi_dm01avso24.t_ili2db_basket AS basket
-	    	ON pos.t_basket = basket.t_id
-	    LEFT JOIN agi_dm01avso24.t_ili2db_import AS aimport
-	    	ON basket.dataset = aimport.dataset
+        LEFT JOIN agi_dm01avso24.t_ili2db_basket AS basket
+            ON pos.t_basket = basket.t_id
+        LEFT JOIN agi_dm01avso24.t_ili2db_import AS aimport
+            ON basket.dataset = aimport.dataset
     WHERE 
         pos.pos IS NOT NULL
 )
@@ -116,9 +116,9 @@ FROM
     LEFT JOIN agi_dm01avso24.bodenbedeckung_bbnachfuehrung AS nachfuehrung
         ON bodenbedeckung.entstehung = nachfuehrung.t_id
     LEFT JOIN agi_dm01avso24.t_ili2db_basket AS basket
-    	ON pos.t_basket = basket.t_id
+        ON pos.t_basket = basket.t_id
     LEFT JOIN agi_dm01avso24.t_ili2db_import AS aimport
-    	ON basket.dataset = aimport.dataset        
+        ON basket.dataset = aimport.dataset        
     
 UNION ALL
 
@@ -161,12 +161,12 @@ FROM
     LEFT JOIN agi_dm01avso24.bodenbedeckung_bbnachfuehrung AS nachfuehrung
         ON bodenbedeckung.entstehung = nachfuehrung.t_id
     LEFT JOIN agi_dm01avso24.t_ili2db_basket AS basket
-    	ON pos.t_basket = basket.t_id
+        ON pos.t_basket = basket.t_id
     LEFT JOIN agi_dm01avso24.t_ili2db_import AS aimport
-    	ON basket.dataset = aimport.dataset        
+        ON basket.dataset = aimport.dataset        
 
 UNION ALL
- 
+
 SELECT
     einzelobjekt_position.objektname,
     einzelobjekt_position.orientierung,
@@ -183,9 +183,9 @@ FROM
     einzelobjekt_flaeche
     INNER JOIN einzelobjekt_position
         ON einzelobjekt_flaeche.t_id = einzelobjekt_position.objektname_von
-   
+
 UNION ALL
-  
+
 SELECT
     einzelobjekt_position.objektname,
     einzelobjekt_position.orientierung,

--- a/agi_mopublic_pub/agi_mopublic_pub_mopublic_ortsname.sql
+++ b/agi_mopublic_pub/agi_mopublic_pub_mopublic_ortsname.sql
@@ -1,3 +1,12 @@
+WITH aimport AS
+(
+	SELECT
+		max(importdate) AS importdate, dataset
+	FROM
+		agi_dm01avso24.t_ili2db_import
+	GROUP BY
+		dataset 
+)
 SELECT
     ortsname.aname AS ortsname,
     CASE
@@ -28,14 +37,6 @@ FROM
         ON ortsname.entstehung = nachfuehrung.t_id
     LEFT JOIN agi_dm01avso24.t_ili2db_basket AS basket
         ON ortsname.t_basket = basket.t_id    
-    LEFT JOIN 
-    (
-        SELECT
-            max(importdate) AS importdate, dataset
-        FROM
-            agi_dm01avso24.t_ili2db_import
-        GROUP BY
-            dataset 
-    ) AS aimport
+    LEFT JOIN aimport
         ON basket.dataset = aimport.dataset    
 ;

--- a/agi_mopublic_pub/agi_mopublic_pub_mopublic_ortsname.sql
+++ b/agi_mopublic_pub/agi_mopublic_pub_mopublic_ortsname.sql
@@ -1,11 +1,11 @@
 WITH aimport AS
 (
-	SELECT
-		max(importdate) AS importdate, dataset
-	FROM
-		agi_dm01avso24.t_ili2db_import
-	GROUP BY
-		dataset 
+    SELECT
+        max(importdate) AS importdate, dataset
+    FROM
+        agi_dm01avso24.t_ili2db_import
+    GROUP BY
+        dataset 
 )
 SELECT
     ortsname.aname AS ortsname,

--- a/agi_mopublic_pub/agi_mopublic_pub_mopublic_rohrleitung.sql
+++ b/agi_mopublic_pub/agi_mopublic_pub_mopublic_rohrleitung.sql
@@ -1,3 +1,12 @@
+WITH aimport AS
+(
+	SELECT
+		max(importdate) AS importdate, dataset
+	FROM
+		agi_dm01avso24.t_ili2db_import
+	GROUP BY
+		dataset 
+)
 SELECT
     objekt.art AS art_txt,
     objekt.betreiber,
@@ -13,14 +22,6 @@ FROM
         ON objekt.entstehung = nachfuehrung.t_id
     LEFT JOIN agi_dm01avso24.t_ili2db_basket AS basket
         ON objekt.t_basket = basket.t_id    
-    LEFT JOIN 
-    (
-        SELECT
-            max(importdate) AS importdate, dataset
-        FROM
-            agi_dm01avso24.t_ili2db_import
-        GROUP BY
-            dataset 
-    ) AS aimport
+    LEFT JOIN aimport
         ON basket.dataset = aimport.dataset    
 ;

--- a/agi_mopublic_pub/agi_mopublic_pub_mopublic_rohrleitung.sql
+++ b/agi_mopublic_pub/agi_mopublic_pub_mopublic_rohrleitung.sql
@@ -1,11 +1,11 @@
 WITH aimport AS
 (
-	SELECT
-		max(importdate) AS importdate, dataset
-	FROM
-		agi_dm01avso24.t_ili2db_import
-	GROUP BY
-		dataset 
+    SELECT
+        max(importdate) AS importdate, dataset
+    FROM
+        agi_dm01avso24.t_ili2db_import
+    GROUP BY
+        dataset 
 )
 SELECT
     objekt.art AS art_txt,

--- a/agi_mopublic_pub/agi_mopublic_pub_mopublic_strassenachse.sql
+++ b/agi_mopublic_pub/agi_mopublic_pub_mopublic_strassenachse.sql
@@ -1,11 +1,11 @@
 WITH aimport AS
 (
-	SELECT
-		max(importdate) AS importdate, dataset
-	FROM
-		agi_dm01avso24.t_ili2db_import
-	GROUP BY
-		dataset 
+    SELECT
+        max(importdate) AS importdate, dataset
+    FROM
+        agi_dm01avso24.t_ili2db_import
+    GROUP BY
+        dataset 
 )
 SELECT
     aname.atext AS strassenname,

--- a/agi_mopublic_pub/agi_mopublic_pub_mopublic_strassenachse.sql
+++ b/agi_mopublic_pub/agi_mopublic_pub_mopublic_strassenachse.sql
@@ -1,3 +1,12 @@
+WITH aimport AS
+(
+	SELECT
+		max(importdate) AS importdate, dataset
+	FROM
+		agi_dm01avso24.t_ili2db_import
+	GROUP BY
+		dataset 
+)
 SELECT
     aname.atext AS strassenname,
     strasse.ordnung,
@@ -15,14 +24,6 @@ FROM
         ON nachfuehrung.t_id = lokalisation.entstehung
     LEFT JOIN agi_dm01avso24.t_ili2db_basket AS basket
         ON strasse.t_basket = basket.t_id    
-    LEFT JOIN 
-    (
-        SELECT
-            max(importdate) AS importdate, dataset
-        FROM
-            agi_dm01avso24.t_ili2db_import
-        GROUP BY
-            dataset 
-    ) AS aimport
+    LEFT JOIN aimport
         ON basket.dataset = aimport.dataset    
 ;

--- a/agi_mopublic_pub/agi_mopublic_pub_mopublic_strassenname_pos.sql
+++ b/agi_mopublic_pub/agi_mopublic_pub_mopublic_strassenname_pos.sql
@@ -1,3 +1,12 @@
+WITH aimport AS
+(
+	SELECT
+		max(importdate) AS importdate, dataset
+	FROM
+		agi_dm01avso24.t_ili2db_import
+	GROUP BY
+		dataset 
+)
 SELECT 
     aname.atext AS strassenname,
     CASE
@@ -29,15 +38,7 @@ FROM
         ON lokalisation.entstehung = nachfuehrung.t_id
     LEFT JOIN agi_dm01avso24.t_ili2db_basket AS basket
         ON aname.t_basket = basket.t_id    
-    LEFT JOIN 
-    (
-        SELECT
-            max(importdate) AS importdate, dataset
-        FROM
-            agi_dm01avso24.t_ili2db_import
-        GROUP BY
-            dataset 
-    ) AS aimport
+    LEFT JOIN aimport
         ON basket.dataset = aimport.dataset    
 WHERE
     pos.pos IS NOT NULL

--- a/agi_mopublic_pub/agi_mopublic_pub_mopublic_strassenname_pos.sql
+++ b/agi_mopublic_pub/agi_mopublic_pub_mopublic_strassenname_pos.sql
@@ -1,11 +1,11 @@
 WITH aimport AS
 (
-	SELECT
-		max(importdate) AS importdate, dataset
-	FROM
-		agi_dm01avso24.t_ili2db_import
-	GROUP BY
-		dataset 
+    SELECT
+        max(importdate) AS importdate, dataset
+    FROM
+        agi_dm01avso24.t_ili2db_import
+    GROUP BY
+        dataset 
 )
 SELECT 
     aname.atext AS strassenname,


### PR DESCRIPTION
Die SQL-Queries von agi_mopublic_pub wurden beschleunigt, insbesondere bei

* Grundstücken
* projektierten Grundstücken
* Gebäudeadressen

Sämtliche Queries wurden von Subselects auf CTEs umgebaut.