### PR TITLE
[awjf_biotopbaeume_pub] Job deaktiviert

### DIFF
--- a/awjf_biotopbaeume_pub/job.properties
+++ b/awjf_biotopbaeume_pub/job.properties
@@ -1,2 +1,1 @@
 logRotator.numToKeep=30
-triggers.cron=H H(1-3) * * *


### PR DESCRIPTION
Job auf Manuell umgestellt da dass Schema awjf_forsterviere von der sogis-DB auf die edit-DB gezügelt wurde.
Joins funktionieren aus diesem Grund nicht mehr:
```
FROM
    awjf_biotopbaeume.biotopbaeume_biotopbaum biotopbaum
    LEFT JOIN awjf_forstreviere.forstreviere_forstreviergeometrie AS forstgeometrie
        ON
            forstgeometrie.geometrie && biotopbaum.geometrie
            AND
            ST_Contains(forstgeometrie.geometrie, biotopbaum.geometrie)
    LEFT JOIN awjf_forstreviere.forstreviere_forstrevier AS forstrevier
        ON
            forstgeometrie.forstrevier = forstrevier.t_id
    LEFT JOIN awjf_forstreviere.forstreviere_forstkreis AS forstkreis
        ON
            forstgeometrie.forstkreis = forstkreis.t_id
```