### PR TITLE
[arp_npl_pub] Upload .xtf-Datei inkl. Angabe BFS-Nummer ermöglichen

### DIFF
--- a/arp_npl_pub/Jenkinsfile
+++ b/arp_npl_pub/Jenkinsfile
@@ -1,0 +1,49 @@
+// Start with a scripted pipeline part
+node('master') {
+    stage('Prepare') {
+        gretlJobRepoUrl = env.GRETL_JOB_REPO_URL
+        uploadDirName = 'upload'
+        uploadFileName = 'uploadFile'
+        // By default the uploaded file is stored in the following directory:
+        buildDir = "$JENKINS_HOME/jobs/$JOB_BASE_NAME/builds/$BUILD_NUMBER"
+        // Create a subdirectory for the uploaded file:
+        sh "mkdir $buildDir/$uploadDirName"
+        inputFile = input (
+            message: 'Datei hochladen',
+            parameters: [
+                file(name: "$uploadDirName/$uploadFileName", description: 'Hochzuladende Datei auswählen'),
+                string(name: 'dataset', description: 'BFS-Nummer der Daten angeben')
+            ]
+        )
+        dir(buildDir) {
+            stash name: 'uploadDir', includes: "upload/**"
+        }
+        sh "rm -r $buildDir/$uploadDirName"
+    }
+}
+
+// Declarative pipeline starts here
+pipeline {
+    agent { label params.nodeLabel ?: 'gretl' }
+    stages {
+        stage('Run GRETL-Job') {
+            steps {
+                git url: gretlJobRepoUrl, branch: "${params.BRANCH ?: 'master'}", changelog: false
+                dir(env.JOB_BASE_NAME) {
+                    unstash name: 'uploadDir'
+                    sh "gretl -Dorg.gradle.jvmargs=-Xmx2G -Pdataset=$inputFile.dataset"
+                }
+            }
+        }
+    }
+    post {
+        unsuccessful {
+            emailext (
+                to: '${DEFAULT_RECIPIENTS}',
+                recipientProviders: [requestor()],
+                subject: "GRETL-Job ${JOB_NAME} (${BUILD_DISPLAY_NAME}) ist fehlgeschlagen",
+                body: "Die Ausführung des GRETL-Jobs ${JOB_NAME} (${BUILD_DISPLAY_NAME}) war nicht erfolgreich. Details dazu finden Sie in den Log-Meldungen unter ${RUN_DISPLAY_URL}."
+            )
+        }
+    }
+}


### PR DESCRIPTION
Indem man das spezielle Jenkinsfile aus Commit https://github.com/sogis/gretljobs/commit/4e9739dbb44561c2a8f28fd9f9ca05276b36506e im Job-Verzeichnis `arp_npl_pub` ablegt, wird man als User direkt nach dem Start des GRETL-Jobs nach der hochzuladenden Datei und nach der BFS-Nummer der Daten gefragt.

In `build.gradle` kann man über den relativen Pfad `upload/uploadFile` auf die hochgeladene Datei zugreifen. (D.h. Ordnername ist `upload`, Dateiname ist `uploadFile`. Der Dateiname lautet immer so, das File wird beim Hochladen also umbenannt.)
Und man kann über die Variable `dataset` auf den Dataset-Namen (d.h. die BFS-Nummer) zugreifen.

Nun muss `build.gradle` noch so angepasst werden, dass die hochgeladene Datei in die Edit-DB importiert wird. 