### PR TITLE
Verbesserungen in docker-compose.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,10 +182,11 @@ docker volume prune
 Dabei werden alle Docker Volumes, die nicht an einen Container angebunden sind,
 unwiderruflich gelöscht.
 (Falls man nur die Volumes dieser Entwicklungs-DBs löschen möchte,
-kann man folgendes versuchen (wobei der *Value* des Labels nicht zwingend
-immer *gretljobs* ist;
-man kann ihn durch `docker volume inspect VOLUMENAME` herausfinden:
+kann man den folgenden Befehl verwenden:
 `docker volume prune --filter 'label=com.docker.compose.project=gretljobs'`
+Wobei der *Value* des Labels nicht zwingend immer *gretljobs* ist,
+sondern vom Verzeichnisnamen abhängt, in welchem `docker-compose.yml` liegt;
+man kann ihn durch `docker volume inspect VOLUMENAME` herausfinden.)
 
 Die DBs sind mit folgenden Verbindungsparametern erreichbar:
 

--- a/README.md
+++ b/README.md
@@ -165,17 +165,27 @@ und mit der Entwicklung von GRETL-Jobs beginnen.
 
 Zwei Docker-DB-Server starten; einer enthält die *edit*-DB, der andere die *pub*-DB:
 ```
-docker-compose up --force-recreate
+docker-compose up
 ```
-(Die Option `--force-recreate` bewirkt, dass man mit leeren DBs startet;
-falls man bereits Daten importiert hat
-und die Container unter Beibehaltung dieser Daten neu starten möchte,
-lässt man diese Option weg.)
-
 Nun können in den DBs nach Belieben Schemas angelegt und Daten importiert werden.
 Dies kann z.B. mit *ili2pg* erfolgen
 oder durch Ausführen von SQL-Skripten
 oder durch Restoren aus einem Dump.
+
+Die Daten bleiben auch
+z.B. nach `docker-compose stop` oder `docker-compose down` erhalten.
+Falls man mit leeren DBs neu starten möchte:
+```
+docker-compose down
+docker volume prune
+```
+Dabei werden alle Docker Volumes, die nicht an einen Container angebunden sind,
+unwiderruflich gelöscht.
+(Falls man nur die Volumes dieser Entwicklungs-DBs löschen möchte,
+kann man folgendes versuchen (wobei der *Value* des Labels nicht zwingend
+immer *gretljobs* ist;
+man kann ihn durch `docker volume inspect VOLUMENAME` herausfinden:
+`docker volume prune --filter 'label=com.docker.compose.project=gretljobs'`
 
 Die DBs sind mit folgenden Verbindungsparametern erreichbar:
 

--- a/development_dbs/setup.sql
+++ b/development_dbs/setup.sql
@@ -9,7 +9,7 @@ SET application_name="container_setup";
 --create extension fuzzystrmatch;
 --create extension postgis_tiger_geocoder;
 create extension pg_stat_statements;
-create extension pgaudit;
+--create extension pgaudit;
 --create extension plr;
 
 alter user postgres password 'PG_ROOT_PASSWORD';
@@ -38,7 +38,7 @@ create extension postgis;
 create extension fuzzystrmatch;
 --create extension postgis_tiger_geocoder;
 create extension pg_stat_statements;
-create extension pgaudit;
+--create extension pgaudit;
 --create extension plr;
 -- Additional extension needed for working with ili2pg:
 CREATE EXTENSION "uuid-ossp";

--- a/development_dbs/setup.sql
+++ b/development_dbs/setup.sql
@@ -8,7 +8,7 @@ SET application_name="container_setup";
 --create extension postgis_topology;
 --create extension fuzzystrmatch;
 --create extension postgis_tiger_geocoder;
-create extension pg_stat_statements;
+--create extension pg_stat_statements;
 --create extension pgaudit;
 --create extension plr;
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,12 @@ services:
       - "54321:5432"
     volumes:
       - ./development_dbs/setup.sql:/pgconf/setup.sql
+      - sshd_edit:/sshd
+      - pgconf_edit:/pgconf
+      - pgdata_edit:/pgdata
+      - pgwal_edit:/pgwal
+      - recover_edit:/recover
+      - backrestrepo_edit:/backrestrepo
     hostname: primary  
   pub-db:
     build: .
@@ -35,4 +41,23 @@ services:
       - "54322:5432"
     volumes:
       - ./development_dbs/setup.sql:/pgconf/setup.sql
+      - sshd_pub:/sshd
+      - pgconf_pub:/pgconf
+      - pgdata_pub:/pgdata
+      - pgwal_pub:/pgwal
+      - recover_pub:/recover
+      - backrestrepo_pub:/backrestrepo
     hostname: primary  
+volumes:
+  sshd_edit:
+  pgconf_edit:
+  pgdata_edit:
+  pgwal_edit:
+  recover_edit:
+  backrestrepo_edit:
+  sshd_pub:
+  pgconf_pub:
+  pgdata_pub:
+  pgwal_pub:
+  recover_pub:
+  backrestrepo_pub:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       - pgwal_edit:/pgwal
       - recover_edit:/recover
       - backrestrepo_edit:/backrestrepo
-    hostname: primary  
+    hostname: primary-edit
   pub-db:
     build: .
     image: sogis/postgis-db:localbuild
@@ -47,7 +47,7 @@ services:
       - pgwal_pub:/pgwal
       - recover_pub:/recover
       - backrestrepo_pub:/backrestrepo
-    hostname: primary  
+    hostname: primary-pub
 volumes:
   sshd_edit:
   pgconf_edit:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     ports:
       - "54321:5432"
     volumes:
-      - ${PWD}/development_dbs/setup.sql:/pgconf/setup.sql
+      - ./development_dbs/setup.sql:/pgconf/setup.sql
     hostname: primary  
   pub-db:
     build: .
@@ -34,5 +34,5 @@ services:
     ports:
       - "54322:5432"
     volumes:
-      - ${PWD}/development_dbs/setup.sql:/pgconf/setup.sql
+      - ./development_dbs/setup.sql:/pgconf/setup.sql
     hostname: primary  


### PR DESCRIPTION
* Pfad für Bind Mount relativ zum Compose File angeben (statt mit ${PWD})
* Named Volumes verwenden, damit die Daten auch nach einem docker-compose down erhalten bleiben
* Eindeutige Hostnamen verwenden
* Extension "pgaudit" nicht installieren, weil sie zu "fehlleitenden" Fehlermeldungen geführt hat