### PR TITLE
Updates to gretl_job_generator.groovy

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,7 @@ muss sein spezifisches Jenkinsfile ebenfalls im Job-Ordner abgelegt werden.
 
 #### `job.properties`
 
-Die Datei `job.properties` muss in ISO 8859-1 encodiert sein, damit allfällige Umlaute etc. korrekt eingelesen werden.
-Sie kann folgende Eigenschaften des GRETL-Jobs enthalten:
+Die Datei `job.properties` kann folgende Eigenschaften des GRETL-Jobs enthalten:
 
 ```java
 logRotator.numToKeep=30

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ nodeLabel=gretl-ili2pg4
 ```
 
 Mit `logRotator.numToKeep` kann eingestellt werden, wieviele Ausführungen des Jobs aufbewahrt werden sollen, d.h. für wieviele Ausführungen beispielsweise das Logfile vorgehalten wird. Standardwert ist 15. Wenn man diese Einstellung weglässt, werden also die 15 letzten Ausführungen aufbewahrt.
+Falls man alle Ausführungen aufbewahren möchte, kann man hier den Wert `unlimited` setzen.
 
 Mit `triggers.cron` kann eingestellt werden, zu welchem Zeitpunkt der Job automatisch gestartet werden soll. Im Beispiel `H H(1-3) * * *` wird der Job jeden Tag irgendwann zwischen 01:00 Uhr und 03:59 Uhr ausgeführt. (Dokumentation der Schreibweise siehe https://github.com/jenkinsci/jenkins/blob/master/core/src/main/resources/hudson/triggers/TimerTrigger/help-spec.jelly). Wenn man diese Einstellung weglässt, wird der Job nie automatisch gestartet, und er muss manuell gestartet werden.
 

--- a/gretl_job_generator.groovy
+++ b/gretl_job_generator.groovy
@@ -90,8 +90,10 @@ for (jobFile in jobFiles) {
     authorization {
       permissions(properties.getProperty('authorization.permissions'), ['hudson.model.Item.Build', 'hudson.model.Item.Read'])
     }
-    logRotator {
-      numToKeep(properties.getProperty('logRotator.numToKeep') as Integer)
+    if (properties.getProperty('logRotator.numToKeep') != 'unlimited') {
+      logRotator {
+        numToKeep(properties.getProperty('logRotator.numToKeep') as Integer)
+      }
     }
     if (properties.getProperty('triggers.upstream') != 'none') {
       triggers {

--- a/gretl_job_generator.groovy
+++ b/gretl_job_generator.groovy
@@ -63,7 +63,7 @@ for (jobFile in jobFiles) {
   def propertiesFile = new File(baseDir, propertiesFilePath)
   if (propertiesFile.exists()) {
     println 'properties file found: ' + propertiesFilePath
-    properties.load(propertiesFile.newDataInputStream())
+    properties.load(new FileReader(propertiesFile))
   }
   
   def productionEnv = ("${OPENSHIFT_BUILD_NAMESPACE}" == 'agi-gretl-production')


### PR DESCRIPTION
Applied the following changes in order to keep `gretl_job_generator.groovy` in sync with https://github.com/sogis/oereb-gretljobs/blob/master/gretl_job_generator.groovy:
* Properties file may be UTF-8 encoded now
* `logRotator.numToKeep` also accepts `unlimited`