### PR TITLE
Add processing DB example

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,31 +50,6 @@ services:
       - recover_pub:/recover
       - backrestrepo_pub:/backrestrepo
     hostname: primary-pub
-  processing-db:
-#    build: .
-    image: crunchydata/crunchy-postgres-gis:centos8-13.3-3.1-4.6.3
-    environment:
-      MODE: postgres
-      PG_DATABASE: processing
-      PG_LOCALE: en_US.UTF-8
-      PG_PRIMARY_PORT: 5432
-      PG_MODE: primary
-      PG_USER: admin
-      PG_PASSWORD: admin
-      PG_PRIMARY_USER: repl
-      PG_PRIMARY_PASSWORD: repl
-      PG_ROOT_PASSWORD: secret
-    ports:
-      - "54323:5432"
-    volumes:
-      - ./development_dbs/setup.sql:/pgconf/setup.sql
-      - sshd_processing:/sshd
-      - pgconf_processing:/pgconf
-      - pgdata_processing:/pgdata
-      - pgwal_processing:/pgwal
-      - recover_processing:/recover
-      - backrestrepo_processing:/backrestrepo
-    hostname: primary-processing
 volumes:
   sshd_edit:
   pgconf_edit:
@@ -88,9 +63,3 @@ volumes:
   pgwal_pub:
   recover_pub:
   backrestrepo_pub:
-  sshd_processing:
-  pgconf_processing:
-  pgdata_processing:
-  pgwal_processing:
-  recover_processing:
-  backrestrepo_processing:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,6 +50,31 @@ services:
       - recover_pub:/recover
       - backrestrepo_pub:/backrestrepo
     hostname: primary-pub
+  processing-db:
+#    build: .
+    image: crunchydata/crunchy-postgres-gis:centos8-13.3-3.1-4.6.3
+    environment:
+      MODE: postgres
+      PG_DATABASE: processing
+      PG_LOCALE: en_US.UTF-8
+      PG_PRIMARY_PORT: 5432
+      PG_MODE: primary
+      PG_USER: admin
+      PG_PASSWORD: admin
+      PG_PRIMARY_USER: repl
+      PG_PRIMARY_PASSWORD: repl
+      PG_ROOT_PASSWORD: secret
+    ports:
+      - "54323:5432"
+    volumes:
+      - ./development_dbs/setup.sql:/pgconf/setup.sql
+      - sshd_processing:/sshd
+      - pgconf_processing:/pgconf
+      - pgdata_processing:/pgdata
+      - pgwal_processing:/pgwal
+      - recover_processing:/recover
+      - backrestrepo_processing:/backrestrepo
+    hostname: primary-processing
 volumes:
   sshd_edit:
   pgconf_edit:
@@ -63,3 +88,9 @@ volumes:
   pgwal_pub:
   recover_pub:
   backrestrepo_pub:
+  sshd_processing:
+  pgconf_processing:
+  pgdata_processing:
+  pgwal_processing:
+  recover_processing:
+  backrestrepo_processing:

--- a/processing_db/Jenkinsfile
+++ b/processing_db/Jenkinsfile
@@ -40,9 +40,9 @@ pipeline {
               - name: PG_MODE
                 value: primary
               - name: PG_USER
-                value: admin
+                value: user
               - name: PG_PASSWORD
-                value: admin
+                value: pass
               - name: PG_PRIMARY_USER
                 value: repl
               - name: PG_PRIMARY_PASSWORD

--- a/processing_db/Jenkinsfile
+++ b/processing_db/Jenkinsfile
@@ -1,0 +1,64 @@
+// Start with a scripted pipeline part
+node('master') {
+    stage('Prepare') {
+        gretlJobRepoUrl = env.GRETL_JOB_REPO_URL
+    }
+}
+
+// Declarative pipeline starts here
+pipeline {
+    agent {
+      kubernetes {
+        cloud 'openshift'
+        inheritFrom 'gretl'
+        defaultContainer 'jnlp'
+        yaml '''
+          spec:
+            containers:
+            - name: processing-db
+              image: crunchydata/crunchy-postgres-gis:centos8-13.3-3.1-4.6.3
+              env:
+              - name: MODE
+                value: postgres
+              - name: PG_DATABASE
+                value: processing
+              - name: PG_LOCALE
+                value: en_US.UTF-8
+              - name: PG_PRIMARY_PORT
+                value: 5432
+              - name: PG_MODE
+                value: primary
+              - name: PG_USER
+                value: admin
+              - name: PG_PASSWORD
+                value: admin
+              - name: PG_PRIMARY_USER
+                value: repl
+              - name: PG_PRIMARY_PASSWORD
+                value: repl
+              - name: PG_ROOT_PASSWORD
+                value: secret
+          '''
+      }
+    }
+    stages {
+        stage('Run GRETL-Job') {
+            steps {
+                git url: gretlJobRepoUrl, branch: "${params.BRANCH ?: 'master'}", changelog: false
+                dir(env.JOB_BASE_NAME) {
+                    sh 'gretl -Dorg.gradle.jvmargs=-Xmx2G'
+                }
+            }
+        }
+    }
+    post {
+        unsuccessful {
+            emailext (
+                to: '${DEFAULT_RECIPIENTS}',
+                recipientProviders: [requestor()],
+                subject: "GRETL-Job ${JOB_NAME} (${BUILD_DISPLAY_NAME}) ist fehlgeschlagen",
+                body: "Die Ausführung des GRETL-Jobs ${JOB_NAME} (${BUILD_DISPLAY_NAME}) war nicht erfolgreich. Details dazu finden Sie in den Log-Meldungen unter ${RUN_DISPLAY_URL}."
+            )
+        }
+    }
+}

--- a/processing_db/Jenkinsfile
+++ b/processing_db/Jenkinsfile
@@ -18,9 +18,6 @@ pipeline {
               supplementalGroups: [26]
             containers:
             - name: jnlp
-              env:
-              - name: ORG_GRADLE_PROJECT_processingDbHost
-                value: 127.0.0.1
               envFrom:
               - configMapRef:
                   name: gretl-resources

--- a/processing_db/Jenkinsfile
+++ b/processing_db/Jenkinsfile
@@ -55,6 +55,11 @@ pipeline {
     }
     stages {
         stage('Run GRETL-Job') {
+            environment {
+                ORG_GRADLE_PROJECT_dbUriProcessing = 'jdbc:postgresql://127.0.0.1/processing'
+                ORG_GRADLE_PROJECT_dbUserProcessing = 'user'
+                ORG_GRADLE_PROJECT_dbPwdProcessing = 'pass'
+            }
             steps {
                 git url: gretlJobRepoUrl, branch: "${params.BRANCH ?: 'master'}", changelog: false
                 dir(env.JOB_BASE_NAME) {

--- a/processing_db/Jenkinsfile
+++ b/processing_db/Jenkinsfile
@@ -16,6 +16,9 @@ pipeline {
           spec:
             containers:
             - name: jnlp
+              env:
+              - name: ORG_GRADLE_PROJECT_processingDbHostname
+                value: localhost
               envFrom:
               - configMapRef:
                   name: gretl-resources

--- a/processing_db/Jenkinsfile
+++ b/processing_db/Jenkinsfile
@@ -19,8 +19,8 @@ pipeline {
             containers:
             - name: jnlp
               env:
-              - name: ORG_GRADLE_PROJECT_processingDbHostname
-                value: localhost
+              - name: ORG_GRADLE_PROJECT_processingDbHost
+                value: 127.0.0.1
               envFrom:
               - configMapRef:
                   name: gretl-resources

--- a/processing_db/Jenkinsfile
+++ b/processing_db/Jenkinsfile
@@ -15,6 +15,12 @@ pipeline {
         yaml '''
           spec:
             containers:
+            - name: jnlp
+              envFrom:
+              - configMapRef:
+                  name: gretl-resources
+              - secretRef:
+                  name: gretl-secrets
             - name: processing-db
               image: crunchydata/crunchy-postgres-gis:centos8-13.3-3.1-4.6.3
               env:

--- a/processing_db/Jenkinsfile
+++ b/processing_db/Jenkinsfile
@@ -7,6 +7,10 @@ node('master') {
 
 // Declarative pipeline starts here
 pipeline {
+    options {
+        disableConcurrentBuilds()
+        timeout(time: 1, unit: 'DAYS')
+    }
     agent {
       kubernetes {
         cloud 'openshift'
@@ -54,7 +58,13 @@ pipeline {
             steps {
                 git url: gretlJobRepoUrl, branch: "${params.BRANCH ?: 'master'}", changelog: false
                 dir(env.JOB_BASE_NAME) {
-                    sh 'gretl -Dorg.gradle.jvmargs=-Xmx2G'
+                    sh 'gretl -Dorg.gradle.jvmargs=-Xmx2G createEmptySchema'
+                    waitUntil {
+                        echo 'Second part of the job (import more data)'
+                        echo 'Third part of the job (do more calculations)'
+                        input message: 'Soll das Resultat jetzt publiziert werden? (Oder ist eine weitere Iteration nötig?)', parameters: [booleanParam(name: 'PUBLISH_RESULT', defaultValue: false, description: 'Resultat jetzt publizieren')]
+                    }
+                    echo 'Fourth part of the job (publish data)'
                 }
             }
         }

--- a/processing_db/Jenkinsfile
+++ b/processing_db/Jenkinsfile
@@ -14,6 +14,8 @@ pipeline {
         defaultContainer 'jnlp'
         yaml '''
           spec:
+            securityContext:
+              supplementalGroups: [26]
             containers:
             - name: jnlp
               env:

--- a/processing_db/Jenkinsfile
+++ b/processing_db/Jenkinsfile
@@ -67,7 +67,7 @@ pipeline {
                     waitUntil {
                         echo 'Second part of the job (import more data)'
                         echo 'Third part of the job (do more calculations)'
-                        input message: 'Resultat publizieren oder Berechnung erneut durchführen?', parameters: [booleanParam(name: 'PUBLISH_RESULT', defaultValue: false, description: 'Häkchen setzen, um das Resultat zu publizieren und den Job abzuschliessen')]
+                        input message: 'Resultat publizieren oder Berechnung nochmals durchführen?', parameters: [booleanParam(name: 'PUBLISH_RESULT', defaultValue: false, description: 'Häkchen setzen, um das Resultat zu publizieren und den Job abzuschliessen')]
                     }
                     echo 'Fourth part of the job (publish data)'
                 }

--- a/processing_db/Jenkinsfile
+++ b/processing_db/Jenkinsfile
@@ -67,7 +67,7 @@ pipeline {
                     waitUntil {
                         echo 'Second part of the job (import more data)'
                         echo 'Third part of the job (do more calculations)'
-                        input message: 'Soll das Resultat jetzt publiziert werden? (Oder ist eine weitere Iteration nötig?)', parameters: [booleanParam(name: 'PUBLISH_RESULT', defaultValue: false, description: 'Resultat jetzt publizieren')]
+                        input message: 'Resultat publizieren oder Berechnung erneut durchführen?', parameters: [booleanParam(name: 'PUBLISH_RESULT', defaultValue: false, description: 'Häkchen setzen, um das Resultat zu publizieren und den Job abzuschliessen')]
                     }
                     echo 'Fourth part of the job (publish data)'
                 }

--- a/processing_db/README.md
+++ b/processing_db/README.md
@@ -1,0 +1,10 @@
+# Beispiel eines GRETL-Jobs der eine separate DB für die Prozessierung von Daten startet
+
+## Entwicklungs-DBs starten
+
+In diesem Fall müssen die Entwicklungs-DBs mit einem leicht anderen Befehl
+gestartet werden:
+
+```
+COMPOSE_FILE=docker-compose.yml:processing_db/docker-compose.override.yml docker-compose up --build
+```

--- a/processing_db/README.md
+++ b/processing_db/README.md
@@ -2,9 +2,22 @@
 
 ## Entwicklungs-DBs starten
 
-In diesem Fall müssen die Entwicklungs-DBs mit einem leicht anderen Befehl
-gestartet werden:
+In diesem Fall müssen die Entwicklungs-DBs
+mit einem leicht anderen Befehl gestartet werden
+(wobei die Option `--build` auch hier grundsätzlich weggelassen werden kann):
 
 ```
 COMPOSE_FILE=docker-compose.yml:processing_db/docker-compose.override.yml docker-compose up --build
+```
+
+## GRETL-Job lokal ausführen
+
+In diesem Fall muss dem GRETL-Wrapperskript `start-gretl.sh`
+zusätzlich die Property `-PprocessingDbHost=processing-db` übergeben werden.
+(Der übergebene Wert muss dem Service-Namen
+in `docker-compose.override.yaml` entsprechen.)
+Beispiel:
+
+```
+./start-gretl.sh --docker-image sogis/gretl-runtime:latest [--docker-network NETWORK] --job-directory $PWD/jobname -PprocessingDbHost=processing-db [taskName...] [--option-name...]
 ```

--- a/processing_db/README.md
+++ b/processing_db/README.md
@@ -12,12 +12,11 @@ COMPOSE_FILE=docker-compose.yml:processing_db/docker-compose.override.yml docker
 
 ## GRETL-Job lokal ausführen
 
-In diesem Fall muss dem GRETL-Wrapperskript `start-gretl.sh`
-zusätzlich die Property `-PprocessingDbHost=processing-db` übergeben werden.
-(Der übergebene Wert muss dem Service-Namen
-in `docker-compose.override.yaml` entsprechen.)
-Beispiel:
+In diesem Fall müssen vor dem Ausführen des GRETL-Wrapperskripts
+zusätzlich folgende Umgebungsvariablen gesetzt werden:
 
 ```
-./start-gretl.sh --docker-image sogis/gretl-runtime:latest [--docker-network NETWORK] --job-directory $PWD/jobname -PprocessingDbHost=processing-db [taskName...] [--option-name...]
+export ORG_GRADLE_PROJECT_dbUriProcessing=jdbc:postgresql://processing-db/processing
+export ORG_GRADLE_PROJECT_dbUserProcessing=user
+export ORG_GRADLE_PROJECT_dbPwdProcessing=pass
 ```

--- a/processing_db/bodenbedeckung_boflaeche.sql
+++ b/processing_db/bodenbedeckung_boflaeche.sql
@@ -1,0 +1,1 @@
+SELECT t_basket, t_datasetname, geometrie, qualitaet, art, entstehung FROM agi_dm01avso24.bodenbedeckung_boflaeche;

--- a/processing_db/build.gradle
+++ b/processing_db/build.gradle
@@ -4,9 +4,9 @@ import ch.so.agi.gretl.api.TransferSet
 apply plugin: 'ch.so.agi.gretl'
 
 
-// Set the dbHost valiable to the value of the processingDbHost property if it's set,
-// otherwise use the default value (which is 'processing-db')
-def dbHost = project.hasProperty('processingDbHost') ? processingDbHost : 'processing-db'
+// Set the dbHost variable to the value of the processingDbHost property if it's set,
+// otherwise use the default value (which is '127.0.0.1')
+def dbHost = project.hasProperty('processingDbHost') ? processingDbHost : '127.0.0.1'
 def dbUriProcessing = "jdbc:postgresql://${dbHost}/processing"
 def dbUserProcessing = 'admin'
 def dbPwdProcessing = 'admin'

--- a/processing_db/build.gradle
+++ b/processing_db/build.gradle
@@ -1,9 +1,7 @@
 import ch.so.agi.gretl.tasks.*
 import ch.so.agi.gretl.api.TransferSet
-import java.nio.file.Paths
 
 apply plugin: 'ch.so.agi.gretl'
-apply plugin: "de.undercouch.download"
 
 
 def dbHostname = 'processing-db' // for use with Docker Compose

--- a/processing_db/build.gradle
+++ b/processing_db/build.gradle
@@ -4,8 +4,8 @@ import ch.so.agi.gretl.api.TransferSet
 apply plugin: 'ch.so.agi.gretl'
 
 
-def dbHostname = project.hasProperty('processingDbHostname') ?: 'processing-db'
-def dbUriProcessing = "jdbc:postgresql://${dbHostname}/processing"
+def dbHost = project.hasProperty('processingDbHost') ?: 'processing-db'
+def dbUriProcessing = "jdbc:postgresql://${dbHost}/processing"
 def dbUserProcessing = 'admin'
 def dbPwdProcessing = 'admin'
 

--- a/processing_db/build.gradle
+++ b/processing_db/build.gradle
@@ -4,14 +4,6 @@ import ch.so.agi.gretl.api.TransferSet
 apply plugin: 'ch.so.agi.gretl'
 
 
-// Set the dbHost variable to the value of the processingDbHost property if it's set,
-// otherwise use the default value (which is '127.0.0.1')
-def dbHost = project.hasProperty('processingDbHost') ? processingDbHost : '127.0.0.1'
-def dbUriProcessing = "jdbc:postgresql://${dbHost}/processing"
-def dbUserProcessing = 'admin'
-def dbPwdProcessing = 'admin'
-
-
 defaultTasks 'processData'
 // Finally it will rather be:
 // defaultTasks 'publishData'

--- a/processing_db/build.gradle
+++ b/processing_db/build.gradle
@@ -4,10 +4,7 @@ import ch.so.agi.gretl.api.TransferSet
 apply plugin: 'ch.so.agi.gretl'
 
 
-def dbHostname = 'processing-db' // for use with Docker Compose
-if ( gretlEnvironment == 'production' || gretlEnvironment == 'integration' || gretlEnvironment == 'test') {
-    dbHostname = 'localhost' // for use with Kubernetes
-}
+def dbHostname = project.hasProperty('processingDbHostname') ?: 'processing-db'
 def dbUriProcessing = "jdbc:postgresql://${dbHostname}/processing"
 def dbUserProcessing = 'admin'
 def dbPwdProcessing = 'admin'

--- a/processing_db/build.gradle
+++ b/processing_db/build.gradle
@@ -1,0 +1,67 @@
+import ch.so.agi.gretl.tasks.*
+import ch.so.agi.gretl.api.TransferSet
+import java.nio.file.Paths
+
+apply plugin: 'ch.so.agi.gretl'
+apply plugin: "de.undercouch.download"
+
+
+def dbUriProcessing = 'jdbc:postgresql://processing-db/processing'
+def dbUserProcessing = 'admin'
+def dbPwdProcessing = 'admin'
+
+
+defaultTasks 'processData'
+// Finally it will rather be:
+// defaultTasks 'publishData'
+
+
+task createEmptySchema(type: Ili2pgImportSchema) {
+    database = [dbUriProcessing, dbUserProcessing, dbPwdProcessing]
+    dbschema = 'av'
+    models = 'DM01AVSO24LV95'
+    defaultSrsCode = '2056'
+    createGeomIdx = true
+    createFk = true
+    createFkIdx = true
+    createUnique = true
+    createEnumTabs = true
+    beautifyEnumDispName = true
+    createMetaInfo = true
+    createNumChecks = true
+    nameByTopic = true
+    strokeArcs = true
+    createImportTabs = true
+    createBasketCol = true
+    createDatasetCol = true
+}
+
+task transferData(type: Db2Db) {
+    sourceDb = [dbUriEdit, dbUserEdit, dbPwdEdit]
+    targetDb = [dbUriProcessing, dbUserProcessing, dbPwdProcessing]
+    transferSets = [
+        new TransferSet('bodenbedeckung_boflaeche.sql', 'av.bodenbedeckung_boflaeche', true)
+    ]
+}
+
+task prepareProcessingDb() {
+    dependsOn = ['createEmptySchema', 'transferData']
+    doLast {
+        println "Processing DB is ready"
+    }
+}
+
+task processData(type: SqlExecutor) {
+    dependsOn prepareProcessingDb
+    database = [dbUriProcessing, dbUserProcessing, dbPwdProcessing]
+    sqlFiles = ['processing.sql']
+}
+
+task publishData(type: Db2Db) {
+    dependsOn processData
+    sourceDb = [dbUriProcessing, dbUserProcessing, dbPwdProcessing]
+    targetDb = [dbUriPub, dbUserPub, dbPwdPub]
+    transferSets = [
+        new TransferSet('publish.sql', 'destination_table', true)
+    ]
+}

--- a/processing_db/build.gradle
+++ b/processing_db/build.gradle
@@ -4,7 +4,9 @@ import ch.so.agi.gretl.api.TransferSet
 apply plugin: 'ch.so.agi.gretl'
 
 
-def dbHost = project.hasProperty('processingDbHost') ?: 'processing-db'
+// Set the dbHost valiable to the value of the processingDbHost property if it's set,
+// otherwise use the default value (which is 'processing-db')
+def dbHost = project.hasProperty('processingDbHost') ? processingDbHost : 'processing-db'
 def dbUriProcessing = "jdbc:postgresql://${dbHost}/processing"
 def dbUserProcessing = 'admin'
 def dbPwdProcessing = 'admin'

--- a/processing_db/build.gradle
+++ b/processing_db/build.gradle
@@ -6,7 +6,11 @@ apply plugin: 'ch.so.agi.gretl'
 apply plugin: "de.undercouch.download"
 
 
-def dbUriProcessing = 'jdbc:postgresql://processing-db/processing'
+def dbHostname = 'processing-db' // for use with Docker Compose
+if ( gretlEnvironment == 'production' || gretlEnvironment == 'integration' || gretlEnvironment == 'test') {
+    dbHostname = 'localhost' // for use with Kubernetes
+}
+def dbUriProcessing = "jdbc:postgresql://${dbHostname}/processing"
 def dbUserProcessing = 'admin'
 def dbPwdProcessing = 'admin'
 

--- a/processing_db/docker-compose.override.yml
+++ b/processing_db/docker-compose.override.yml
@@ -1,7 +1,6 @@
 version: '3'
 services:
   processing-db:
-#    build: .
     image: crunchydata/crunchy-postgres-gis:centos8-13.3-3.1-4.6.3
     environment:
       MODE: postgres

--- a/processing_db/docker-compose.override.yml
+++ b/processing_db/docker-compose.override.yml
@@ -9,8 +9,8 @@ services:
       PG_LOCALE: en_US.UTF-8
       PG_PRIMARY_PORT: 5432
       PG_MODE: primary
-      PG_USER: admin
-      PG_PASSWORD: admin
+      PG_USER: user
+      PG_PASSWORD: pass
       PG_PRIMARY_USER: repl
       PG_PRIMARY_PASSWORD: repl
       PG_ROOT_PASSWORD: secret

--- a/processing_db/docker-compose.override.yml
+++ b/processing_db/docker-compose.override.yml
@@ -1,0 +1,34 @@
+version: '3'
+services:
+  processing-db:
+#    build: .
+    image: crunchydata/crunchy-postgres-gis:centos8-13.3-3.1-4.6.3
+    environment:
+      MODE: postgres
+      PG_DATABASE: processing
+      PG_LOCALE: en_US.UTF-8
+      PG_PRIMARY_PORT: 5432
+      PG_MODE: primary
+      PG_USER: admin
+      PG_PASSWORD: admin
+      PG_PRIMARY_USER: repl
+      PG_PRIMARY_PASSWORD: repl
+      PG_ROOT_PASSWORD: secret
+    ports:
+      - "54323:5432"
+    volumes:
+      - ./development_dbs/setup.sql:/pgconf/setup.sql
+      - sshd_processing:/sshd
+      - pgconf_processing:/pgconf
+      - pgdata_processing:/pgdata
+      - pgwal_processing:/pgwal
+      - recover_processing:/recover
+      - backrestrepo_processing:/backrestrepo
+    hostname: primary-processing
+volumes:
+  sshd_processing:
+  pgconf_processing:
+  pgdata_processing:
+  pgwal_processing:
+  recover_processing:
+  backrestrepo_processing:

--- a/processing_db/processing.sql
+++ b/processing_db/processing.sql
@@ -1,0 +1,5 @@
+UPDATE
+    av.bodenbedeckung_boflaeche
+SET
+    geometrie = ST_Buffer(geometrie, 10)
+;


### PR DESCRIPTION
Beispiel, wie ein GRETL-Job aussehen könnte, der eine eigene DB für Geoprocessing benötigt.

Prinzip dahinter:

- Der Job erhält ein individuelles Jenkinsfile; es unterscheidet sich vom Standard-Jenkinsfile darin, dass als Agent nicht der normale Agent verwendet wird, sondern ein Pod, der zwei Container enthält: Das GRETL-Runtime und eine PostGIS-DB. Dies wird erreicht, indem vom normalen Agent geerbt wird (`inheritFrom 'gretl'`) und per YAML ein zusätzlicher Container (`name: processing-db`) zum Pod hinzugefügt wird. (Im Beispiel wird der Einfachheit halber der originale Crunchydata-Container verwendet.)
- In `build.gradle` wird zuerst mit `ili2pgImportSchema` ein Schema (es heisst hier extra nur `av`) in der Processing-DB angelegt und mit `Db2Db` die benötigten Daten aus der Edit-DB in die Processing-DB übertragen; dann kommt der Task `processData`, wo das Geoprocessing stattfindet (hier heillos simpel gehalten); danach der Task `publishData`, der das Resultat in die Pub-DB überträgt (hier habe ich nichts umgesetzt). Der Ablauf muss nicht genau so sein; er ist hier exemplarisch mal so aufgebaut. `processData` könnte z.B. auch ein Db2Db-Task sein, der das Resultat direkt in die Pub-DB schreibt.
- (`docker-compose.yml` habe ich so angepasst, dass die Sache im Prinzip auch lokal laufen würde; hierzu muss man aber separat irgendwie die lokale Edit-DB noch mit Daten befüllen.)