### PR TITLE
#

### DIFF
--- a/ada_denkmalschutz_pub/denkmal_polygon.sql
+++ b/ada_denkmalschutz_pub/denkmal_polygon.sql
@@ -4,6 +4,8 @@ mpoly AS (
 	SELECT 
 		denkmal_id,
 		ST_RemoveRepeatedPoints(st_multi(st_buffer(st_buffer(st_buffer(st_buffer(st_union(apolygon),0.01),-0.01),-0.01),0.01)),0.01) AS mpoly
+-- TODO: Das Buffern und Re-Buffern ist definitiv nicht optimal. Allerdings ist es der einzige funktionierende Weg, die kleinen Digitalisierungsfehler zu eliminieren. 
+--       Evtl. findet man hier aber in Zukunft eine bessere Lösung! 
 	FROM 
 		ada_denkmalschutz.gis_geometrie
 	WHERE 

--- a/ada_denkmalschutz_pub/denkmal_polygon.sql
+++ b/ada_denkmalschutz_pub/denkmal_polygon.sql
@@ -3,7 +3,7 @@ WITH
 mpoly AS (
 	SELECT 
 		denkmal_id,
-		st_multi(st_union(apolygon)) AS mpoly
+		ST_RemoveRepeatedPoints(st_multi(st_buffer(st_buffer(st_buffer(st_buffer(st_union(apolygon),0.01),-0.01),-0.01),0.01)),0.01) AS mpoly
 	FROM 
 		ada_denkmalschutz.gis_geometrie
 	WHERE 


### PR DESCRIPTION
Beim Umbau der Geometrie passieren Fehler - z.T. wegen schlechtem digitalisieren, z.T. aber auch wegen st_union und Interlis Genauigkeit von 1mm -> duplicate coord. Deshalb muss sowohl ge- und rebuffert, als auch doppelte Stütztpunkte entfernt werden. 