### PR TITLE
Max. Heap Space in gradle.properties setzen

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@ pipeline {
             steps {
                 git url: gretlJobRepoUrl, branch: "${params.BRANCH ?: 'master'}", changelog: false
                 dir(env.JOB_BASE_NAME) {
-                    sh 'gretl -Dorg.gradle.jvmargs=-Xmx2G'
+                    sh 'gretl'
                 }
             }
         }

--- a/README.md
+++ b/README.md
@@ -125,6 +125,9 @@ Die Anleitung, wie man solche Ressourcen (z.B. DB-Verbindungen) in Jenkins defin
 Jeder GRETL-Job braucht im Minimum das File `build.gradle`.
 Bei Bedarf platziert man zudem ein File `job.properties` im Job-Ordner,
 um den Job in Jenkins zu konfigurieren.
+Ebenfalls optional kann eine Datei `gradle.properties`
+im Job-Ordner platziert werden,
+um Properties für den Gradle-Prozess zu setzen.
 Falls der Job in Jenkins mit einem anderen `Jenkinsfile`
 als dem Standard-Jenkinsfile gestartet werden soll,
 muss sein spezifisches Jenkinsfile ebenfalls im Job-Ordner abgelegt werden.
@@ -174,6 +177,21 @@ mit einem grösseren `/tmp`-Verzeichnis ausgeführt.
 Lässt man diese Property weg,
 wird der Job auf einem normalen Jenkins Agent
 (mit dem Label `gretl`) ausgeführt.
+
+#### `gradle.properties`
+
+Die Datei `gradle.properties` kann z.B. dazu benutzt werden,
+dem Job mehr Heap Space (gewissermassen mehr RAM) zur Verfügung zu stellen.
+Um ihm z.B. bis zu 2GB zuzuweisen,
+muss `gradle.properties` die folgende Zeile enthalten:
+
+```
+org.gradle.jvmargs=-Xmx2048m
+```
+
+Weitere mögliche Optionen sind unter
+https://docs.gradle.org/current/userguide/build_environment.html
+dokumentiert.
 
 #### `Jenkinsfile`
 

--- a/afu_abbaustellen_pub/Jenkinsfile
+++ b/afu_abbaustellen_pub/Jenkinsfile
@@ -16,7 +16,7 @@ pipeline {
             steps {
                 git url: gretlJobRepoUrl, branch: "${params.BRANCH ?: 'master'}", changelog: false
                 dir(env.JOB_BASE_NAME) {
-                    sh "gretl -Dorg.gradle.jvmargs=-Xmx2G -PafuAbbaustellenAppXtfUrl=${params.afuAbbaustellenAppXtfUrl}"
+                    sh "gretl -PafuAbbaustellenAppXtfUrl=${params.afuAbbaustellenAppXtfUrl}"
                 }
             }
         }

--- a/afu_gefahrenkartierung_pub_export_ai/gradle.properties
+++ b/afu_gefahrenkartierung_pub_export_ai/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.jvmargs=-Xmx2g

--- a/afu_nabodat_import/Jenkinsfile
+++ b/afu_nabodat_import/Jenkinsfile
@@ -28,7 +28,7 @@ pipeline {
                 git url: gretlJobRepoUrl, branch: "${params.BRANCH ?: 'master'}", changelog: false
                 dir(env.JOB_BASE_NAME) {
                     unstash name: 'uploadDir'
-                    sh 'gretl -Dorg.gradle.jvmargs=-Xmx2G'
+                    sh 'gretl'
                 }
             }
         }

--- a/agi_check_ili_export/gradle.properties
+++ b/agi_check_ili_export/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.jvmargs=-Xmx3g

--- a/alw_fruchtfolgeflaechen/Jenkinsfile
+++ b/alw_fruchtfolgeflaechen/Jenkinsfile
@@ -70,13 +70,13 @@ pipeline {
             steps {
                 git url: gretlJobRepoUrl, branch: "${params.BRANCH ?: 'master'}", changelog: false
                 dir(env.JOB_BASE_NAME) {
-                    sh 'gretl -Dorg.gradle.jvmargs=-Xmx2G prepare_db importAll'
-                    sh 'gretl -Dorg.gradle.jvmargs=-Xmx2G fff_zusammensetzen'
+                    sh 'gretl prepare_db importAll'
+                    sh 'gretl fff_zusammensetzen'
                     waitUntil {
-                        sh 'gretl -Dorg.gradle.jvmargs=-Xmx2G fff_to_edit_db'
+                        sh 'gretl fff_to_edit_db'
                         input message: 'Resultat publizieren oder Berechnung nochmals durchführen?', parameters: [booleanParam(name: 'PUBLISH_RESULT', defaultValue: false, description: 'Häkchen setzen, um das Resultat zu publizieren und den Job abzuschliessen')]
                     }
-                    sh 'gretl -Dorg.gradle.jvmargs=-Xmx2G fff_to_edit_db_finish'
+                    sh 'gretl fff_to_edit_db_finish'
                 }
             }
         }

--- a/alw_fruchtfolgeflaechen_export_ai/gradle.properties
+++ b/alw_fruchtfolgeflaechen_export_ai/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.jvmargs=-Xmx3g

--- a/arp_npl_import/Jenkinsfile
+++ b/arp_npl_import/Jenkinsfile
@@ -34,7 +34,7 @@ pipeline {
                 git url: gretlJobRepoUrl, branch: "${params.BRANCH ?: 'master'}", changelog: false
                 dir(env.JOB_BASE_NAME) {
                     unstash name: 'uploadDir'
-                    sh "gretl -Dorg.gradle.jvmargs=-Xmx2G -Pili2pgDataset=$inputFile.ili2pgDataset"
+                    sh "gretl -Pili2pgDataset=$inputFile.ili2pgDataset"
                 }
             }
         }

--- a/avt_ausnahmetransportrouten_export_ai/Jenkinsfile
+++ b/avt_ausnahmetransportrouten_export_ai/Jenkinsfile
@@ -28,7 +28,7 @@ pipeline {
                 git url: gretlJobRepoUrl, branch: "${params.BRANCH ?: 'master'}", changelog: false
                 dir(env.JOB_BASE_NAME) {
                     unstash name: 'uploadDir'
-                    sh 'gretl -Dorg.gradle.jvmargs=-Xmx2G'
+                    sh 'gretl'
                 }
             }
         }

--- a/avt_groblaermkataster_pub/Jenkinsfile
+++ b/avt_groblaermkataster_pub/Jenkinsfile
@@ -28,7 +28,7 @@ pipeline {
                 git url: gretlJobRepoUrl, branch: "${params.BRANCH ?: 'master'}", changelog: false
                 dir(env.JOB_BASE_NAME) {
                     unstash name: 'uploadDir'
-                    sh 'gretl -Dorg.gradle.jvmargs=-Xmx2G'
+                    sh 'gretl'
                 }
             }
         }

--- a/avt_kantonsstrassen_pub/Jenkinsfile
+++ b/avt_kantonsstrassen_pub/Jenkinsfile
@@ -28,7 +28,7 @@ pipeline {
                 git url: gretlJobRepoUrl, branch: "${params.BRANCH ?: 'master'}", changelog: false
                 dir(env.JOB_BASE_NAME) {
                     unstash name: 'uploadDir'
-                    sh 'gretl -Dorg.gradle.jvmargs=-Xmx2G'
+                    sh 'gretl'
                 }
             }
         }

--- a/awjf_biotopbaeume_import/Jenkinsfile
+++ b/awjf_biotopbaeume_import/Jenkinsfile
@@ -28,7 +28,7 @@ pipeline {
                 git url: gretlJobRepoUrl, branch: "${params.BRANCH ?: 'master'}", changelog: false
                 dir(env.JOB_BASE_NAME) {
                     unstash name: 'uploadDir'
-                    sh 'gretl -Dorg.gradle.jvmargs=-Xmx2G'
+                    sh 'gretl'
                 }
             }
         }

--- a/awjf_gesuchsteller/Jenkinsfile
+++ b/awjf_gesuchsteller/Jenkinsfile
@@ -28,7 +28,7 @@ pipeline {
                 git url: gretlJobRepoUrl, branch: "${params.BRANCH ?: 'master'}", changelog: false
                 dir(env.JOB_BASE_NAME) {
                     unstash name: 'uploadDir'
-                    sh 'gretl -Dorg.gradle.jvmargs=-Xmx2G'
+                    sh 'gretl'
                 }
             }
         }


### PR DESCRIPTION
Ich habe mich wieder mal mit RAM- und Heap-Limits auseinandergesetzt, weil ein Job von Martin mehr RAM benötigte. Und auch der Job _arp_npl_export_ai_, der ja nicht mehr durchläuft, hat mich für folgende Lösung inspiriert:

Das Argument `-Xmx...` für die JVM soll (innerhalb des Pod-Limits von gegenwärtig 3.5GB) neu durch die Job-Entwickler gesetzt werden können, indem sie eine Datei _gradle.properties_ im Job-Verzeichnis platzieren, in der z.B. steht: `org.gradle.jvmargs=-Xmx3g`. Damit das greift, muss nun aus allen Jenkinsfiles die Kommandozeilen-Option `-Dorg.gradle.jvmargs=-Xmx2G` entfernt werden. Denn diese Option übersteuert das, was man in _gradle.properties_ definiert. Deshalb hat z.B. der Job _arp_npl_export_ai_ nur 1864192 KB zur Verfügung, obwohl in _gradle.properties_ `-Xmx=3g` gesetzt ist.

Diese Änderung hat zur Folge, dass diejenigen Jobs, die tatsächlich auf 2GB Heap angewiesen sind, wahrscheinlich nicht mehr durchlaufen werden; wir werden diesen Jobs also nach und nach das _gradle.properties_ hinzufügen müssen. Nehmen wir das in Kauf?

Was ich zusätzlich noch machen werde: In den Betriebsumgebungen das Limit für den Heap bewusst auf 1GB setzen. Denn mir scheint, dass dies für viele Jobs, z.B. die reinen "Edit-nach-Pub-DB-Jobs", ausreicht.
Wenn ich das nicht setzen würde, wäre das Limit neu bei ca. 875 MB, denn OpenShift setzt dies für den Jenkins Agent so: Es setzt Xmx auf einen Viertel des Pod-Memory-Limits, das aktuell bei 3.5GB ist. Und dadurch ist es ja immer wieder anders. Wenn ich es fix auf 1GB setze, ist es wenigstens immer gleich.

In diesem Zusammenhang könnte ich sogar in _start-gretl.sh_ noch eine Option einbauen, mit welcher man den Job lokal ebenfalls auf 1GB begrenzen kann, um zu sehen, ob er dann auch im Betrieb durchlaufen wird, oder ob er mehr Heap braucht. Dies lasse ich aber vorläufig mal weg.

Noch zum Pod Limit: Dieses ist in allen Umgebungen nicht garantiert, sondern eben das Limit. Garantiert ist 1GB. Das scheint mir bisher so zu funktionieren, haben doch seit einiger Zeit alle Jobs 2GB Heap gekriegt, aber der Pod nur 1GB garantiert erhalten.