### PR TITLE
[avt_kunstbauten_pub] Formatierung bezugspunkt angepasst

### DIFF
--- a/avt_kunstbauten_pub/kunstbaute.sql
+++ b/avt_kunstbauten_pub/kunstbaute.sql
@@ -24,7 +24,7 @@ SELECT
   apoint, 
   aname, 
   kubaid, 
-  bezugspunkt, 
+  REPLACE(bezugspunkt,'-','/') AS bezugspunkt, 
   eigentuemer, 
   gemeinde, 
   typ, 


### PR DESCRIPTION
Infolge Probleme im Web GIS Client (Text wird im WGC als Datum interpretiert) muss der Platzhalte '-' mit einem '/' ersetzt werden bis sourcepole den Fehler behoben hat,