### PR TITLE
Update Jenkinsfile for new Jenkins agent

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,8 +15,10 @@ pipeline {
         stage('Run GRETL-Job') {
             steps {
                 git url: gretlJobRepoUrl, branch: "${params.BRANCH ?: 'master'}", changelog: false
-                dir(env.JOB_BASE_NAME) {
-                    sh 'gretl'
+                container('gretl') {
+                    dir(env.JOB_BASE_NAME) {
+                        sh 'gretl'
+                    }
                 }
             }
         }

--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ docker exec -e PGHOST=/tmp -it gretljobs_edit-db_1 psql --single-transaction -d 
 
 
 
-## GRETL Runtime Docker Image verwenden
+## GRETL Docker Image verwenden
 
 Für die Entwicklung von GRETL-Jobs
 kann GRETL mit einem Wrapper-Skript als Docker-Container gestartet werden.
@@ -324,8 +324,8 @@ export ORG_GRADLE_PROJECT_dbPwdPub=gretl
 Danach kann der GRETL-Container gestartet werden. Beispiel-Aufruf:
 
 ```
-docker pull sogis/gretl-runtime:latest
-./start-gretl.sh --docker-image sogis/gretl-runtime:latest [--docker-network NETWORK] --job-directory $PWD/jobname [taskName...] [--option-name...]
+docker pull sogis/gretl:latest
+./start-gretl.sh --docker-image sogis/gretl:latest [--docker-network NETWORK] --job-directory $PWD/jobname [taskName...] [--option-name...]
 ```
 
 Mit `--docker-image IMAGE:TAG` wird angegeben,

--- a/afu_abbaustellen_pub/Jenkinsfile
+++ b/afu_abbaustellen_pub/Jenkinsfile
@@ -15,8 +15,10 @@ pipeline {
         stage('Run GRETL-Job') {
             steps {
                 git url: gretlJobRepoUrl, branch: "${params.BRANCH ?: 'master'}", changelog: false
-                dir(env.JOB_BASE_NAME) {
-                    sh "gretl -PafuAbbaustellenAppXtfUrl=${params.afuAbbaustellenAppXtfUrl}"
+                container('gretl') {
+                    dir(env.JOB_BASE_NAME) {
+                        sh "gretl -PafuAbbaustellenAppXtfUrl=${params.afuAbbaustellenAppXtfUrl}"
+                    }
                 }
             }
         }

--- a/afu_nabodat_import/Jenkinsfile
+++ b/afu_nabodat_import/Jenkinsfile
@@ -26,9 +26,11 @@ pipeline {
         stage('Run GRETL-Job') {
             steps {
                 git url: gretlJobRepoUrl, branch: "${params.BRANCH ?: 'master'}", changelog: false
-                dir(env.JOB_BASE_NAME) {
-                    unstash name: 'uploadDir'
-                    sh 'gretl'
+                container('gretl') {
+                    dir(env.JOB_BASE_NAME) {
+                        unstash name: 'uploadDir'
+                        sh 'gretl'
+                    }
                 }
             }
         }

--- a/afu_oekomorphologie_import/Jenkinsfile
+++ b/afu_oekomorphologie_import/Jenkinsfile
@@ -26,9 +26,11 @@ pipeline {
         stage('Run GRETL-Job') {
             steps {
                 git url: gretlJobRepoUrl, branch: "${params.BRANCH ?: 'master'}", changelog: false
-                dir(env.JOB_BASE_NAME) {
-                    unstash name: 'uploadDir'
-                    sh 'gretl'
+                container('gretl') {
+                    dir(env.JOB_BASE_NAME) {
+                        unstash name: 'uploadDir'
+                        sh 'gretl'
+                    }
                 }
             }
         }

--- a/agi_dm01avso24/README.md
+++ b/agi_dm01avso24/README.md
@@ -34,7 +34,7 @@ export ORG_GRADLE_PROJECT_dbPwdEdit="gretl"
 ```
 
 ```
-scripts/start-gretl.sh --docker-image sogis/gretl-runtime:latest --job-directory agi_dm01avso24/ tasks --all
+scripts/start-gretl.sh --docker-image sogis/gretl:latest --job-directory agi_dm01avso24/ tasks --all
 ```
 
 

--- a/alw_fruchtfolgeflaechen/Jenkinsfile
+++ b/alw_fruchtfolgeflaechen/Jenkinsfile
@@ -15,12 +15,17 @@ pipeline {
       kubernetes {
         cloud 'openshift'
         inheritFrom 'gretl'
-        yamlMergeStrategy merge()
         yaml '''
           spec:
             securityContext:
               supplementalGroups: [26]
             containers:
+            - name: gretl
+              envFrom:
+              - configMapRef:
+                  name: gretl-resources
+              - secretRef:
+                  name: gretl-secrets
             - name: processing-db
               image: crunchydata/crunchy-postgres-gis:centos8-13.3-3.1-4.6.3
               env:

--- a/alw_fruchtfolgeflaechen/Jenkinsfile
+++ b/alw_fruchtfolgeflaechen/Jenkinsfile
@@ -15,18 +15,12 @@ pipeline {
       kubernetes {
         cloud 'openshift'
         inheritFrom 'gretl'
-        defaultContainer 'jnlp'
+        yamlMergeStrategy merge()
         yaml '''
           spec:
             securityContext:
               supplementalGroups: [26]
             containers:
-            - name: jnlp
-              envFrom:
-              - configMapRef:
-                  name: gretl-resources
-              - secretRef:
-                  name: gretl-secrets
             - name: processing-db
               image: crunchydata/crunchy-postgres-gis:centos8-13.3-3.1-4.6.3
               env:
@@ -69,14 +63,16 @@ pipeline {
             }
             steps {
                 git url: gretlJobRepoUrl, branch: "${params.BRANCH ?: 'master'}", changelog: false
-                dir(env.JOB_BASE_NAME) {
-                    sh 'gretl prepare_db importAll'
-                    sh 'gretl fff_zusammensetzen'
-                    waitUntil {
-                        sh 'gretl fff_to_edit_db'
-                        input message: 'Resultat publizieren oder Berechnung nochmals durchführen?', parameters: [booleanParam(name: 'PUBLISH_RESULT', defaultValue: false, description: 'Häkchen setzen, um das Resultat zu publizieren und den Job abzuschliessen')]
+                container('gretl') {
+                    dir(env.JOB_BASE_NAME) {
+                        sh 'gretl prepare_db importAll'
+                        sh 'gretl fff_zusammensetzen'
+                        waitUntil {
+                            sh 'gretl fff_to_edit_db'
+                            input message: 'Resultat publizieren oder Berechnung nochmals durchführen?', parameters: [booleanParam(name: 'PUBLISH_RESULT', defaultValue: false, description: 'Häkchen setzen, um das Resultat zu publizieren und den Job abzuschliessen')]
+                        }
+                        sh 'gretl fff_to_edit_db_finish'
                     }
-                    sh 'gretl fff_to_edit_db_finish'
                 }
             }
         }

--- a/arp_npl_import/Jenkinsfile
+++ b/arp_npl_import/Jenkinsfile
@@ -32,9 +32,11 @@ pipeline {
         stage('Run GRETL-Job') {
             steps {
                 git url: gretlJobRepoUrl, branch: "${params.BRANCH ?: 'master'}", changelog: false
-                dir(env.JOB_BASE_NAME) {
-                    unstash name: 'uploadDir'
-                    sh "gretl -Pili2pgDataset=$inputFile.ili2pgDataset"
+                container('gretl') {
+                    dir(env.JOB_BASE_NAME) {
+                        unstash name: 'uploadDir'
+                        sh "gretl -Pili2pgDataset=$inputFile.ili2pgDataset"
+                    }
                 }
             }
         }

--- a/arp_npl_pub/README.md
+++ b/arp_npl_pub/README.md
@@ -46,5 +46,5 @@ export DB_PWD_PUB=sogis_admin
 ```
 
 ```
-./start-gretl.sh --docker_image sogis/gretl-runtime:production --job_directory /Users/stefan/Projekte/gretl-arp-import/arp_npl_import/ --task_name transferArpNpl
+./start-gretl.sh --docker_image sogis/gretl:latest --job_directory /Users/stefan/Projekte/gretl-arp-import/arp_npl_import/ --task_name transferArpNpl
 ```

--- a/avt_ausnahmetransportrouten_export_ai/Jenkinsfile
+++ b/avt_ausnahmetransportrouten_export_ai/Jenkinsfile
@@ -26,9 +26,11 @@ pipeline {
         stage('Run GRETL-Job') {
             steps {
                 git url: gretlJobRepoUrl, branch: "${params.BRANCH ?: 'master'}", changelog: false
-                dir(env.JOB_BASE_NAME) {
-                    unstash name: 'uploadDir'
-                    sh 'gretl'
+                container('gretl') {
+                    dir(env.JOB_BASE_NAME) {
+                        unstash name: 'uploadDir'
+                        sh 'gretl'
+                    }
                 }
             }
         }

--- a/avt_groblaermkataster_pub/Jenkinsfile
+++ b/avt_groblaermkataster_pub/Jenkinsfile
@@ -26,9 +26,11 @@ pipeline {
         stage('Run GRETL-Job') {
             steps {
                 git url: gretlJobRepoUrl, branch: "${params.BRANCH ?: 'master'}", changelog: false
-                dir(env.JOB_BASE_NAME) {
-                    unstash name: 'uploadDir'
-                    sh 'gretl'
+                container('gretl') {
+                    dir(env.JOB_BASE_NAME) {
+                        unstash name: 'uploadDir'
+                        sh 'gretl'
+                    }
                 }
             }
         }

--- a/avt_kantonsstrassen_pub/Jenkinsfile
+++ b/avt_kantonsstrassen_pub/Jenkinsfile
@@ -26,9 +26,11 @@ pipeline {
         stage('Run GRETL-Job') {
             steps {
                 git url: gretlJobRepoUrl, branch: "${params.BRANCH ?: 'master'}", changelog: false
-                dir(env.JOB_BASE_NAME) {
-                    unstash name: 'uploadDir'
-                    sh 'gretl'
+                container('gretl') {
+                    dir(env.JOB_BASE_NAME) {
+                        unstash name: 'uploadDir'
+                        sh 'gretl'
+                    }
                 }
             }
         }

--- a/awjf_biotopbaeume_import/Jenkinsfile
+++ b/awjf_biotopbaeume_import/Jenkinsfile
@@ -26,9 +26,11 @@ pipeline {
         stage('Run GRETL-Job') {
             steps {
                 git url: gretlJobRepoUrl, branch: "${params.BRANCH ?: 'master'}", changelog: false
-                dir(env.JOB_BASE_NAME) {
-                    unstash name: 'uploadDir'
-                    sh 'gretl'
+                container('gretl') {
+                    dir(env.JOB_BASE_NAME) {
+                        unstash name: 'uploadDir'
+                        sh 'gretl'
+                    }
                 }
             }
         }

--- a/awjf_gesuchsteller/Jenkinsfile
+++ b/awjf_gesuchsteller/Jenkinsfile
@@ -26,9 +26,11 @@ pipeline {
         stage('Run GRETL-Job') {
             steps {
                 git url: gretlJobRepoUrl, branch: "${params.BRANCH ?: 'master'}", changelog: false
-                dir(env.JOB_BASE_NAME) {
-                    unstash name: 'uploadDir'
-                    sh 'gretl'
+                container('gretl') {
+                    dir(env.JOB_BASE_NAME) {
+                        unstash name: 'uploadDir'
+                        sh 'gretl'
+                    }
                 }
             }
         }

--- a/start-gretl.sh
+++ b/start-gretl.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # use like this:
-# ./start-gretl.sh --docker-image sogis/gretl-runtime:latest [--docker-network NETWORK] --job-directory $PWD/jobname [taskName...] [--option-name...]
+# ./start-gretl.sh --docker-image sogis/gretl:latest [--docker-network NETWORK] --job-directory $PWD/jobname [taskName...] [--option-name...]
 # [--docker-network NETWORK] may be used for connecting the container to an already existing docker network
 # [--option-name...] takes any Gradle option, including project properties
 # (e.g. -Pmyprop=myvalue) and system properties (e.g. -Dmyprop=myvalue).
@@ -44,7 +44,7 @@ fi
 declare gretl_cmd="gretl ${gradle_options[@]} -PgretlShare=/tmp/gretl-share"
 
 echo "======================================================="
-echo "Starts the GRETL runtime to execute the given GRETL job"
+echo "Starts the GRETL image to execute the given GRETL job"
 echo "Docker Image: $docker_image"
 echo "Docker network: $docker_network"
 echo "job directory: $job_directory"
@@ -62,7 +62,7 @@ mkdir -p /tmp/gretl-share
 # 4. Pass all environment variables starting with ORG_GRADLE_PROJECT_ to the container
 # 5. run as current user to avoid permission problems on generated .gradle directory
 # 6. connect container to a specific docker network if specified by the user
-# 7. run gretl-runtime image passed by the user
+# 7. run gretl image passed by the user
 # 8. executed commands seperated by semicolon:
 #    a. jenkins jnlp client
 #    b. change to project directory
@@ -75,5 +75,4 @@ docker run -i --rm --name gretl \
      ${envvars_string} \
     --user $UID \
     ${network_string} \
-    "$docker_image" "-c" \
-        "/usr/local/bin/run-jnlp-client > /dev/null 2>&1;cd /home/gradle/project;$gretl_cmd"
+    "$docker_image" "-c" "$gretl_cmd"


### PR DESCRIPTION
This PR needs to be merged after merging and applying https://github.com/sogis/gretl/pull/60

Jobs tested in CRC, as far as possible:

- [x] amb_zivilschutz_adressen_export (standard Jenkinsfile)
- [x] afu_gefahrenkartierung_pub_export_ai (big _tmp_ directory)
- [x] alw_fruchtfolgeflaechen (additional DB container)
- [x] arp_npl_import (file upload and string parameter)

Tested in test environment:

- [x] amb_zivilschutz_adressen_export (standard Jenkinsfile)
- [x] afu_gefahrenkartierung_pub_export_ai (big _tmp_ directory): 43 min vs. 50 min
- [x] alw_fruchtfolgeflaechen (additional DB container)
- [x] arp_npl_import (file upload and string parameter)
- [x] afu_gewaesserschutz_pub (upload to AI using curl)
- [x] ada_denkmalschutz_pub: 19 s vs. 27 s
- [x] amb_sirenenplanung_pub: 31 s vs. 46 s
- [x] arp_bauzonengrenzen_pub: 33 s vs. 42 s
- [x] afu_gewaesserschutz_pub: 41 s vs. 54 s
- [x] agi_mopublic_pub: 3:46 min vs. 4:24 min

To do after the merge:
- [ ] New File: avt_oev_gueteklassen_import/Jenkinsfile
- [ ] Directory has been renamed: afu_oekomorphologie_import