### PR TITLE
[arp_npl_pub] fix dataset

### DIFF
--- a/arp_npl_pub/arp_npl_pub_bfs_zuordnung.sql
+++ b/arp_npl_pub/arp_npl_pub_bfs_zuordnung.sql
@@ -2,7 +2,7 @@
 
 -- Grundnutzung
 UPDATE
-   ${dbSchemaNPL}.nutzungsplanung_grundnutzung gr
+    ${dbSchemaNPL}.nutzungsplanung_grundnutzung gr
      SET gr.bfs_nr = gg.bfs_gemeindenummer
   FROM ${dbSchemaHoheitsgr}.hoheitsgrenzen_gemeindegrenze gg
     WHERE ST_Within(ST_Centroid(gr.geometrie),gg.geometrie);

--- a/arp_npl_pub/arp_npl_pub_bfs_zuordnung.sql
+++ b/arp_npl_pub/arp_npl_pub_bfs_zuordnung.sql
@@ -3,6 +3,6 @@
 -- Grundnutzung
 UPDATE
     ${dbSchemaNPL}.nutzungsplanung_grundnutzung gr
-     SET gr.bfs_nr = gg.bfs_gemeindenummer
+     SET bfs_nr = gg.bfs_gemeindenummer
   FROM ${dbSchemaHoheitsgr}.hoheitsgrenzen_gemeindegrenze gg
     WHERE ST_Within(ST_Centroid(gr.geometrie),gg.geometrie);

--- a/arp_npl_pub/arp_npl_pub_bfs_zuordnung.sql
+++ b/arp_npl_pub/arp_npl_pub_bfs_zuordnung.sql
@@ -2,7 +2,9 @@
 
 -- Grundnutzung
 UPDATE
-   arp_npl_pub.nutzungsplanung_grundnutzung gr
+   ${dbSchemaNPL}.nutzungsplanung_grundnutzung gr
      SET bfs_nr = gg.bfs_gemeindenummer
-  FROM agi_hoheitsgrenzen_pub.hoheitsgrenzen_gemeindegrenze gg
+  FROM ${dbSchemaHoheitsg}.hoheitsgrenzen_gemeindegrenze gg
     WHERE ST_Within(ST_Centroid(gr.geometrie),gg.geometrie);
+
+    

--- a/arp_npl_pub/arp_npl_pub_bfs_zuordnung.sql
+++ b/arp_npl_pub/arp_npl_pub_bfs_zuordnung.sql
@@ -10,6 +10,13 @@ UPDATE
   FROM ${dbSchemaHoheitsgr}.hoheitsgrenzen_gemeindegrenze gg
     WHERE ST_Within(ST_Centroid(gr.geometrie),gg.geometrie);
 
+-- Beschriftung
+UPDATE
+    ${dbSchemaNPL}.nutzungsplanung_nutzungsplanung_beschriftung be
+     SET bfs_nr = gg.bfs_gemeindenummer
+  FROM ${dbSchemaHoheitsgr}.hoheitsgrenzen_gemeindegrenze gg
+    WHERE ST_Within(be.pos,gg.geometrie);
+    
 -- Erschliessungsplanung
 -- Beschriftung
 UPDATE
@@ -38,3 +45,39 @@ UPDATE
      SET bfs_nr = gg.bfs_gemeindenummer
   FROM ${dbSchemaHoheitsgr}.hoheitsgrenzen_gemeindegrenze gg
     WHERE ST_Within(epkt.geometrie,gg.geometrie);
+
+-- überlagernde Objekte
+-- Flächenobjekt
+UPDATE
+    ${dbSchemaNPL}.nutzungsplanung_ueberlagernd_flaeche uefl
+     SET bfs_nr = gg.bfs_gemeindenummer
+  FROM ${dbSchemaHoheitsgr}.hoheitsgrenzen_gemeindegrenze gg
+    WHERE ST_Within(ST_Centroid(uefl.geometrie),gg.geometrie);
+    
+-- Linienobjekt
+UPDATE
+    ${dbSchemaNPL}.nutzungsplanung_ueberlagernd_linie uelin
+     SET bfs_nr = gg.bfs_gemeindenummer
+  FROM ${dbSchemaHoheitsgr}.hoheitsgrenzen_gemeindegrenze gg
+    WHERE ST_Within(ST_LineInterpolatePoint(uelin.geometrie,0.5),gg.geometrie);
+    
+-- Punktobjekt
+UPDATE
+    ${dbSchemaNPL}.nutzungsplanung_ueberlagernd_punkt uepkt
+     SET bfs_nr = gg.bfs_gemeindenummer
+  FROM ${dbSchemaHoheitsgr}.hoheitsgrenzen_gemeindegrenze gg
+    WHERE ST_Within(uepkt.geometrie,gg.geometrie);
+
+-- VS Perimeter Beschriftung
+UPDATE
+    ${dbSchemaNPL}.nutzungsplanung_vs_perimeter_beschriftung vsbe
+     SET bfs_nr = gg.bfs_gemeindenummer
+  FROM ${dbSchemaHoheitsgr}.hoheitsgrenzen_gemeindegrenze gg
+    WHERE ST_Within(vsbe.pos,gg.geometrie);
+
+-- VS Perimeter Verfahrensstand
+UPDATE
+    ${dbSchemaNPL}.nutzungsplanung_vs_perimeter_verfahrensstand vsver
+     SET bfs_nr = gg.bfs_gemeindenummer
+  FROM ${dbSchemaHoheitsgr}.hoheitsgrenzen_gemeindegrenze gg
+    WHERE ST_Within(ST_Centroid(vsver.geometrie),gg.geometrie);

--- a/arp_npl_pub/arp_npl_pub_bfs_zuordnung.sql
+++ b/arp_npl_pub/arp_npl_pub_bfs_zuordnung.sql
@@ -2,8 +2,7 @@
 
 -- Grundnutzung
 UPDATE
-   arp_npl_pub.nutzungsplanung_grundnutzung
+   arp_npl_pub.nutzungsplanung_grundnutzung gr
      SET bfs_nr = gg.bfs_gemeindenummer
-  FROM arp_npl_pub.nutzungsplanung_grundnutzung gn
-    LEFT JOIN agi_hoheitsgrenzen_pub.hoheitsgrenzen_gemeindegrenze gg
-      ON ST_Within(ST_Centroid(gn.geometrie),gg.geometrie);
+  FROM agi_hoheitsgrenzen_pub.hoheitsgrenzen_gemeindegrenze gg
+    WHERE ST_Within(ST_Centroid(gr.geometrie),gg.geometrie);

--- a/arp_npl_pub/arp_npl_pub_bfs_zuordnung.sql
+++ b/arp_npl_pub/arp_npl_pub_bfs_zuordnung.sql
@@ -2,7 +2,7 @@
 
 -- Grundnutzung
 UPDATE
-    ${dbSchemaNPL}.nutzungsplanung_grundnutzung gr
+    arp_npl_pub.nutzungsplanung_grundnutzung gr
      SET bfs_nr = gg.bfs_gemeindenummer
-  FROM ${dbSchemaHoheitsgr}.hoheitsgrenzen_gemeindegrenze gg
+  FROM agi_hoheitsgrenzen_pub.hoheitsgrenzen_gemeindegrenze gg
     WHERE ST_Within(ST_Centroid(gr.geometrie),gg.geometrie);

--- a/arp_npl_pub/arp_npl_pub_bfs_zuordnung.sql
+++ b/arp_npl_pub/arp_npl_pub_bfs_zuordnung.sql
@@ -2,7 +2,7 @@
 
 -- Grundnutzung
 UPDATE
-    arp_npl_pub.nutzungsplanung_grundnutzung gr
+    ${dbSchemaNPL}.nutzungsplanung_grundnutzung gr
      SET bfs_nr = gg.bfs_gemeindenummer
-  FROM agi_hoheitsgrenzen_pub.hoheitsgrenzen_gemeindegrenze gg
+  FROM ${dbSchemaHoheitsgr}.hoheitsgrenzen_gemeindegrenze gg
     WHERE ST_Within(ST_Centroid(gr.geometrie),gg.geometrie);

--- a/arp_npl_pub/arp_npl_pub_bfs_zuordnung.sql
+++ b/arp_npl_pub/arp_npl_pub_bfs_zuordnung.sql
@@ -1,4 +1,7 @@
 -- BFS-Nr-Zuordnung zu Nutzungsplanungsdaten
+-- Bei Flächen werden Zentroide gerechnet, bei Linien die mittlere Punkt der Linie
+-- damit wird sichergestellt, dass eine eindeutige Gemeindezuordnung erfolgt bei
+-- Objekten die die Gemeindegrenze berühren
 
 -- Grundnutzung
 UPDATE
@@ -6,3 +9,32 @@ UPDATE
      SET bfs_nr = gg.bfs_gemeindenummer
   FROM ${dbSchemaHoheitsgr}.hoheitsgrenzen_gemeindegrenze gg
     WHERE ST_Within(ST_Centroid(gr.geometrie),gg.geometrie);
+
+-- Erschliessungsplanung
+-- Beschriftung
+UPDATE
+    ${dbSchemaNPL}.nutzungsplanung_erschliessung_beschriftung be
+     SET bfs_nr = gg.bfs_gemeindenummer
+  FROM ${dbSchemaHoheitsgr}.hoheitsgrenzen_gemeindegrenze gg
+    WHERE ST_Within(be.pos,gg.geometrie);
+
+-- Flächenobjekt
+UPDATE
+    ${dbSchemaNPL}.nutzungsplanung_erschliessung_flaechenobjekt efl
+     SET bfs_nr = gg.bfs_gemeindenummer
+  FROM ${dbSchemaHoheitsgr}.hoheitsgrenzen_gemeindegrenze gg
+    WHERE ST_Within(ST_Centroid(efl.geometrie),gg.geometrie);
+
+-- Linienobjekt
+UPDATE
+    ${dbSchemaNPL}.nutzungsplanung_erschliessung_linienobjekt elin
+     SET bfs_nr = gg.bfs_gemeindenummer
+  FROM ${dbSchemaHoheitsgr}.hoheitsgrenzen_gemeindegrenze gg
+    WHERE ST_Within(ST_LineInterpolatePoint(elin.geometrie,0.5),gg.geometrie);
+
+-- Punktobjekt
+UPDATE
+    ${dbSchemaNPL}.nutzungsplanung_erschliessung_punktobjekt epkt
+     SET bfs_nr = gg.bfs_gemeindenummer
+  FROM ${dbSchemaHoheitsgr}.hoheitsgrenzen_gemeindegrenze gg
+    WHERE ST_Within(epkt.geometrie,gg.geometrie);

--- a/arp_npl_pub/arp_npl_pub_bfs_zuordnung.sql
+++ b/arp_npl_pub/arp_npl_pub_bfs_zuordnung.sql
@@ -1,0 +1,9 @@
+-- BFS-Nr-Zuordnung zu Nutzungsplanungsdaten
+
+-- Grundnutzung
+UPDATE
+   arp_npl_pub.nutzungsplanung_grundnutzung
+     SET bfs_nr = gg.bfs_gemeindenummer
+  FROM arp_npl_pub.nutzungsplanung_grundnutzung gn
+    LEFT JOIN agi_hoheitsgrenzen_pub.hoheitsgrenzen_gemeindegrenze gg
+      ON ST_Within(ST_Centroid(gn.geometrie),gg.geometrie);

--- a/arp_npl_pub/arp_npl_pub_bfs_zuordnung.sql
+++ b/arp_npl_pub/arp_npl_pub_bfs_zuordnung.sql
@@ -3,8 +3,6 @@
 -- Grundnutzung
 UPDATE
    ${dbSchemaNPL}.nutzungsplanung_grundnutzung gr
-     SET bfs_nr = gg.bfs_gemeindenummer
-  FROM ${dbSchemaHoheitsg}.hoheitsgrenzen_gemeindegrenze gg
+     SET gr.bfs_nr = gg.bfs_gemeindenummer
+  FROM ${dbSchemaHoheitsgr}.hoheitsgrenzen_gemeindegrenze gg
     WHERE ST_Within(ST_Centroid(gr.geometrie),gg.geometrie);
-
-    

--- a/arp_npl_pub/arp_npl_pub_datenbereinigung.sql
+++ b/arp_npl_pub/arp_npl_pub_datenbereinigung.sql
@@ -1,27 +1,16 @@
 -- Erschliessung Linienobjekt
 -- Remove nan coordinates
--- TODO: this needs an update after Postgis 3.1 and GEOS 3.9 was deployed
--- ST_MakeValid() should then properly handle NaN stuff
 UPDATE
- arp_npl_pub.nutzungsplanung_erschliessung_linienobjekt
+ ${dbSchemaNPL}.nutzungsplanung_erschliessung_linienobjekt
  SET geometrie =
-       ST_GeometryFromText(
-         -- remove extra comma at the end of wkt, if nan coordinate is at the end
-         regexp_replace(
-          -- match and replace nan coordinates
-          regexp_replace(ST_AsText(geometrie),'(NaN NaN)+,*','','g'),
-          ',\)$',
-          ')'
-         ),
-         2056
-       )
+       ST_MakeValid(geometrie)
   WHERE
-   ST_IsValid(geometrie) = False AND ST_IsValidReason(geometrie) ~* 'nan'
+   ST_IsValid(geometrie) = False
 ;
 
 -- remove LineString geometries with too few points
 DELETE
-   FROM arp_npl_pub.nutzungsplanung_erschliessung_linienobjekt
+   FROM ${dbSchemaNPL}.nutzungsplanung_erschliessung_linienobjekt
    WHERE
      ST_IsValid(geometrie) = False AND ST_IsValidReason(geometrie) ~* 'Too few points in geometry'
 ;
@@ -29,7 +18,7 @@ DELETE
 -- Grundnutzung
 -- remove Polygon geometries with too few points
 DELETE
-   FROM arp_npl_pub.nutzungsplanung_grundnutzung
+   FROM ${dbSchemaNPL}.nutzungsplanung_grundnutzung
    WHERE
      ST_IsValid(geometrie) = False AND ST_IsValidReason(geometrie) ~* 'Too few points in geometry'
 ;
@@ -37,7 +26,7 @@ DELETE
 -- Überlagernd Fläche
 -- remove Polygon geometries with too few points
 DELETE
-   FROM arp_npl_pub.nutzungsplanung_ueberlagernd_flaeche
+   FROM ${dbSchemaNPL}.nutzungsplanung_ueberlagernd_flaeche
    WHERE
      ST_IsValid(geometrie) = False AND ST_IsValidReason(geometrie) ~* 'Too few points in geometry'
 ;
@@ -45,18 +34,9 @@ DELETE
 -- Überlagernd Linie
 -- Remove nan coordinates
 UPDATE
- arp_npl_pub.nutzungsplanung_ueberlagernd_linie
+ ${dbSchemaNPL}.nutzungsplanung_ueberlagernd_linie
  SET geometrie =
-       ST_GeometryFromText(
-         -- remove extra comma at the end of wkt, if nan coordinate is at the end
-         regexp_replace(
-          -- match and replace nan coordinates
-          regexp_replace(ST_AsText(geometrie),'(NaN NaN)+,*','','g'),
-          ',\)$',
-          ')'
-         ),
-         2056
-       )
+       ST_MakeValid(geometrie)
   WHERE
-   ST_IsValid(geometrie) = False AND ST_IsValidReason(geometrie) ~* 'nan'
+   ST_IsValid(geometrie) = False
 ;

--- a/arp_npl_pub/auswertung_zonen_per_gemeinde.sql
+++ b/arp_npl_pub/auswertung_zonen_per_gemeinde.sql
@@ -12,26 +12,39 @@ distinct_bfs AS (
      FROM arp_npl_pub.nutzungsplanung_grundnutzung
      ORDER BY bfs_nr ASC
 ),
-endresult AS (
+zonenflaechen AS (
   SELECT uuid_generate_v4() AS t_ili_tid,
        gem.gemeindename AS gemeindename,
-       bfs.bfs_nr, zones.typ_kt,
+       bfs.bfs_nr,
+       zones.typ_kt,
        round(SUM(ST_Area(grunutz.geometrie)::numeric),0) AS flaeche_zone_aggregiert,
-       count(bobe.t_id) AS anzahl_gebaeude,
-       round(avg(ST_Area(bobe.geometrie))) AS flaeche_gebaeude_durchschnitt,
-       round(sum(ST_Area(bobe.geometrie))) AS flaeche_gebaeude_summe,
-       round(min(ST_Area(bobe.geometrie))) AS flaeche_gebaeude_minimum,
-       round(max(ST_Area(bobe.geometrie))) AS flaeche_gebaeude_maximum
+       ST_Union(grunutz.geometrie) AS geometrie
     FROM distinct_bfs bfs
     CROSS JOIN distinct_zones zones
     LEFT JOIN arp_npl_pub.nutzungsplanung_grundnutzung grunutz
       ON grunutz.bfs_nr = bfs.bfs_nr AND grunutz.typ_kt = zones.typ_kt
     LEFT JOIN agi_hoheitsgrenzen_pub.hoheitsgrenzen_gemeindegrenze gem
       ON bfs.bfs_nr = gem.bfs_gemeindenummer
-    LEFT JOIN agi_mopublic_pub.mopublic_bodenbedeckung bobe
-      ON bobe.art_txt = 'Gebaeude' AND ST_Intersects(grunutz.geometrie,bobe.geometrie)
     GROUP BY bfs.bfs_nr, zones.typ_kt, gem.gemeindename
     ORDER BY bfs_nr ASC, typ_kt ASC
+),
+zfl_mit_gebaeudedaten AS (
+  SELECT zfl.t_ili_tid,
+       zfl.gemeindename,
+       zfl.bfs_nr,
+       zfl.typ_kt,
+       zfl.flaeche_zone_aggregiert,
+       count(bobe.t_id) AS anzahl_gebaeude,
+       round(avg(ST_Area(bobe.geometrie))) AS flaeche_gebaeude_durchschnitt,
+       round(sum(ST_Area(bobe.geometrie))) AS flaeche_gebaeude_summe,
+       round(min(ST_Area(bobe.geometrie))) AS flaeche_gebaeude_minimum,
+       round(max(ST_Area(bobe.geometrie))) AS flaeche_gebaeude_maximum
+    FROM zonenflaechen zfl
+    LEFT JOIN agi_mopublic_pub.mopublic_bodenbedeckung bobe
+      ON bobe.art_txt = 'Gebaeude' AND ST_Intersects(zfl.geometrie,bobe.geometrie)
+    GROUP BY zfl.t_ili_tid, zfl.bfs_nr, zfl.typ_kt, zfl.gemeindename, zfl.flaeche_zone_aggregiert
+    ORDER BY bfs_nr ASC, typ_kt ASC
 )
-SELECT * FROM endresult WHERE flaeche_zone_aggregiert IS NOT NULL
+
+SELECT * FROM zfl_mit_gebaeudedaten WHERE flaeche_zone_aggregiert IS NOT NULL
 ;

--- a/arp_npl_pub/build.gradle
+++ b/arp_npl_pub/build.gradle
@@ -18,6 +18,9 @@ task transferArpNpl(type: Db2Db) {
             new TransferSet("transform_arp_npl_pub_nutzungsplanung_beschriftung.sql", 'arp_npl_pub.nutzungsplanung_nutzungsplanung_beschriftung', true),
             new TransferSet("transform_arp_npl_pub_erschliessung_flaechenobjekt_json_dokumente.sql", 'arp_npl_pub.nutzungsplanung_erschliessung_flaechenobjekt', true),
             new TransferSet("transform_arp_npl_pub_erschliessung_linienobjekt_json_dokumente.sql", 'arp_npl_pub.nutzungsplanung_erschliessung_linienobjekt', true),
-            new TransferSet("transform_arp_npl_pub_erschliessung_punktobjekt_json_dokumente.sql", 'arp_npl_pub.nutzungsplanung_erschliessung_punktobjekt', true)
+            new TransferSet("transform_arp_npl_pub_erschliessung_punktobjekt_json_dokumente.sql", 'arp_npl_pub.nutzungsplanung_erschliessung_punktobjekt', true),
+            new TransferSet("transform_arp_npl_pub_erschliessung_beschriftung.sql", 'arp_npl_pub.nutzungsplanung_erschliessung_beschriftung', true),
+            new TransferSet("transform_arp_npl_pub_verfahrenstand_vs_perimeter_verfahrenstand.sql", 'arp_npl_pub.nutzungsplanung_vs_perimeter_verfahrensstand', true),
+            new TransferSet("transform_arp_npl_pub_verfahrenstand_vs_perimeter_beschriftung.sql", 'arp_npl_pub.nutzungsplanung_vs_perimeter_beschriftung', true)
     ];
 }

--- a/arp_npl_pub/build.gradle
+++ b/arp_npl_pub/build.gradle
@@ -3,7 +3,7 @@ import ch.so.agi.gretl.api.TransferSet
 
 def GROUP = "npl_edit_to_pub"
 
-defaultTasks 'updateAggregationGrundnutzungsflaechen'
+defaultTasks 'transferArpNpl'
 
 task transferArpNpl(type: Db2Db) {
     description = "Übertrag neue Nutzungsplanungsdaten"
@@ -11,39 +11,6 @@ task transferArpNpl(type: Db2Db) {
     sourceDb = [dbUriEdit, dbUserEdit, dbPwdEdit]
     targetDb = [dbUriPub, dbUserPub, dbPwdPub]
     transferSets = [
-            new TransferSet("transform_arp_npl_pub_nutzungsplanung_grundnutzung_json_dokumente.sql", 'arp_npl_pub.nutzungsplanung_grundnutzung', true),
-            new TransferSet("transform_arp_npl_pub_nutzungsplanung_ueberlagernd_flaeche_json_dokumente.sql", 'arp_npl_pub.nutzungsplanung_ueberlagernd_flaeche', true),
-            new TransferSet("transform_arp_npl_pub_nutzungsplanung_ueberlagernd_linie_json_dokumente.sql", 'arp_npl_pub.nutzungsplanung_ueberlagernd_linie', true),
-            new TransferSet("transform_arp_npl_pub_nutzungsplanung_ueberlagernd_punkt_json_dokumente.sql", 'arp_npl_pub.nutzungsplanung_ueberlagernd_punkt', true),
-            new TransferSet("transform_arp_npl_pub_nutzungsplanung_beschriftung.sql", 'arp_npl_pub.nutzungsplanung_nutzungsplanung_beschriftung', true),
-            new TransferSet("transform_arp_npl_pub_erschliessung_flaechenobjekt_json_dokumente.sql", 'arp_npl_pub.nutzungsplanung_erschliessung_flaechenobjekt', true),
-            new TransferSet("transform_arp_npl_pub_erschliessung_linienobjekt_json_dokumente.sql", 'arp_npl_pub.nutzungsplanung_erschliessung_linienobjekt', true),
-            new TransferSet("transform_arp_npl_pub_erschliessung_punktobjekt_json_dokumente.sql", 'arp_npl_pub.nutzungsplanung_erschliessung_punktobjekt', true),
-            new TransferSet("transform_arp_npl_pub_erschliessung_beschriftung.sql", 'arp_npl_pub.nutzungsplanung_erschliessung_beschriftung', true),
-            new TransferSet("transform_arp_npl_pub_verfahrenstand_vs_perimeter_verfahrenstand.sql", 'arp_npl_pub.nutzungsplanung_vs_perimeter_verfahrensstand', true),
-            new TransferSet("transform_arp_npl_pub_verfahrenstand_vs_perimeter_beschriftung.sql", 'arp_npl_pub.nutzungsplanung_vs_perimeter_beschriftung', true)
+            new TransferSet("transform_arp_npl_pub_nutzungsplanung_grundnutzung_json_dokumente.sql", 'arp_npl_pub.nutzungsplanung_grundnutzung', true)
     ];
-}
-
-task transferAlteGrundnutzung(type: Db2Db, dependsOn: "transferArpNpl") {
-    description = "Übertrag alte Nutzungsplanungsdaten für Gemeinden die noch nicht aufgebarbeitet wurden."
-    group = GROUP
-    sourceDb = [dbUriSogis, dbUserSogis, dbPwdSogis]
-    targetDb = [dbUriPub, dbUserPub, dbPwdPub]
-    transferSets = [
-            new TransferSet("uebertrag_alte_sogisdaten_zonenplan_grundnutzung.sql", 'arp_npl_pub.nutzungsplanung_grundnutzung', false)            
-    ];
-}
-
-task datenBereinigungPostProcessing(type: SqlExecutor, dependsOn:'transferAlteGrundnutzung'){
-    description = "Datenbereinigung wegen invaliden Geometrien, kann nach ili2pg-Upgrade entfernt werden"
-    database = [dbUriPub, dbUserPub, dbPwdPub]
-    sqlFiles = ['arp_npl_pub_datenbereinigung.sql']
-}
-
-task updateAggregationGrundnutzungsflaechen(type: SqlExecutor, dependsOn: "datenBereinigungPostProcessing") {
-    description = "Aktualisierung der aggregierten Zonenflächen pro Gemeinde"
-    group = GROUP
-    database = [dbUriPub, dbUserPub, dbPwdPub]
-    sqlFiles = ["auswertung_zonen_per_gemeinde.sql"]
 }

--- a/arp_npl_pub/build.gradle
+++ b/arp_npl_pub/build.gradle
@@ -14,6 +14,10 @@ task transferArpNpl(type: Db2Db) {
             new TransferSet("transform_arp_npl_pub_nutzungsplanung_grundnutzung_json_dokumente.sql", 'arp_npl_pub.nutzungsplanung_grundnutzung', true),
             new TransferSet("transform_arp_npl_pub_nutzungsplanung_ueberlagernd_flaeche_json_dokumente.sql", 'arp_npl_pub.nutzungsplanung_ueberlagernd_flaeche', true),
             new TransferSet("transform_arp_npl_pub_nutzungsplanung_ueberlagernd_linie_json_dokumente.sql", 'arp_npl_pub.nutzungsplanung_ueberlagernd_linie', true),
-            new TransferSet("transform_arp_npl_pub_nutzungsplanung_ueberlagernd_punkt_json_dokumente.sql", 'arp_npl_pub.nutzungsplanung_ueberlagernd_punkt', true)
+            new TransferSet("transform_arp_npl_pub_nutzungsplanung_ueberlagernd_punkt_json_dokumente.sql", 'arp_npl_pub.nutzungsplanung_ueberlagernd_punkt', true),
+            new TransferSet("transform_arp_npl_pub_nutzungsplanung_beschriftung.sql", 'arp_npl_pub.nutzungsplanung_nutzungsplanung_beschriftung', true),
+            new TransferSet("transform_arp_npl_pub_erschliessung_flaechenobjekt_json_dokumente.sql", 'arp_npl_pub.nutzungsplanung_erschliessung_flaechenobjekt', true),
+            new TransferSet("transform_arp_npl_pub_erschliessung_linienobjekt_json_dokumente.sql", 'arp_npl_pub.nutzungsplanung_erschliessung_linienobjekt', true),
+            new TransferSet("transform_arp_npl_pub_erschliessung_punktobjekt_json_dokumente.sql", 'arp_npl_pub.nutzungsplanung_erschliessung_punktobjekt', true)
     ];
 }

--- a/arp_npl_pub/build.gradle
+++ b/arp_npl_pub/build.gradle
@@ -47,7 +47,7 @@ task bfsZuordnung(type: SqlExecutor, dependsOn:'datenBereinigungPostProcessing')
     description = "Wegen noch nicht fusionierter Zonenplandaten müssen die BFS-Nr durch geografische Beziehung nochmals zu den AV Gemeinden zugewiesen werden."
     database = [dbUriPub, dbUserPub, dbPwdPub]
     sqlFiles = ['arp_npl_pub_bfs_zuordnung.sql']
-    sqlParameters = [[dbSchemaNPL:DB_Schema_NPL],[dbSchemaHoheitsgr:DB_Schema_Hoheitsgr]]
+    sqlParameters = [[dbSchemaNPL:'arp_npl_pub'],[dbSchemaHoheitsgr:'agi_hoheitsgrenzen_pub']]
 }
 
 task updateAggregationGrundnutzungsflaechen(type: SqlExecutor, dependsOn: "bfsZuordnung") {

--- a/arp_npl_pub/build.gradle
+++ b/arp_npl_pub/build.gradle
@@ -11,6 +11,9 @@ task transferArpNpl(type: Db2Db) {
     sourceDb = [dbUriEdit, dbUserEdit, dbPwdEdit]
     targetDb = [dbUriPub, dbUserPub, dbPwdPub]
     transferSets = [
-            new TransferSet("transform_arp_npl_pub_nutzungsplanung_grundnutzung_json_dokumente.sql", 'arp_npl_pub.nutzungsplanung_grundnutzung', true)
+            new TransferSet("transform_arp_npl_pub_nutzungsplanung_grundnutzung_json_dokumente.sql", 'arp_npl_pub.nutzungsplanung_grundnutzung', true),
+            new TransferSet("transform_arp_npl_pub_nutzungsplanung_ueberlagernd_flaeche_json_dokumente.sql", 'arp_npl_pub.nutzungsplanung_ueberlagernd_flaeche', true),
+            new TransferSet("transform_arp_npl_pub_nutzungsplanung_ueberlagernd_linie_json_dokumente.sql", 'arp_npl_pub.nutzungsplanung_ueberlagernd_linie', true),
+            new TransferSet("transform_arp_npl_pub_nutzungsplanung_ueberlagernd_punkt_json_dokumente.sql", 'arp_npl_pub.nutzungsplanung_ueberlagernd_punkt', true)
     ];
 }

--- a/arp_npl_pub/build.gradle
+++ b/arp_npl_pub/build.gradle
@@ -41,6 +41,7 @@ task datenBereinigungPostProcessing(type: SqlExecutor, dependsOn:'transferAlteGr
     description = "Datenbereinigung wegen invaliden Geometrien, kann nach ili2pg-Upgrade entfernt werden"
     database = [dbUriPub, dbUserPub, dbPwdPub]
     sqlFiles = ['arp_npl_pub_datenbereinigung.sql']
+    sqlParameters = [dbSchemaNPL:DB_Schema_NPL]
 }
 
 task bfsZuordnung(type: SqlExecutor, dependsOn:'datenBereinigungPostProcessing'){

--- a/arp_npl_pub/build.gradle
+++ b/arp_npl_pub/build.gradle
@@ -41,13 +41,13 @@ task datenBereinigungPostProcessing(type: SqlExecutor, dependsOn:'transferAlteGr
     sqlFiles = ['arp_npl_pub_datenbereinigung.sql']
 }
 
-/* task bfsZuordnung(type: SqlExecutor, dependsOn:'datenBereinigungPostProcessing'){
+task bfsZuordnung(type: SqlExecutor, dependsOn:'datenBereinigungPostProcessing'){
     description = "Wegen noch nicht fusionierter Zonenplandaten müssen die BFS-Nr durch geografische Beziehung nochmals zu den AV Gemeinden zugewiesen werden."
     database = [dbUriPub, dbUserPub, dbPwdPub]
     sqlFiles = ['arp_npl_pub_bfs_zuordnung.sql']
-} */
+}
 
-task updateAggregationGrundnutzungsflaechen(type: SqlExecutor, dependsOn: "datenBereinigungPostProcessing") {
+task updateAggregationGrundnutzungsflaechen(type: SqlExecutor, dependsOn: "bfsZuordnung") {
     description = "Aktualisierung der aggregierten Zonenflächen pro Gemeinde"
     group = GROUP
     database = [dbUriPub, dbUserPub, dbPwdPub]

--- a/arp_npl_pub/build.gradle
+++ b/arp_npl_pub/build.gradle
@@ -3,7 +3,7 @@ import ch.so.agi.gretl.api.TransferSet
 
 def GROUP = "npl_edit_to_pub"
 
-defaultTasks 'transferArpNpl'
+defaultTasks 'transferAlteGrundnutzung'
 
 task transferArpNpl(type: Db2Db) {
     description = "Übertrag neue Nutzungsplanungsdaten"
@@ -24,3 +24,14 @@ task transferArpNpl(type: Db2Db) {
             new TransferSet("transform_arp_npl_pub_verfahrenstand_vs_perimeter_beschriftung.sql", 'arp_npl_pub.nutzungsplanung_vs_perimeter_beschriftung', true)
     ];
 }
+
+task transferAlteGrundnutzung(type: Db2Db, dependsOn: "transferArpNpl") {
+    description = "Übertrag alte Nutzungsplanungsdaten für Gemeinden die noch nicht aufgebarbeitet wurden."
+    group = GROUP
+    sourceDb = [dbUriSogis, dbUserSogis, dbPwdSogis]
+    targetDb = [dbUriPub, dbUserPub, dbPwdPub]
+    transferSets = [
+            new TransferSet("uebertrag_alte_sogisdaten_zonenplan_grundnutzung.sql", 'arp_npl_pub.nutzungsplanung_grundnutzung', false)            
+    ];
+}
+

--- a/arp_npl_pub/build.gradle
+++ b/arp_npl_pub/build.gradle
@@ -2,6 +2,8 @@ import ch.so.agi.gretl.tasks.*
 import ch.so.agi.gretl.api.TransferSet
 
 def GROUP = "npl_edit_to_pub"
+def DB_Schema_NPL = "arp_npl_pub"
+def DB_Schema_Hoheitsgr = "agi_hoheitsgrenzen_pub"
 
 defaultTasks 'updateAggregationGrundnutzungsflaechen'
 
@@ -45,6 +47,7 @@ task bfsZuordnung(type: SqlExecutor, dependsOn:'datenBereinigungPostProcessing')
     description = "Wegen noch nicht fusionierter Zonenplandaten müssen die BFS-Nr durch geografische Beziehung nochmals zu den AV Gemeinden zugewiesen werden."
     database = [dbUriPub, dbUserPub, dbPwdPub]
     sqlFiles = ['arp_npl_pub_bfs_zuordnung.sql']
+    sqlParameters = [[dbSchemaNPL:DB_Schema_NPL],[dbSchemaHoheitsg:DB_Schema_Hoheitsgr]]
 }
 
 task updateAggregationGrundnutzungsflaechen(type: SqlExecutor, dependsOn: "bfsZuordnung") {

--- a/arp_npl_pub/build.gradle
+++ b/arp_npl_pub/build.gradle
@@ -47,7 +47,7 @@ task bfsZuordnung(type: SqlExecutor, dependsOn:'datenBereinigungPostProcessing')
     description = "Wegen noch nicht fusionierter Zonenplandaten müssen die BFS-Nr durch geografische Beziehung nochmals zu den AV Gemeinden zugewiesen werden."
     database = [dbUriPub, dbUserPub, dbPwdPub]
     sqlFiles = ['arp_npl_pub_bfs_zuordnung.sql']
-    sqlParameters = [[dbSchemaNPL:DB_Schema_NPL],[dbSchemaHoheitsg:DB_Schema_Hoheitsgr]]
+    sqlParameters = [[dbSchemaNPL:DB_Schema_NPL],[dbSchemaHoheitsgr:DB_Schema_Hoheitsgr]]
 }
 
 task updateAggregationGrundnutzungsflaechen(type: SqlExecutor, dependsOn: "bfsZuordnung") {

--- a/arp_npl_pub/build.gradle
+++ b/arp_npl_pub/build.gradle
@@ -3,7 +3,7 @@ import ch.so.agi.gretl.api.TransferSet
 
 def GROUP = "npl_edit_to_pub"
 
-defaultTasks 'transferAlteGrundnutzung'
+defaultTasks 'updateAggregationGrundnutzungsflaechen'
 
 task transferArpNpl(type: Db2Db) {
     description = "Übertrag neue Nutzungsplanungsdaten"
@@ -35,3 +35,15 @@ task transferAlteGrundnutzung(type: Db2Db, dependsOn: "transferArpNpl") {
     ];
 }
 
+task datenBereinigungPostProcessing(type: SqlExecutor, dependsOn:'transferAlteGrundnutzung'){
+    description = "Datenbereinigung wegen invaliden Geometrien, kann nach ili2pg-Upgrade entfernt werden"
+    database = [dbUriPub, dbUserPub, dbPwdPub]
+    sqlFiles = ['arp_npl_pub_datenbereinigung.sql']
+}
+
+task updateAggregationGrundnutzungsflaechen(type: SqlExecutor, dependsOn: "datenBereinigungPostProcessing") {
+    description = "Aktualisierung der aggregierten Zonenflächen pro Gemeinde"
+    group = GROUP
+    database = [dbUriPub, dbUserPub, dbPwdPub]
+    sqlFiles = ["auswertung_zonen_per_gemeinde.sql"]
+}

--- a/arp_npl_pub/build.gradle
+++ b/arp_npl_pub/build.gradle
@@ -41,7 +41,13 @@ task datenBereinigungPostProcessing(type: SqlExecutor, dependsOn:'transferAlteGr
     sqlFiles = ['arp_npl_pub_datenbereinigung.sql']
 }
 
-task updateAggregationGrundnutzungsflaechen(type: SqlExecutor, dependsOn: "datenBereinigungPostProcessing") {
+task bfsZuordnung(type: SqlExecutor, dependsOn:'datenBereinigungPostProcessing'){
+    description = "Wegen noch nicht fusionierter Zonenplandaten müssen die BFS-Nr durch geografische Beziehung nochmals zu den AV Gemeinden zugewiesen werden."
+    database = [dbUriPub, dbUserPub, dbPwdPub]
+    sqlFiles = ['arp_npl_pub_bfs_zuordnung.sql']
+}
+
+task updateAggregationGrundnutzungsflaechen(type: SqlExecutor, dependsOn: "bfsZuordnung") {
     description = "Aktualisierung der aggregierten Zonenflächen pro Gemeinde"
     group = GROUP
     database = [dbUriPub, dbUserPub, dbPwdPub]

--- a/arp_npl_pub/build.gradle
+++ b/arp_npl_pub/build.gradle
@@ -41,13 +41,13 @@ task datenBereinigungPostProcessing(type: SqlExecutor, dependsOn:'transferAlteGr
     sqlFiles = ['arp_npl_pub_datenbereinigung.sql']
 }
 
-task bfsZuordnung(type: SqlExecutor, dependsOn:'datenBereinigungPostProcessing'){
+/* task bfsZuordnung(type: SqlExecutor, dependsOn:'datenBereinigungPostProcessing'){
     description = "Wegen noch nicht fusionierter Zonenplandaten müssen die BFS-Nr durch geografische Beziehung nochmals zu den AV Gemeinden zugewiesen werden."
     database = [dbUriPub, dbUserPub, dbPwdPub]
     sqlFiles = ['arp_npl_pub_bfs_zuordnung.sql']
-}
+} */
 
-task updateAggregationGrundnutzungsflaechen(type: SqlExecutor, dependsOn: "bfsZuordnung") {
+task updateAggregationGrundnutzungsflaechen(type: SqlExecutor, dependsOn: "datenBereinigungPostProcessing") {
     description = "Aktualisierung der aggregierten Zonenflächen pro Gemeinde"
     group = GROUP
     database = [dbUriPub, dbUserPub, dbPwdPub]

--- a/arp_npl_pub/build.gradle
+++ b/arp_npl_pub/build.gradle
@@ -47,7 +47,7 @@ task bfsZuordnung(type: SqlExecutor, dependsOn:'datenBereinigungPostProcessing')
     description = "Wegen noch nicht fusionierter Zonenplandaten müssen die BFS-Nr durch geografische Beziehung nochmals zu den AV Gemeinden zugewiesen werden."
     database = [dbUriPub, dbUserPub, dbPwdPub]
     sqlFiles = ['arp_npl_pub_bfs_zuordnung.sql']
-    sqlParameters = [[dbSchemaNPL:'arp_npl_pub'],[dbSchemaHoheitsgr:'agi_hoheitsgrenzen_pub']]
+    sqlParameters = [dbSchemaNPL:DB_Schema_NPL,dbSchemaHoheitsgr:DB_Schema_Hoheitsgr]
 }
 
 task updateAggregationGrundnutzungsflaechen(type: SqlExecutor, dependsOn: "bfsZuordnung") {

--- a/arp_npl_pub/transform_arp_npl_pub_erschliessung_beschriftung.sql
+++ b/arp_npl_pub/transform_arp_npl_pub_erschliessung_beschriftung.sql
@@ -78,6 +78,7 @@ WITH beschriftung AS (
 SELECT  
     --g.t_id,
     --g.t_ili_tid,
+    g.t_datasetname,    
     g.bezeichnung AS typ_bezeichnung,
     g.abkuerzung AS typ_abkuerzung,
     g.verbindlichkeit AS typ_verbindlichkeit,

--- a/arp_npl_pub/transform_arp_npl_pub_erschliessung_flaechenobjekt_json_dokumente.sql
+++ b/arp_npl_pub/transform_arp_npl_pub_erschliessung_flaechenobjekt_json_dokumente.sql
@@ -181,6 +181,7 @@ typ_erschliessung_flaechenobjekt_json_dokument_agg AS
 erschliessung_flaechenobjekt_geometrie_typ AS
 (
   SELECT 
+    f.t_datasetname,
     f.t_datasetname::int4 AS bfs_nr,
     f.t_id,
     f.t_ili_tid,
@@ -205,6 +206,7 @@ erschliessung_flaechenobjekt_geometrie_typ AS
 )
 SELECT
   --g.t_id,
+  g.t_datasetname,
   g.t_ili_tid,
   g.typ_bezeichnung,
   g.typ_abkuerzung,

--- a/arp_npl_pub/transform_arp_npl_pub_erschliessung_linienobjekt_json_dokumente.sql
+++ b/arp_npl_pub/transform_arp_npl_pub_erschliessung_linienobjekt_json_dokumente.sql
@@ -193,6 +193,7 @@ typ_erschliessung_linienobjekt_json_dokument_agg AS
 erschliessung_linienobjekt_geometrie_typ AS
 (
   SELECT 
+    f.t_datasetname,
     f.t_datasetname::int4 AS bfs_nr,
     f.t_id,
     f.t_ili_tid,
@@ -217,6 +218,7 @@ erschliessung_linienobjekt_geometrie_typ AS
 )
 SELECT
   --g.t_id,
+  g.t_datasetname,
   g.t_ili_tid,
   g.typ_bezeichnung,
   g.typ_abkuerzung,

--- a/arp_npl_pub/transform_arp_npl_pub_erschliessung_punktobjekt_json_dokumente.sql
+++ b/arp_npl_pub/transform_arp_npl_pub_erschliessung_punktobjekt_json_dokumente.sql
@@ -191,6 +191,7 @@ typ_erschliessung_punktobjekt_json_dokument_agg AS
 erschliessung_punktobjekt_geometrie_typ AS
 (
   SELECT 
+    f.t_datasetname,
     f.t_datasetname::int4 AS bfs_nr,
     f.t_id,
     f.t_ili_tid,
@@ -215,6 +216,7 @@ erschliessung_punktobjekt_geometrie_typ AS
 )
 SELECT
   --g.t_id,
+  g.t_datasetname,
   g.t_ili_tid,
   g.typ_bezeichnung,
   g.typ_abkuerzung,

--- a/arp_npl_pub/transform_arp_npl_pub_nutzungsplanung_beschriftung.sql
+++ b/arp_npl_pub/transform_arp_npl_pub_nutzungsplanung_beschriftung.sql
@@ -104,6 +104,7 @@ WITH beschriftung AS (
         ON typ_ueberlagernd_punkt.t_id = ueberlagernd_punkt.typ_ueberlagernd_punkt 
 )		   
 SELECT  
+    g.t_datasetname,
     g.t_datasetname::int4 AS bfs_nr,
     --g.t_ili_tid,
     g.bezeichnung AS typ_bezeichnung,

--- a/arp_npl_pub/transform_arp_npl_pub_nutzungsplanung_grundnutzung_json_dokumente.sql
+++ b/arp_npl_pub/transform_arp_npl_pub_nutzungsplanung_grundnutzung_json_dokumente.sql
@@ -194,6 +194,7 @@ grundnutzung_geometrie_typ AS
 (
   SELECT 
     g.t_id,
+    g.t_datasetname,
     g.t_datasetname::int4 AS bfs_nr,
     g.t_ili_tid,
     g.name_nummer,
@@ -220,6 +221,7 @@ grundnutzung_geometrie_typ AS
 )
 SELECT
   --g.t_id,
+  g.t_datasetname,
   g.t_ili_tid,
   g.typ_bezeichnung,
   g.typ_abkuerzung,

--- a/arp_npl_pub/transform_arp_npl_pub_nutzungsplanung_ueberlagernd_flaeche_json_dokumente.sql
+++ b/arp_npl_pub/transform_arp_npl_pub_nutzungsplanung_ueberlagernd_flaeche_json_dokumente.sql
@@ -190,6 +190,7 @@ ueberlagernd_flaeche_geometrie_typ AS
 (
   SELECT
     f.t_id,
+    f.t_datasetname,
     f.t_datasetname::int4 AS bfs_nr,
     f.t_ili_tid,
     f.name_nummer,
@@ -213,6 +214,7 @@ ueberlagernd_flaeche_geometrie_typ AS
 )
 SELECT
   --g.t_id,
+  g.t_datasetname,
   g.t_ili_tid,
   g.typ_bezeichnung,
   g.typ_abkuerzung,

--- a/arp_npl_pub/transform_arp_npl_pub_nutzungsplanung_ueberlagernd_linie_json_dokumente.sql
+++ b/arp_npl_pub/transform_arp_npl_pub_nutzungsplanung_ueberlagernd_linie_json_dokumente.sql
@@ -182,6 +182,7 @@ ueberlagernd_linie_geometrie_typ AS
 (
   SELECT
     l.t_id,
+    l.t_datasetname,
     l.t_datasetname::int4 AS bfs_nr,
     l.t_ili_tid,
     l.name_nummer,
@@ -207,6 +208,7 @@ ueberlagernd_linie_geometrie_typ AS
 -- hinzugefügt werden. Plural, da auch Kaskade wieder möglich.
 SELECT
   --g.t_id,
+  g.t_datasetname,
   g.t_ili_tid,
   g.typ_bezeichnung,
   g.typ_abkuerzung,

--- a/arp_npl_pub/transform_arp_npl_pub_nutzungsplanung_ueberlagernd_punkt_json_dokumente.sql
+++ b/arp_npl_pub/transform_arp_npl_pub_nutzungsplanung_ueberlagernd_punkt_json_dokumente.sql
@@ -184,6 +184,7 @@ ueberlagernd_punkt_geometrie_typ AS
     l.t_id,
     l.t_datasetname,
     l.t_datasetname::int4 AS bfs_nr,
+    l.t_ili_tid,
     l.name_nummer,
     l.rechtsstatus,
     l.publiziertab,

--- a/arp_npl_pub/transform_arp_npl_pub_nutzungsplanung_ueberlagernd_punkt_json_dokumente.sql
+++ b/arp_npl_pub/transform_arp_npl_pub_nutzungsplanung_ueberlagernd_punkt_json_dokumente.sql
@@ -182,8 +182,8 @@ ueberlagernd_punkt_geometrie_typ AS
 (
   SELECT
     l.t_id,
+    l.t_datasetname,
     l.t_datasetname::int4 AS bfs_nr,
-    l.t_ili_tid,
     l.name_nummer,
     l.rechtsstatus,
     l.publiziertab,
@@ -207,6 +207,7 @@ ueberlagernd_punkt_geometrie_typ AS
 -- hinzugefügt werden. Plural, da auch Kaskade wieder möglich.
 SELECT
   --g.t_id,
+  g.t_datasetname,
   g.t_ili_tid,
   g.typ_bezeichnung,
   g.typ_abkuerzung,

--- a/arp_npl_pub/transform_arp_npl_pub_verfahrenstand_vs_perimeter_beschriftung.sql
+++ b/arp_npl_pub/transform_arp_npl_pub_verfahrenstand_vs_perimeter_beschriftung.sql
@@ -1,6 +1,7 @@
 SELECT
     --vspos.t_id,
     --vspos.t_ili_tid,
+    vsperim.t_datasetname,
     vsperim.verfahrensstufe,
     vsperim.name_nummer,
     vspos.pos,

--- a/arp_npl_pub/transform_arp_npl_pub_verfahrenstand_vs_perimeter_verfahrenstand.sql
+++ b/arp_npl_pub/transform_arp_npl_pub_verfahrenstand_vs_perimeter_verfahrenstand.sql
@@ -1,5 +1,6 @@
 SELECT
     --vsperim.t_id,
+    vsperim.t_datasetname,      
     vsperim.t_ili_tid,
     vsperim.geometrie,
     vsperim.planungsart,

--- a/arp_npl_pub/uebertrag_alte_sogisdaten_zonenplan_grundnutzung.sql
+++ b/arp_npl_pub/uebertrag_alte_sogisdaten_zonenplan_grundnutzung.sql
@@ -1,6 +1,7 @@
 WITH tmp_result AS (
 SELECT 
     --ogc_fid AS t_id, --TODO REPLACE WITH NEW generated_id
+    gem_bfs::varchar(200) AS t_datasetname,
     uuid_generate_v4() AS t_ili_tid,
     zcode_text AS typ_bezeichnung,
     NULL AS typ_abkuerzung, --ev. MAPPING?


### PR DESCRIPTION
 Die neue Attribut-Spalte "t_datasetname" enthält nun die ursprüngliche "BFS-Nr" aus der xtf-Datei, die Spalte "bfs_nr" wird durch Postgis-Overlay-Funktionen aus dem AV-Gemeindegrenzendatensatz bestimmt.