### PR TITLE
arp_nutzungsplanung_nachfuehrung

### DIFF
--- a/arp_nutzungsplanung_delete_dataset/Jenkinsfile
+++ b/arp_nutzungsplanung_delete_dataset/Jenkinsfile
@@ -15,9 +15,11 @@ pipeline {
         stage('Run GRETL-Job') {
             steps {
                 git url: gretlJobRepoUrl, branch: "${params.BRANCH ?: 'master'}", changelog: false
-                dir(env.JOB_BASE_NAME) {
-                    sh "gretl -Pbfsnr=${params.bfsnr}"
-                    zip zipFile: 'xtfdata.zip', glob: '*.xtf', archive: true
+                container('gretl') {
+                    dir(env.JOB_BASE_NAME) {
+                        sh "gretl -Pbfsnr=${params.bfsnr}"
+                        zip zipFile: 'xtfdata.zip', glob: '*.xtf', archive: true
+                    }
                 }
             }
         }

--- a/arp_nutzungsplanung_delete_dataset/Jenkinsfile
+++ b/arp_nutzungsplanung_delete_dataset/Jenkinsfile
@@ -1,0 +1,35 @@
+// Start with a scripted pipeline part
+node('master') {
+    stage('Prepare') {
+        gretlJobRepoUrl = env.GRETL_JOB_REPO_URL
+    }
+}
+
+// Declarative pipeline starts here
+pipeline {
+    agent { label params.nodeLabel ?: 'gretl' }
+    options {
+        timeout(time: 6, unit: 'HOURS')
+    }
+    stages {
+        stage('Run GRETL-Job') {
+            steps {
+                git url: gretlJobRepoUrl, branch: "${params.BRANCH ?: 'master'}", changelog: false
+                dir(env.JOB_BASE_NAME) {
+                    sh "gretl -Pbfsnr=${params.bfsnr}"
+                    zip zipFile: 'xtfdata.zip', glob: '*.xtf', archive: true
+                }
+            }
+        }
+    }
+    post {
+        unsuccessful {
+            emailext (
+                to: '${DEFAULT_RECIPIENTS}',
+                recipientProviders: [requestor()],
+                subject: "GRETL-Job ${JOB_NAME} (${BUILD_DISPLAY_NAME}) ist fehlgeschlagen",
+                body: "Die Ausführung des GRETL-Jobs ${JOB_NAME} (${BUILD_DISPLAY_NAME}) war nicht erfolgreich. Details dazu finden Sie in den Log-Meldungen unter ${RUN_DISPLAY_URL}."
+            )
+        }
+    }
+}

--- a/arp_nutzungsplanung_delete_dataset/README.md
+++ b/arp_nutzungsplanung_delete_dataset/README.md
@@ -3,7 +3,7 @@
 Löschung von Dataset mit ili2pg Befehl (--delete --dataset) im Schema «arp_nutzungsplanung». Der Datasetname z.B. «2407» oder «2407_prov» kann angegeben werden. 
 
 ## Job Ablauf
-1. XTF-Datei mit Dataset, das gelöscht werden soll, wird als Datensicherung exportiert (Artefakte).
+1. Exportiert das angegebenen Dataset (BFS-Nr.), das gelöscht werden soll, als XTF-Datei. Als temporäre Datensicherung (Artefakte), falls Löschung falsch war.
 2. Löscht die Daten mit dem angegebenen Dataset (BFS-Nr.) aus dem Schema «arp_nutzungsplanung».
 
 ## GRETL

--- a/arp_nutzungsplanung_delete_dataset/README.md
+++ b/arp_nutzungsplanung_delete_dataset/README.md
@@ -1,0 +1,22 @@
+## Information zum GRETL-Job "delete_dataset"
+## Allgemein
+Löschung von Dataset mit ili2pg Befehl (--delete --dataset) im Schema «arp_nutzungsplanung». Der Datasetname z.B. «2407» oder «2407_prov» kann angegeben werden. 
+
+## Job Ablauf
+1. XTF-Datei mit Dataset, das gelöscht werden soll, wird als Datensicherung exportiert (Artefakte).
+2. Löscht die Daten mit dem angegebenen Dataset (BFS-Nr.) aus dem Schema «arp_nutzungsplanung».
+
+## GRETL
+Lokales arbeiten:
+Parameter:
+```
+export ORG_GRADLE_PROJECT_dbUriEdit=jdbc:postgresql://edit-db/edit
+export ORG_GRADLE_PROJECT_dbUserEdit=gretl
+export ORG_GRADLE_PROJECT_dbPwdEdit=gretl
+export ORG_GRADLE_PROJECT_dbUriPub=jdbc:postgresql://pub-db/pub
+export ORG_GRADLE_PROJECT_dbUserPub=gretl
+export ORG_GRADLE_PROJECT_dbPwdPub=gretl
+```
+```
+./start-gretl.sh --docker-image sogis/gretl-runtime:latest --docker-network schema-jobs_default --job-directory $PWD/arp_nutzungsplanung_delete_dataset -Pili2pgDataset='2457'
+```

--- a/arp_nutzungsplanung_delete_dataset/build.gradle
+++ b/arp_nutzungsplanung_delete_dataset/build.gradle
@@ -1,0 +1,29 @@
+/*
+Löschen eines Dataset über die BFS-Nr. Wird benötig wenn neue Daten bei einer Ortsplanungsrevision von Büros geliefert werden.
+*/
+import ch.so.agi.gretl.tasks.*
+import ch.so.agi.gretl.api.TransferSet
+
+
+apply plugin: 'ch.so.agi.gretl'
+apply plugin: 'org.hidetake.ssh'
+
+defaultTasks "exportData_Dataset_BFSNr"
+
+task exportData_Dataset_BFSNr(type: Ili2pgExport) {
+    description = "Exportiert die zu löschenden Daten mit dem angegebenden Datasetname (BFS-Nr.)aus dem Schema arp_nutzungsplanung_v1 in ein INTERLIS-Datei. Dient zur Sicherung"
+    database = [dbUriEdit, dbUserEdit, dbPwdEdit]
+    models = 'SO_ARP_Nutzungsplanung_Nachfuehrung_20201005'
+    dbschema = 'arp_nutzungsplanung_v1'
+    dataset = bfsnr
+    dataFile = "$rootDir/" + ili2pgDataset
+    disableValidation = true
+}
+
+task delete_Dataset_BFSNr(type: Ili2pgDelete, dependsOn: 'exportData_Dataset_BFSNr') {
+    description = "Löscht Daten mit dem angegebenen Datasetname (BFS-Nr.) aus dem Schema arp_nutzungsplanung_v1"
+    database = [dbUriEdit, dbUserEdit, dbPwdEdit]
+    models = 'SO_ARP_Nutzungsplanung_Nachfuehrung_20201005'
+    dbschema = 'arp_nutzungsplanung_v1'
+    dataset = bfsnr
+}

--- a/arp_nutzungsplanung_delete_dataset/build.gradle
+++ b/arp_nutzungsplanung_delete_dataset/build.gradle
@@ -1,14 +1,12 @@
-/*
-Löschen eines Dataset über die BFS-Nr. Wird benötig wenn neue Daten bei einer Ortsplanungsrevision von Büros geliefert werden.
-*/
+// Löschen eines Dataset über die BFS-Nr. Wird benötig wenn neue Daten bei einer Ortsplanungsrevision von Büros geliefert werden.
+
 import ch.so.agi.gretl.tasks.*
 import ch.so.agi.gretl.api.TransferSet
-
 
 apply plugin: 'ch.so.agi.gretl'
 apply plugin: 'org.hidetake.ssh'
 
-defaultTasks "exportData_Dataset_BFSNr"
+defaultTasks "delete_Dataset_BFSNr"
 
 task exportData_Dataset_BFSNr(type: Ili2pgExport) {
     description = "Exportiert die zu löschenden Daten mit dem angegebenden Datasetname (BFS-Nr.)aus dem Schema arp_nutzungsplanung_v1 in ein INTERLIS-Datei. Dient zur Sicherung"
@@ -16,7 +14,7 @@ task exportData_Dataset_BFSNr(type: Ili2pgExport) {
     models = 'SO_ARP_Nutzungsplanung_Nachfuehrung_20201005'
     dbschema = 'arp_nutzungsplanung_v1'
     dataset = bfsnr
-    dataFile = "$rootDir/" + ili2pgDataset
+    dataFile = "$rootDir/" + bfsnr + ".xtf"
     disableValidation = true
 }
 

--- a/arp_nutzungsplanung_delete_dataset/job.properties
+++ b/arp_nutzungsplanung_delete_dataset/job.properties
@@ -1,0 +1,3 @@
+logRotator.numToKeep=15
+parameters.stringParam=bfsnr;;BFS-Nr. der Gemeinde von welchen die Nutzungsplanungsdaten im Schema arp_nutzungsplanung_v1 gelöscht werden sollen.
+authorization.permissions=gretl-users-bjsvw

--- a/arp_nutzungsplanung_import/Jenkinsfile
+++ b/arp_nutzungsplanung_import/Jenkinsfile
@@ -38,7 +38,7 @@ pipeline {
                         sh "gretl -Pili2pgDataset=$inputFile.ili2pgDataset transferData"
                         waitUntil {
                             sh "gretl -Pili2pgDataset=$inputFile.ili2pgDataset validateData_Dataset_BFSNr validateData_Dataset_Kanton"
-                            input message: 'Den Datenimport abschliessen oder die Transferdaten nochmals exportieren?', parameters: [booleanParam(name: 'FINISH', defaultValue: false, description: 'Häkchen setzen, um den Datenimport abzuschliessen')]
+                            input message: 'Den Datenimport abschliessen oder die Transferdaten nochmals aus dem Schema arp_nutzungsplanung_transfer exportieren?', parameters: [booleanParam(name: 'FINISH', defaultValue: false, description: 'Häkchen setzen, um den Datenimport abzuschliessen')]
                         }
                         sh "gretl -Pili2pgDataset=$inputFile.ili2pgDataset importData_Dataset_BFSNr importData_Dataset_Kanton"
                     }

--- a/arp_nutzungsplanung_import/Jenkinsfile
+++ b/arp_nutzungsplanung_import/Jenkinsfile
@@ -32,14 +32,16 @@ pipeline {
         stage('Run GRETL-Job') {
             steps {
                 git url: gretlJobRepoUrl, branch: "${params.BRANCH ?: 'master'}", changelog: false
-                dir(env.JOB_BASE_NAME) {
-                    unstash name: 'uploadDir'
-                    sh "gretl -Pili2pgDataset=$inputFile.ili2pgDataset deleteData_import"
-                    waitUntil {
-                        sh "gretl -Pili2pgDataset=$inputFile.ili2pgDataset validateData_Dataset_BFSNr validateData_Dataset_Kanton"
-                        input message: 'Den Datenimport abschliessen oder die Transferdaten nochmals exportieren?', parameters: [booleanParam(name: 'FINISH', defaultValue: false, description: 'Häkchen setzen, um den Datenimport abzuschliessen')]
+                container('gretl') {
+                    dir(env.JOB_BASE_NAME) {
+                        unstash name: 'uploadDir'
+                        sh "gretl -Pili2pgDataset=$inputFile.ili2pgDataset deleteData_import"
+                        waitUntil {
+                            sh "gretl -Pili2pgDataset=$inputFile.ili2pgDataset validateData_Dataset_BFSNr validateData_Dataset_Kanton"
+                            input message: 'Den Datenimport abschliessen oder die Transferdaten nochmals exportieren?', parameters: [booleanParam(name: 'FINISH', defaultValue: false, description: 'Häkchen setzen, um den Datenimport abzuschliessen')]
+                        }
+                        sh "gretl -Pili2pgDataset=$inputFile.ili2pgDataset importXTF_Dataset_BFSNr importXTF_Kanton"
                     }
-                    sh "gretl -Pili2pgDataset=$inputFile.ili2pgDataset importXTF_Dataset_BFSNr importXTF_Kanton"
                 }
             }
         }

--- a/arp_nutzungsplanung_import/Jenkinsfile
+++ b/arp_nutzungsplanung_import/Jenkinsfile
@@ -34,7 +34,12 @@ pipeline {
                 git url: gretlJobRepoUrl, branch: "${params.BRANCH ?: 'master'}", changelog: false
                 dir(env.JOB_BASE_NAME) {
                     unstash name: 'uploadDir'
-                    sh "gretl -Pili2pgDataset=$inputFile.ili2pgDataset"
+                    sh "gretl -Pili2pgDataset=$inputFile.ili2pgDataset deleteData_import"
+                    waitUntil {
+                        sh "gretl -Pili2pgDataset=$inputFile.ili2pgDataset validateData_Dataset_BFSNr validateData_Dataset_Kanton"
+                        input message: 'Den Datenimport abschliessen oder die Transferdaten nochmals exportieren?', parameters: [booleanParam(name: 'FINISH', defaultValue: false, description: 'Häkchen setzen, um den Datenimport abzuschliessen')]
+                    }
+                    sh "gretl -Pili2pgDataset=$inputFile.ili2pgDataset importXTF_Dataset_BFSNr importXTF_Kanton"
                 }
             }
         }

--- a/arp_nutzungsplanung_import/Jenkinsfile
+++ b/arp_nutzungsplanung_import/Jenkinsfile
@@ -1,0 +1,53 @@
+// Start with a scripted pipeline part
+node('master') {
+    stage('Prepare') {
+        gretlJobRepoUrl = env.GRETL_JOB_REPO_URL
+        uploadDirName = 'upload'
+        uploadFileName = 'uploadFile'
+        // By default the uploaded file is stored in the following directory:
+        buildDir = "$JENKINS_HOME/jobs/$JOB_BASE_NAME/builds/$BUILD_NUMBER"
+        // Create a subdirectory for the uploaded file:
+        sh "mkdir $buildDir/$uploadDirName"
+        inputFile = input (
+            message: 'Datei hochladen',
+            parameters: [
+                file(name: "$uploadDirName/$uploadFileName", description: 'Hochzuladende Datei auswählen'),
+                string(name: 'ili2pgDataset', description: 'BFS-Nummer (Dataset) der Daten angeben')
+            ]
+        )
+        dir(buildDir) {
+            stash name: 'uploadDir', includes: "upload/**"
+        }
+        sh "rm -r $buildDir/$uploadDirName"
+    }
+}
+
+// Declarative pipeline starts here
+pipeline {
+    agent { label params.nodeLabel ?: 'gretl' }
+    options {
+        timeout(time: 6, unit: 'HOURS')
+    }
+    stages {
+        stage('Run GRETL-Job') {
+            steps {
+                git url: gretlJobRepoUrl, branch: "${params.BRANCH ?: 'master'}", changelog: false
+                dir(env.JOB_BASE_NAME) {
+                    unstash name: 'uploadDir'
+                    sh "gretl -Pili2pgDataset=$inputFile.ili2pgDataset"
+                }
+            }
+        }
+    }
+    post {
+        unsuccessful {
+            emailext (
+                to: '${DEFAULT_RECIPIENTS}',
+                recipientProviders: [requestor()],
+                subject: "GRETL-Job ${JOB_NAME} (${BUILD_DISPLAY_NAME}) ist fehlgeschlagen",
+                body: "Die Ausführung des GRETL-Jobs ${JOB_NAME} (${BUILD_DISPLAY_NAME}) war nicht erfolgreich. Details dazu finden Sie in den Log-Meldungen unter ${RUN_DISPLAY_URL}."
+            )
+        }
+    }
+}
+

--- a/arp_nutzungsplanung_import/README.md
+++ b/arp_nutzungsplanung_import/README.md
@@ -1,0 +1,44 @@
+## Information zum GRETL-Job "import"
+## Allgemein
+Diese GRETL-Job ist dazu gedacht, INTERLIS-Transferdatei im Datenmodell «SO_Nutzungsplanung_20171118» (Ersterfassungen oder Teilzonenrevisionen) in das Schema «arp_nutzungsplanung» zu importieren.
+Dies braucht es für die Migration aber auch wenn Daten von Planungsbüro kommen für eine ganze Gemeinde. Z.B. Ersterfassung oder Ortsplanungsrevision. 
+Dazu wird ein Schema benötigt «arp_nutzungsplanung_import». Die Daten werden zuerst in das Schema «arp_nutzungsplanung_import» (Datenmodell «SO_Nutzungsplanung_20171118») importiert und dann umgebaut in das Schema «arp_nutzungsplanung_transfer». 
+Dann werden die Daten aus dem Schema «arp_nutzungsplanung_transfer» exportiert. Einmal Dataset= BFS-Nr. und einmal dataset= 'Kanton'.
+Die Daten im Schema «arp_nutzungsplanung_import» und «arp_nutzungsplanung_transfer» werden wieder gelöscht. Das Schema «arp_nutzungsplanung_transfer» wird benötigt, da der Datenumbau mit Basket, tid und Sequenz einfacher ist. 
+In das Schema «arp_nutzungsplanung» und «arp_nutzungsplanung_kanton» werden dadurch immer nur INTERLIS-Transferdatei importiert. Datasetnamen resp. die BFS-Nr. (Parameter) kann angegeben werden. 
+
+Hinweis:
+Schema «arp_nutzungsplanung_kanton» braucht es, weil der Import von INTERLIS-Daten mit dem gleichen Datasetname nur mit Replace möglich ist. Es gibt beim Dataset «Kanton» pro Gemeinde ein INTERLIS-Datei und man möchte die Daten ergänzen (dazutun) und nicht ersetzen. 
+Deshalb ist das Schema «arp_nutzungsplanung_kanton» ohne --createBasketCol --createDatasetCol angelegt.
+
+Für ein Dataset (BFS-Nr.) aus dem Schema "arp_nutzungsplanung" zu löschen gibt es ein eigener Gretljob. Daten aus dem Schema «arp_nutzungsplanung_kanton» müssen manuell gelöscht werden.
+
+## Job Ablauf
+1. XTF-Datei hochladen und Parameter (BFS-Nr.) angeben (dazu braucht es das Jenkinsfile).
+2. Import in Schema «arp_nutzungsplanung_import» (deleteData d.h. die Daten werden vorgängig gelöscht aber Basket Tabelle löscht es nicht, deshalb Schritt 5. nötig)
+2. XTF im upload-Ordner löschen
+3. Schema «arp_nutzungsplanung_transfer» leeren mit SQL-Skript
+4. Daten Umbau mit SQL-Skript
+5. Dataset (BFS-Nr.) löschen aus «arp_nutzungsplanung_import» (löscht auch die Einträge in Tabelle basket)
+6. Export Dataset «BFS-Nr.» und «Kanton» aus Schema «arp_nutzungsplanung_transfer»
+7. Validation der INTERLIS-Dateien «BFS-Nr.» und «Kanton» 
+8. Import ins Schema «arp_nutzungsplanung» und «arp_nutzungsplanung_kanton»
+9. Falls Import eine Fehlermeldung gibt, müssen die Daten im Schema «arp_nutzungsplanung_transfer» manuell korrigiert werden. Ab Schritt 6. wird dann der Job weitergeführt
+10. INTERLIS-Dateien «BFS-Nr.» und «Kanton» 
+
+
+## GRETL
+Lokales arbeiten:
+Parameter:
+```
+export ORG_GRADLE_PROJECT_dbUriEdit=jdbc:postgresql://edit-db/edit
+export ORG_GRADLE_PROJECT_dbUserEdit=gretl
+export ORG_GRADLE_PROJECT_dbPwdEdit=gretl
+export ORG_GRADLE_PROJECT_dbUriPub=jdbc:postgresql://pub-db/pub
+export ORG_GRADLE_PROJECT_dbUserPub=gretl
+export ORG_GRADLE_PROJECT_dbPwdPub=gretl
+```
+nur Lokal ein Ordner "upload" anlegen im Gretljob Verzeichnis. XTF-Datei in das Verzeichnis kopieren mit der Benennung "uploadFile" 
+```
+./start-gretl.sh --docker-image sogis/gretl-runtime:latest --docker-network schema-jobs_default --job-directory $PWD/arp_nutzungsplanung_import -Pili2pgDataset='2457'
+```

--- a/arp_nutzungsplanung_import/README.md
+++ b/arp_nutzungsplanung_import/README.md
@@ -24,7 +24,7 @@ Für ein Dataset (BFS-Nr.) aus dem Schema "arp_nutzungsplanung" zu löschen gibt
 7. Validation der INTERLIS-Dateien «BFS-Nr.» und «Kanton» 
 8. Import ins Schema «arp_nutzungsplanung» und «arp_nutzungsplanung_kanton»
 9. Falls Import eine Fehlermeldung gibt, müssen die Daten im Schema «arp_nutzungsplanung_transfer» manuell korrigiert werden. Ab Schritt 6. wird dann der Job weitergeführt
-10. INTERLIS-Dateien «BFS-Nr.» und «Kanton» 
+10. INTERLIS-Dateien «BFS-Nr.» und «Kanton» löschen
 
 
 ## GRETL

--- a/arp_nutzungsplanung_import/build.gradle
+++ b/arp_nutzungsplanung_import/build.gradle
@@ -30,7 +30,7 @@ task deleteXtfFile_upload(type: Delete, dependsOn: 'importXTF_import'){
     delete "upload/${ili2pgDataset}.xtf"
 }
 
-task deleteData_transfer (type: SqlExecutor, dependsOn: 'deleteXtfFile_upload') {
+task deleteData_transfer(type: SqlExecutor, dependsOn: 'deleteXtfFile_upload') {
     description = "Löscht/leert die Daten aus dem Schema arp_nutzungsplanung_transfer."
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     sqlFiles = ["delete_arp_nutzungsplanung_transfer.sql"]
@@ -42,7 +42,7 @@ task transferData(type: SqlExecutor, dependsOn: 'deleteData_transfer') {
     sqlFiles = ["insert_arp_nutzungsplanung_transfer.sql"]
 }
 
-task deleteData_import (type: Ili2pgDelete, dependsOn: 'transferData') {
+task deleteData_import(type: Ili2pgDelete, dependsOn: 'transferData') {
     description = "Löscht/leert Daten mit dem angegebenen Datasetname (BFS-Nr.) aus dem Schema arp_nutzungsplanung_import_v1"
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     models = 'SO_ARP_Nutzungsplanung_Nachfuehrung_20201005'
@@ -91,7 +91,7 @@ task exportData_Dataset_Kanton(type: Ili2pgExport) {
     disableValidation = true
 }
 
-task validateData_Dataset_Kanton (type: IliValidator, dependsOn: 'exportData_Dataset_Kanton') {
+task validateData_Dataset_Kanton(type: IliValidator, dependsOn: 'exportData_Dataset_Kanton') {
     description = "Validiert die exportierten INTERLIS-Datei gegen das Modell."
     dataFiles = file(ili2pgDataset + "_Kanton.xtf")
     failOnError = true

--- a/arp_nutzungsplanung_import/build.gradle
+++ b/arp_nutzungsplanung_import/build.gradle
@@ -8,8 +8,6 @@ import ch.so.agi.gretl.api.TransferSet
 
 apply plugin: 'ch.so.agi.gretl'
 
-defaultTasks "importXTF_Dataset_BFSNr", "importXTF_Kanton"
-
 task copyXtfFile(type: Copy) {
     from "upload/"
     into "upload/"
@@ -52,7 +50,7 @@ task deleteData_import (type: Ili2pgDelete, dependsOn: 'transferData') {
     dataset = ili2pgDataset
 }
 
-task exportData_Dataset_BFSNr(type: Ili2pgExport, dependsOn: 'deleteData_import') {
+task exportData_Dataset_BFSNr(type: Ili2pgExport) {
     description = "Exportiert die umgebauten Daten mit DataSet= BFSNr aus dem Schema arp_nutzungsplanung_transfer in ein INTERLIS-Datei."
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     dbschema = 'arp_nutzungsplanung_transfer_v1'
@@ -72,7 +70,7 @@ task deleteXtfFile_BFSNr(type: Delete){
     delete file(ili2pgDataset + ".xtf")
 }
 
-task importXTF_Dataset_BFSNr(type: Ili2pgImport, dependsOn: 'validateData_Dataset_BFSNr') {
+task importXTF_Dataset_BFSNr(type: Ili2pgImport) {
     description = 'Import der umgebaute INTERLIS-Datei in das Schema arp_nutzungsplanung mit Dataset=BFS-Nr. Im Schema arp_nutzungsplanung werden die Daten nachgeführt.'
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     dbschema = 'arp_nutzungsplanung_v1'
@@ -83,7 +81,7 @@ task importXTF_Dataset_BFSNr(type: Ili2pgImport, dependsOn: 'validateData_Datase
     finalizedBy deleteXtfFile_BFSNr
 }
 
-task exportData_Dataset_Kanton(type: Ili2pgExport, dependsOn: 'deleteData_import') {
+task exportData_Dataset_Kanton(type: Ili2pgExport) {
     description = "Exportiert die umgebauten Daten mit DataSet=Kanton aus dem Schema arp_nutzungsplanung_transfer in ein INTERLIS-Datei."
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     dbschema = 'arp_nutzungsplanung_transfer_v1'
@@ -103,7 +101,7 @@ task deleteXtfFile_Kanton(type: Delete){
     delete file(ili2pgDataset + "_Kanton.xtf")
 }
 
-task importXTF_Kanton(type: Ili2pgImport, dependsOn: 'validateData_Dataset_Kanton') {
+task importXTF_Kanton(type: Ili2pgImport) {
     description = 'Import der umgebaute INTERLIS-Datei in das Schema arp_nutzungsplanung mit Dataset=Kanton. Im Schema arp_nutzungsplanung werden die Daten nachgeführt.'
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     dbschema = 'arp_nutzungsplanung_kanton_v1'

--- a/arp_nutzungsplanung_import/build.gradle
+++ b/arp_nutzungsplanung_import/build.gradle
@@ -64,7 +64,7 @@ task exportData_Dataset_BFSNr(type: Ili2pgExport) {
 task validateData_Dataset_BFSNr(type: IliValidator, dependsOn: 'exportData_Dataset_BFSNr') {
     description = "Validiert die exportierten INTERLIS-Datei gegen das Modell."
     dataFiles = file(ili2pgDataset + ".xtf")
-    failOnError = true
+    failOnError = false
 }
 
 task deleteXtfFile_BFSNr(type: Delete){
@@ -95,7 +95,7 @@ task exportData_Dataset_Kanton(type: Ili2pgExport) {
 task validateData_Dataset_Kanton(type: IliValidator, dependsOn: 'exportData_Dataset_Kanton') {
     description = "Validiert die exportierten INTERLIS-Datei gegen das Modell."
     dataFiles = file(ili2pgDataset + "_Kanton.xtf")
-    failOnError = true
+    failOnError = false
 }
 
 task deleteXtfFile_Kanton(type: Delete){

--- a/arp_nutzungsplanung_import/build.gradle
+++ b/arp_nutzungsplanung_import/build.gradle
@@ -1,0 +1,114 @@
+
+// Import Daten der Nutzungsplanung pro Gemeinde (dataset=BFS-Nr.) in das Schema "arp_nutzungsplanung_import" und macht ein Datenumbau in die Struktur des Nachführungsmodells (Schema "arp_nutzungsplanung_transfer"). 
+// Das resultierende XTF wird ins Schema "arp_nutzungsplanung" importiert. 
+
+import ch.so.agi.gretl.tasks.*
+import ch.so.agi.gretl.api.TransferSet
+
+
+apply plugin: 'ch.so.agi.gretl'
+
+defaultTasks "importXTF_Dataset_BFSNr", "importXTF_Kanton"
+
+task copyXtfFile(type: Copy) {
+    from "upload/"
+    into "upload/"
+    include("uploadFile")
+    rename("uploadFile", "${ili2pgDataset}.xtf")
+}
+
+task importXTF_import(type: Ili2pgReplace, dependsOn: 'copyXtfFile') {
+    description = 'Import das XTF (Herkunft von Planungsbüros) einer Gemeinde in das Schema "arp_nutzungsplanung_import". Immer nur eine Gemeinde ist in diesem Schema "_import" vorhanden. Bei jedem Import wird das Schema wieder geleert '
+    database = [dbUriEdit, dbUserEdit, dbPwdEdit]
+    dbschema = 'arp_nutzungsplanung_import_v1'
+    models = 'SO_Nutzungsplanung_20171118'
+    deleteData= true
+    dataset = ili2pgDataset
+    dataFile = "upload/${ili2pgDataset}.xtf"
+    disableValidation = true
+}
+
+task deleteXtfFile_upload(type: Delete, dependsOn: 'importXTF_import'){
+    delete "upload/${ili2pgDataset}.xtf"
+}
+
+task deleteData_transfer (type: SqlExecutor, dependsOn: 'deleteXtfFile_upload') {
+    description = "Löscht/leert die Daten aus dem Schema arp_nutzungsplanung_transfer."
+    database = [dbUriEdit, dbUserEdit, dbPwdEdit]
+    sqlFiles = ["delete_arp_nutzungsplanung_transfer.sql"]
+}
+
+task transferData(type: SqlExecutor, dependsOn: 'deleteData_transfer') {
+    description = "Führt den Datenumbau in das Schema arp_nutzungsplanung_transfer durch. Das braucht es, damit ein XFT ins Schema arp_nutzungsplanung importiert werden kann"
+    database = [dbUriEdit, dbUserEdit, dbPwdEdit]
+    sqlFiles = ["insert_arp_nutzungsplanung_transfer.sql"]
+}
+
+task deleteData_import (type: Ili2pgDelete, dependsOn: 'transferData') {
+    description = "Löscht/leert Daten mit dem angegebenen Datasetname (BFS-Nr.) aus dem Schema arp_nutzungsplanung_import_v1"
+    database = [dbUriEdit, dbUserEdit, dbPwdEdit]
+    models = 'SO_ARP_Nutzungsplanung_Nachfuehrung_20201005'
+    dbschema = 'arp_nutzungsplanung_import_v1'
+    dataset = ili2pgDataset
+}
+
+task exportData_Dataset_BFSNr(type: Ili2pgExport, dependsOn: 'deleteData_import') {
+    description = "Exportiert die umgebauten Daten mit DataSet= BFSNr aus dem Schema arp_nutzungsplanung_transfer in ein INTERLIS-Datei."
+    database = [dbUriEdit, dbUserEdit, dbPwdEdit]
+    dbschema = 'arp_nutzungsplanung_transfer_v1'
+    models = 'SO_ARP_Nutzungsplanung_Nachfuehrung_20201005'
+    dataset = ili2pgDataset
+    dataFile= file(ili2pgDataset + ".xtf")
+    disableValidation = true
+}
+
+task validateData_Dataset_BFSNr(type: IliValidator, dependsOn: 'exportData_Dataset_BFSNr') {
+    description = "Validiert die exportierten INTERLIS-Datei gegen das Modell."
+    dataFiles = file(ili2pgDataset + ".xtf")
+    failOnError = true
+}
+
+task deleteXtfFile_BFSNr(type: Delete){
+    delete file(ili2pgDataset + ".xtf")
+}
+
+task importXTF_Dataset_BFSNr(type: Ili2pgImport, dependsOn: 'validateData_Dataset_BFSNr') {
+    description = 'Import der umgebaute INTERLIS-Datei in das Schema arp_nutzungsplanung mit Dataset=BFS-Nr. Im Schema arp_nutzungsplanung werden die Daten nachgeführt.'
+    database = [dbUriEdit, dbUserEdit, dbPwdEdit]
+    dbschema = 'arp_nutzungsplanung_v1'
+    models = 'SO_ARP_Nutzungsplanung_Nachfuehrung_20201005'
+    dataset = ili2pgDataset
+    dataFile = file(ili2pgDataset + ".xtf")
+    disableValidation = true
+    finalizedBy deleteXtfFile_BFSNr
+}
+
+task exportData_Dataset_Kanton(type: Ili2pgExport, dependsOn: 'deleteData_import') {
+    description = "Exportiert die umgebauten Daten mit DataSet=Kanton aus dem Schema arp_nutzungsplanung_transfer in ein INTERLIS-Datei."
+    database = [dbUriEdit, dbUserEdit, dbPwdEdit]
+    dbschema = 'arp_nutzungsplanung_transfer_v1'
+    models = 'SO_ARP_Nutzungsplanung_Nachfuehrung_20201005'
+    dataset = 'Kanton'
+    dataFile = file(ili2pgDataset + "_Kanton.xtf")
+    disableValidation = true
+}
+
+task validateData_Dataset_Kanton (type: IliValidator, dependsOn: 'exportData_Dataset_Kanton') {
+    description = "Validiert die exportierten INTERLIS-Datei gegen das Modell."
+    dataFiles = file(ili2pgDataset + "_Kanton.xtf")
+    failOnError = true
+}
+
+task deleteXtfFile_Kanton(type: Delete){
+    delete file(ili2pgDataset + "_Kanton.xtf")
+}
+
+task importXTF_Kanton(type: Ili2pgImport, dependsOn: 'validateData_Dataset_Kanton') {
+    description = 'Import der umgebaute INTERLIS-Datei in das Schema arp_nutzungsplanung mit Dataset=Kanton. Im Schema arp_nutzungsplanung werden die Daten nachgeführt.'
+    database = [dbUriEdit, dbUserEdit, dbPwdEdit]
+    dbschema = 'arp_nutzungsplanung_kanton_v1'
+    models = 'SO_ARP_Nutzungsplanung_Nachfuehrung_20201005'
+    dataFile = file(ili2pgDataset + "_Kanton.xtf")
+    disableValidation = true
+    finalizedBy deleteXtfFile_Kanton
+}

--- a/arp_nutzungsplanung_import/delete_arp_nutzungsplanung_transfer.sql
+++ b/arp_nutzungsplanung_import/delete_arp_nutzungsplanung_transfer.sql
@@ -1,0 +1,91 @@
+-- Grundnutzung
+DELETE FROM
+    arp_nutzungsplanung_transfer_v1.nutzungsplanung_typ_grundnutzung_dokument
+;
+DELETE FROM
+    arp_nutzungsplanung_transfer_v1.nutzungsplanung_grundnutzung
+;
+DELETE FROM
+    arp_nutzungsplanung_transfer_v1.nutzungsplanung_typ_grundnutzung
+;
+--überlagernde Fläche
+DELETE FROM
+    arp_nutzungsplanung_transfer_v1.nutzungsplanung_typ_ueberlagernd_flaeche_dokument
+;
+DELETE FROM
+    arp_nutzungsplanung_transfer_v1.nutzungsplanung_ueberlagernd_flaeche
+;
+DELETE FROM
+    arp_nutzungsplanung_transfer_v1.nutzungsplanung_typ_ueberlagernd_flaeche
+;
+--überlagernde Linie
+DELETE FROM
+    arp_nutzungsplanung_transfer_v1.nutzungsplanung_typ_ueberlagernd_linie_dokument
+;
+DELETE FROM
+    arp_nutzungsplanung_transfer_v1.nutzungsplanung_ueberlagernd_linie
+;
+DELETE FROM
+    arp_nutzungsplanung_transfer_v1.nutzungsplanung_typ_ueberlagernd_linie
+;
+--überlagernde Punkt
+DELETE FROM
+    arp_nutzungsplanung_transfer_v1.nutzungsplanung_typ_ueberlagernd_punkt_dokument
+;
+DELETE FROM
+    arp_nutzungsplanung_transfer_v1.nutzungsplanung_ueberlagernd_punkt
+;
+DELETE FROM
+    arp_nutzungsplanung_transfer_v1.nutzungsplanung_typ_ueberlagernd_punkt
+;
+--Erschliessung Fläche
+DELETE FROM
+    arp_nutzungsplanung_transfer_v1.erschlssngsplnung_typ_erschliessung_flaechenobjekt_dokument
+;
+DELETE FROM
+    arp_nutzungsplanung_transfer_v1.erschlssngsplnung_erschliessung_flaechenobjekt
+;
+DELETE FROM
+    arp_nutzungsplanung_transfer_v1.erschlssngsplnung_typ_erschliessung_flaechenobjekt
+;
+--Erschliessung Linie
+DELETE FROM
+    arp_nutzungsplanung_transfer_v1.erschlssngsplnung_typ_erschliessung_linienobjekt_dokument
+;
+DELETE FROM
+    arp_nutzungsplanung_transfer_v1.erschlssngsplnung_erschliessung_linienobjekt
+;
+DELETE FROM
+    arp_nutzungsplanung_transfer_v1.erschlssngsplnung_typ_erschliessung_linienobjekt
+;
+--Erschliessung Punkt
+DELETE FROM
+    arp_nutzungsplanung_transfer_v1.erschlssngsplnung_typ_erschliessung_punktobjekt_dokument
+;
+DELETE FROM
+    arp_nutzungsplanung_transfer_v1.erschlssngsplnung_erschliessung_punktobjekt
+;
+DELETE FROM
+    arp_nutzungsplanung_transfer_v1.erschlssngsplnung_typ_erschliessung_punktobjekt
+;
+-- Lärmempfindlichkeitsstufen
+DELETE FROM
+    arp_nutzungsplanung_transfer_v1.laermmpfhktsstfen_typ_empfindlichkeitsstufe_dokument
+;
+DELETE FROM
+    arp_nutzungsplanung_transfer_v1.laermmpfhktsstfen_empfindlichkeitsstufe
+;
+DELETE FROM
+    arp_nutzungsplanung_transfer_v1.laermmpfhktsstfen_typ_empfindlichkeitsstufe
+;
+-- Dokument
+DELETE FROM
+    arp_nutzungsplanung_transfer_v1.rechtsvorschrften_dokument
+;
+-- Basket / Dataset 
+DELETE FROM
+    arp_nutzungsplanung_transfer_v1.t_ili2db_basket
+;
+DELETE FROM
+    arp_nutzungsplanung_transfer_v1.t_ili2db_dataset
+;

--- a/arp_nutzungsplanung_import/insert_arp_nutzungsplanung_transfer.sql
+++ b/arp_nutzungsplanung_import/insert_arp_nutzungsplanung_transfer.sql
@@ -1,0 +1,2190 @@
+-- Datenumbau von Modell SO_Nutzungsplanung_20171118 ins Modell SO_ARP_Nutzungsplanung_Nachfuehrung_20201005
+-- Datenumbau erfolgt pro XTF
+
+-- dataset
+INSERT INTO arp_nutzungsplanung_transfer_v1.t_ili2db_dataset
+SELECT
+    t_id,
+    datasetname
+FROM
+    arp_nutzungsplanung_import_v1.t_ili2db_dataset
+;
+
+-- neues Dataset "Kanton" einfügen
+INSERT INTO arp_nutzungsplanung_transfer_v1.t_ili2db_dataset
+SELECT
+    nextval('arp_nutzungsplanung_import_v1.t_ili2db_seq'::regclass) AS t_id,
+    'Kanton' AS datasetname
+;
+
+-- basket
+INSERT INTO arp_nutzungsplanung_transfer_v1.t_ili2db_basket
+SELECT
+    basket.t_id,
+    basket.dataset,
+    replace (basket.topic, 'SO_Nutzungsplanung_20171118', 'SO_ARP_Nutzungsplanung_Nachfuehrung_20201005')AS topic,
+    basket.t_ili_tid,
+    basket.attachmentkey,
+    basket.domains
+FROM
+    arp_nutzungsplanung_import_v1.t_ili2db_basket AS basket
+WHERE basket.topic != 'SO_Nutzungsplanung_20171118.TransferMetadaten'
+        AND
+      basket.topic != 'SO_Nutzungsplanung_20171118.Verfahrenstand'
+;
+-- neue Topic SO_ARP_Nutzungsplanung_Nachfuehrung_20201005.Laermempfindlichkeitsstufen einfügen in basket
+INSERT INTO arp_nutzungsplanung_transfer_v1.t_ili2db_basket
+SELECT
+    nextval('arp_nutzungsplanung_import_v1.t_ili2db_seq'::regclass) AS t_id,
+    basket.dataset,
+   'SO_ARP_Nutzungsplanung_Nachfuehrung_20201005.Laermempfindlichkeitsstufen' AS topic,
+    NULL AS t_ili_tid,
+    'Datenumbau neues Topic Laermempfindlichkeitsstufen' attachmentkey,
+    NULL AS domains
+FROM
+    arp_nutzungsplanung_import_v1.t_ili2db_basket AS basket
+WHERE
+    topic= 'SO_Nutzungsplanung_20171118.Nutzungsplanung'
+;
+
+-- neue Baket für dataset "Kanton". Topic Nutzungsplanung.
+INSERT INTO arp_nutzungsplanung_transfer_v1.t_ili2db_basket
+SELECT
+    nextval('arp_nutzungsplanung_import_v1.t_ili2db_seq'::regclass) AS t_id,
+    (SELECT
+        t_id
+    FROM
+        arp_nutzungsplanung_transfer_v1.t_ili2db_dataset
+    WHERE
+        datasetname='Kanton') AS dataset,
+    'SO_ARP_Nutzungsplanung_Nachfuehrung_20201005.Nutzungsplanung' AS topic,
+    Null AS t_ili_tid,
+    'Nachfuehrung_Kanton' AS attachmentkey,
+    Null AS domains
+;
+
+-- neue Baket für dataset "Kanton". Topic Erschliessungsplanung.
+INSERT INTO arp_nutzungsplanung_transfer_v1.t_ili2db_basket
+SELECT
+    nextval('arp_nutzungsplanung_import_v1.t_ili2db_seq'::regclass) AS t_id,
+    (SELECT
+        t_id
+    FROM
+        arp_nutzungsplanung_transfer_v1.t_ili2db_dataset
+    WHERE
+        datasetname='Kanton') AS dataset,
+    'SO_ARP_Nutzungsplanung_Nachfuehrung_20201005.Erschliessungsplanung' AS topic,
+    Null AS t_ili_tid,
+    'Nachfuehrung_Kanton' AS attachmentkey,
+    Null AS domains
+;
+
+-- neue Baket für dataset "Kanton". Topic Rechtsvorschriften.
+INSERT INTO arp_nutzungsplanung_transfer_v1.t_ili2db_basket
+SELECT
+    nextval('arp_nutzungsplanung_import_v1.t_ili2db_seq'::regclass) AS t_id,
+    (SELECT
+        t_id
+    FROM
+        arp_nutzungsplanung_transfer_v1.t_ili2db_dataset
+    WHERE
+        datasetname='Kanton') AS dataset,
+    'SO_ARP_Nutzungsplanung_Nachfuehrung_20201005.Rechtsvorschriften' AS topic,
+    Null AS t_ili_tid,
+    'Nachfuehrung_Kanton' AS attachmentkey,
+    Null AS domains
+;
+
+--Dokumente
+INSERT INTO arp_nutzungsplanung_transfer_v1.rechtsvorschrften_dokument
+SELECT
+    t_id,
+    t_basket,
+    t_datasetname,
+    t_ili_tid,
+    dokumentid,
+    titel,
+    offiziellertitel,
+    abkuerzung,
+    offiziellenr,
+    kanton,
+    gemeinde,
+    publiziertab,
+    CASE rechtsstatus
+        WHEN 'laufendeAenderung'
+            THEN 'AenderungMitVorwirkung'
+        ELSE 'inKraft'
+    END AS rechtsstatus,
+    'https://geo.so.ch/docs/ch.so.arp.zonenplaene/Zonenplaene_pdf/' || textimweb AS textimweb,
+    bemerkungen,
+    rechtsvorschrift
+FROM
+    arp_nutzungsplanung_import_v1.rechtsvorschrften_dokument
+;
+
+-- Grundnutzung
+INSERT INTO arp_nutzungsplanung_transfer_v1.nutzungsplanung_typ_grundnutzung
+SELECT
+    t_id,
+    t_basket,
+    t_datasetname,
+    t_ili_tid,
+    typ_kt,
+    code_kommunal,
+    nutzungsziffer,
+    nutzungsziffer_art,
+    geschosszahl,
+    bezeichnung,
+    abkuerzung,
+    'Nutzungsplanfestlegung' ASverbindlichkeit,
+    bemerkungen
+FROM
+    arp_nutzungsplanung_import_v1.nutzungsplanung_typ_grundnutzung
+;
+
+INSERT INTO arp_nutzungsplanung_transfer_v1.nutzungsplanung_grundnutzung
+SELECT
+    t_id,
+    t_basket,
+    t_datasetname,
+    t_ili_tid,
+    geometrie,
+    name_nummer AS geschaefts_nummer,
+    CASE rechtsstatus
+        WHEN 'laufendeAenderung'
+            THEN 'AenderungMitVorwirkung'
+        ELSE 'inKraft'
+    END AS rechtsstatus,
+    publiziertab,
+    bemerkungen,
+    erfasser,
+    datum,
+    NULL AS publiziertbis,
+    typ_grundnutzung
+FROM
+    arp_nutzungsplanung_import_v1.nutzungsplanung_grundnutzung
+;
+
+/*
+ * Auflösung Verknüpfung Dokument zu Dokument
+ * Es werden von der Zwischentabelle nur diejenigen Verknüpfungen kopiert,
+ * deren Typ tatsächlich auch im Zielschema bei den Typen vorhanden ist.
+ * Das hilft zwar bei Typen, die zum Kantons-Basket gehören würden und
+ * so nicht fälschlicherweise der Gemeinde zugewiesen werden. Es führt
+ * aber dazu, dass eventuell Dokumente kopiert wurden, die dann mit nix
+ * verküpft sind.
+ *
+ */
+
+INSERT INTO 
+    arp_nutzungsplanung_transfer_v1.nutzungsplanung_typ_grundnutzung_dokument 
+(
+    t_id,
+    t_basket,
+    t_datasetname,
+    typ_grundnutzung,
+    dokument
+)
+
+SELECT 
+    t_id,
+    t_basket,
+    t_datasetname,
+    typ_grundnutzung,
+    dokument
+FROM 
+    arp_nutzungsplanung_import_v1.nutzungsplanung_typ_grundnutzung_dokument AS typ_grundnutzung_dokument 
+WHERE 
+    typ_grundnutzung IN 
+    (
+        SELECT  
+            t_id 
+        FROM 
+            arp_nutzungsplanung_transfer_v1.nutzungsplanung_typ_grundnutzung 
+    )
+;    
+    
+WITH RECURSIVE x(ursprung, hinweis, parents, last_ursprung, depth) AS 
+(
+    SELECT 
+        ursprung, 
+        hinweis, 
+        ARRAY[ursprung] AS parents, 
+        ursprung AS last_ursprung, 
+        0 AS "depth" 
+    FROM 
+        arp_nutzungsplanung_import_v1.rechtsvorschrften_hinweisweiteredokumente
+    WHERE
+        ursprung != hinweis
+    -- Hier könnte zusätzlich nach Basket gefilter werden.
+    -- Dann müssen aber die bereits kopierten Dokumente
+    -- korrekt zugewiesen sein, was momentan nicht ist.
+
+    UNION ALL
+  
+    SELECT 
+        x.ursprung, 
+        x.hinweis, 
+        parents||t1.hinweis, 
+        t1.hinweis AS last_ursprung, 
+        x."depth" + 1
+    FROM 
+        x 
+        INNER JOIN arp_nutzungsplanung_import_v1.rechtsvorschrften_hinweisweiteredokumente t1 
+        ON (last_ursprung = t1.ursprung)
+    WHERE 
+        t1.hinweis IS NOT NULL
+    -- Dito. Siehe oben.
+)
+,
+zusaetzliche_dokumente AS 
+(
+    SELECT 
+        DISTINCT ON (x.last_ursprung, x.ursprung)
+        x.ursprung AS top_level_dokument,
+        x.last_ursprung AS t_id
+    FROM 
+        x
+)
+INSERT INTO 
+    arp_nutzungsplanung_transfer_v1.nutzungsplanung_typ_grundnutzung_dokument 
+    (
+        t_basket,
+        t_datasetname,
+        typ_grundnutzung,
+        dokument 
+    )
+    SELECT 
+        DISTINCT 
+        typ_grundnutzung_dokument.t_basket,
+        typ_grundnutzung_dokument.t_datasetname,
+        typ_grundnutzung_dokument.typ_grundnutzung,
+        zusaetzliche_dokumente.t_id AS vorschrift_vorschriften_dokument
+    FROM 
+        zusaetzliche_dokumente
+        LEFT JOIN arp_nutzungsplanung_transfer_v1.nutzungsplanung_typ_grundnutzung_dokument AS typ_grundnutzung_dokument
+        ON typ_grundnutzung_dokument.dokument = zusaetzliche_dokumente.top_level_dokument
+    WHERE
+        NOT EXISTS 
+        (
+            SELECT 
+                typ_grundnutzung,
+                dokument
+            FROM 
+                arp_nutzungsplanung_transfer_v1.nutzungsplanung_typ_grundnutzung_dokument
+            WHERE 
+                typ_grundnutzung = nutzungsplanung_typ_grundnutzung_dokument.typ_grundnutzung 
+                AND
+                dokument = zusaetzliche_dokumente.t_id
+        )
+        AND
+        typ_grundnutzung_dokument.typ_grundnutzung IS NOT NULL
+;
+
+--überlagernde Fläche
+INSERT INTO arp_nutzungsplanung_transfer_v1.nutzungsplanung_typ_ueberlagernd_flaeche
+SELECT
+    t_id,
+-- Für Nachführungseinheit "Kanton" gibt es einen eigenen Basket
+    CASE typ_kt
+        WHEN 'N526_kantonale_Landwirtschafts_und_Schutzzone_Witi'
+            THEN
+                (SELECT
+                    t_id
+                FROM
+                    arp_nutzungsplanung_transfer_v1.t_ili2db_basket
+                WHERE
+                    topic ='SO_ARP_Nutzungsplanung_Nachfuehrung_20201005.Nutzungsplanung'
+                    AND
+                    attachmentkey = 'Nachfuehrung_Kanton')
+        WHEN 'N610_Perimeter_kantonaler_Nutzungsplan'
+            THEN
+                (SELECT
+                    t_id
+                FROM
+                    arp_nutzungsplanung_transfer_v1.t_ili2db_basket
+                WHERE
+                    topic ='SO_ARP_Nutzungsplanung_Nachfuehrung_20201005.Nutzungsplanung'
+                    AND
+                    attachmentkey = 'Nachfuehrung_Kanton')
+          ELSE t_basket
+    END AS t_basket,
+-- Für Nachführungseinheit "Kanton" gibt es einen eigenes Dataset
+    CASE typ_kt
+        WHEN 'N526_kantonale_Landwirtschafts_und_Schutzzone_Witi'
+            THEN 'Kanton'
+        WHEN 'N610_Perimeter_kantonaler_Nutzungsplan'
+            THEN 'Kanton'
+          ELSE t_datasetname
+    END AS t_datasetname,
+    t_ili_tid,
+    typ_kt,
+    code_kommunal,
+    bezeichnung,
+    abkuerzung,
+    verbindlichkeit,
+    bemerkungen
+FROM
+    arp_nutzungsplanung_import_v1.nutzungsplanung_typ_ueberlagernd_flaeche
+WHERE
+    typ_kt!= 'N520_BLN_Gebiet'
+    AND
+    typ_kt!= 'N521_Juraschutzzone'
+    AND
+    typ_kt!= 'N522_Naturreservat_inkl_Geotope'
+    AND
+    typ_kt!= 'N524_Siedlungstrennguertel_von_kommunaler_Bedeutung'
+    AND
+    typ_kt!= 'N525_Siedlungstrennguertel_von_kantonaler_Bedeutung'
+    AND
+    typ_kt!= 'N527_kantonale_Uferschutzzone'
+    AND
+    typ_kt!= 'N530_Naturgefahren_erhebliche_Gefaehrdung'
+    AND
+    typ_kt!= 'N531_Naturgefahren_mittlere_Gefaehrdung'
+    AND
+    typ_kt!= 'N532_Naturgefahren_geringe_Gefaehrdung'
+    AND
+    typ_kt!= 'N533_Naturgefahren_Restgefaehrdung'
+    AND
+    typ_kt!= 'N593_Grundwasserschutzzone_S1'
+    AND
+    typ_kt!= 'N594_Grundwasserschutzzone_S2'
+    AND
+    typ_kt!= 'N595_Grundwasserschutzzone_S3'
+    AND
+    typ_kt!= 'N596_Grundwasserschutzareal'
+    AND
+    typ_kt!= 'N680_Empfindlichkeitsstufe_I'
+    AND
+    typ_kt!= 'N681_Empfindlichkeitsstufe_II'
+    AND
+    typ_kt!= 'N682_Empfindlichkeitsstufe_II_aufgestuft'
+    AND
+    typ_kt!= 'N683_Empfindlichkeitsstufe_III'
+    AND
+    typ_kt!= 'N684_Empfindlichkeitsstufe_III_aufgestuft'
+    AND
+    typ_kt!= 'N685_Empfindlichkeitsstufe_IV'
+    AND
+    typ_kt!= 'N686_keine_Empfindlichkeitsstufe'
+    AND
+    typ_kt!= 'N690_kantonales_Vorranggebiet_Natur_und_Landschaft'
+    AND
+    typ_kt!= 'N812_geologisches_Objekt'
+    AND
+    typ_kt!= 'N820_kantonal_geschuetztes_Kulturobjekt'
+;
+
+INSERT INTO arp_nutzungsplanung_transfer_v1.nutzungsplanung_ueberlagernd_flaeche
+
+SELECT
+    ueberlagernd_flaeche.t_id,
+    -- Für Nachführungseinheit "Kanton" gibt es einen eigenen Basket
+    CASE typ_kt
+        WHEN 'N526_kantonale_Landwirtschafts_und_Schutzzone_Witi'
+            THEN
+                (SELECT
+                    t_id
+                FROM
+                    arp_nutzungsplanung_transfer_v1.t_ili2db_basket
+                WHERE
+                    topic ='SO_ARP_Nutzungsplanung_Nachfuehrung_20201005.Nutzungsplanung'
+                    AND
+                    attachmentkey = 'Nachfuehrung_Kanton')
+        WHEN 'N610_Perimeter_kantonaler_Nutzungsplan'
+            THEN
+                (SELECT
+                    t_id
+                FROM
+                    arp_nutzungsplanung_transfer_v1.t_ili2db_basket
+                WHERE
+                    topic ='SO_ARP_Nutzungsplanung_Nachfuehrung_20201005.Nutzungsplanung'
+                    AND
+                    attachmentkey = 'Nachfuehrung_Kanton')
+          ELSE ueberlagernd_flaeche.t_basket
+    END AS t_basket,
+-- Für Nachführungseinheit "Kanton" gibt es einen eigenes Dataset
+    CASE typ_kt
+        WHEN 'N526_kantonale_Landwirtschafts_und_Schutzzone_Witi'
+            THEN 'Kanton'
+        WHEN 'N610_Perimeter_kantonaler_Nutzungsplan'
+            THEN 'Kanton'
+        ELSE ueberlagernd_flaeche.t_datasetname
+    END AS t_datasetname,
+    ueberlagernd_flaeche.t_ili_tid,
+    ueberlagernd_flaeche.geometrie,
+    ueberlagernd_flaeche.name_nummer AS geschaefts_nummer,
+    CASE ueberlagernd_flaeche.rechtsstatus
+        WHEN 'laufendeAenderung'
+            THEN 'AenderungMitVorwirkung'
+        ELSE 'inKraft'
+    END AS rechtsstatus,
+    ueberlagernd_flaeche.publiziertab,
+    ueberlagernd_flaeche.bemerkungen,
+    ueberlagernd_flaeche.erfasser,
+    ueberlagernd_flaeche.datum,
+    NULL AS publiziertbis,
+    ueberlagernd_flaeche.typ_ueberlagernd_flaeche
+FROM
+    arp_nutzungsplanung_import_v1.nutzungsplanung_ueberlagernd_flaeche AS ueberlagernd_flaeche
+    LEFT JOIN arp_nutzungsplanung_import_v1.nutzungsplanung_typ_ueberlagernd_flaeche AS typ
+    ON typ.t_id = ueberlagernd_flaeche.typ_ueberlagernd_flaeche
+WHERE
+    typ.typ_kt!= 'N520_BLN_Gebiet'
+    AND
+    typ_kt!= 'N521_Juraschutzzone'
+    AND
+    typ.typ_kt!= 'N522_Naturreservat_inkl_Geotope'
+    AND
+    typ.typ_kt!= 'N524_Siedlungstrennguertel_von_kommunaler_Bedeutung'
+    AND
+    typ.typ_kt!= 'N525_Siedlungstrenngu el_von_kantonaler_Bedeutung'
+    AND
+    typ.typ_kt!= 'N527_kantonale_Uferschutzzone'
+    AND
+    typ.typ_kt!= 'N530_Naturgefahren_erhebliche_Gefaehrdung'
+    AND
+    typ.typ_kt!= 'N531_Naturgefahren_mittlere_Gefaehrdung'
+    AND
+    typ.typ_kt!= 'N532_Naturgefahren_geringe_Gefaehrdung'
+    AND
+    typ.typ_kt!= 'N533_Naturgefahren_Restgefaehrdung'
+    AND
+    typ.typ_kt!= 'N593_Grundwasserschutzzone_S1'
+    AND
+    typ.typ_kt!= 'N594_Grundwasserschutzzone_S2'
+    AND
+    typ.typ_kt!= 'N595_Grundwasserschutzzone_S3'
+    AND
+    typ.typ_kt!= 'N596_Grundwasserschutzareal'
+    AND
+    typ.typ_kt!= 'N680_Empfindlichkeitsstufe_I'
+    AND
+    typ.typ_kt!= 'N681_Empfindlichkeitsstufe_II'
+    AND
+    typ.typ_kt!= 'N682_Empfindlichkeitsstufe_II_aufgestuft'
+    AND
+    typ.typ_kt!= 'N683_Empfindlichkeitsstufe_III'
+    AND
+    typ.typ_kt!= 'N684_Empfindlichkeitsstufe_III_aufgestuft'
+    AND
+    typ.typ_kt!= 'N685_Empfindlichkeitsstufe_IV'
+    AND
+    typ.typ_kt!= 'N686_keine_Empfindlichkeitsstufe'
+    AND
+    typ.typ_kt!= 'N690_kantonales_Vorranggebiet_Natur_und_Landschaft'
+    AND
+    typ.typ_kt!= 'N812_geologisches_Objekt'
+    AND
+    typ.typ_kt!= 'N820_kantonal_geschuetztes_Kulturobjekt'
+;
+
+/*
+ * Beziehung Dokument übberlagernde Fläche. Auflösung Verknüpfung Dokument zu Dokument
+ * Es werden von der Zwischentabelle nur diejenigen Verknüpfungen kopiert,
+ * deren Typ tatsächlich auch im Zielschema bei den Typen vorhanden ist.
+ * Das hilft zwar bei Typen, die zum Kantons-Basket gehören würden und
+ * so nicht fälschlicherweise der Gemeinde zugewiesen werden. Es führt
+ * aber dazu, dass eventuell Dokumente kopiert wurden, die dann mit nix
+ * verküpft sind.
+ *
+ */
+ 
+INSERT INTO 
+    arp_nutzungsplanung_transfer_v1.nutzungsplanung_typ_ueberlagernd_flaeche_dokument 
+(
+    t_id,
+    t_basket,
+    t_datasetname,
+    typ_ueberlagernd_flaeche,
+    dokument
+)
+SELECT
+    typ_ueberlagernd_flaeche_dokument.t_id,
+    -- Für Nachführungseinheit "Kanton" gibt es einen eigenen Basket
+    CASE typ.typ_kt
+        WHEN 'N526_kantonale_Landwirtschafts_und_Schutzzone_Witi'
+            THEN
+                (SELECT
+                    t_id
+                FROM
+                    arp_nutzungsplanung_transfer_v1.t_ili2db_basket
+                WHERE  
+                    topic ='SO_ARP_Nutzungsplanung_Nachfuehrung_20201005.Nutzungsplanung'
+                    AND
+                    attachmentkey = 'Nachfuehrung_Kanton')
+        WHEN 'N610_Perimeter_kantonaler_Nutzungsplan'
+            THEN
+                (SELECT
+                    t_id
+                FROM
+                    arp_nutzungsplanung_transfer_v1.t_ili2db_basket
+                WHERE
+                    topic ='SO_ARP_Nutzungsplanung_Nachfuehrung_20201005.Nutzungsplanung'
+                    AND
+                    attachmentkey = 'Nachfuehrung_Kanton')
+        ELSE typ_ueberlagernd_flaeche_dokument.t_basket
+    END AS t_basket,
+-- Für Nachführungseinheit "Kanton" gibt es einen eigenes Dataset
+    CASE typ_kt
+        WHEN 'N526_kantonale_Landwirtschafts_und_Schutzzone_Witi'
+            THEN 'Kanton'
+        WHEN 'N610_Perimeter_kantonaler_Nutzungsplan'
+            THEN 'Kanton'
+        ELSE typ_ueberlagernd_flaeche_dokument.t_datasetname
+    END AS t_datasetname,
+    typ_ueberlagernd_flaeche_dokument.typ_ueberlagernd_flaeche,
+    typ_ueberlagernd_flaeche_dokument.dokument
+FROM
+    arp_nutzungsplanung_import_v1.nutzungsplanung_typ_ueberlagernd_flaeche_dokument AS typ_ueberlagernd_flaeche_dokument
+    LEFT JOIN arp_nutzungsplanung_import_v1.nutzungsplanung_typ_ueberlagernd_flaeche AS typ
+    ON typ.t_id = typ_ueberlagernd_flaeche_dokument.typ_ueberlagernd_flaeche
+
+WHERE 
+    typ_ueberlagernd_flaeche IN 
+    (
+        SELECT  
+            t_id 
+        FROM 
+            arp_nutzungsplanung_transfer_v1.nutzungsplanung_typ_ueberlagernd_flaeche
+    )
+;    
+    
+WITH RECURSIVE x(ursprung, hinweis, parents, last_ursprung, depth) AS 
+(
+    SELECT 
+        ursprung, 
+        hinweis, 
+        ARRAY[ursprung] AS parents, 
+        ursprung AS last_ursprung, 
+        0 AS "depth" 
+    FROM 
+        arp_nutzungsplanung_import_v1.rechtsvorschrften_hinweisweiteredokumente
+    WHERE
+        ursprung != hinweis
+    -- Hier könnte zusätzlich nach Basket gefilter werden.
+    -- Dann müssen aber die bereits kopierten Dokumente
+    -- korrekt zugewiesen sein, was momentan nicht ist.
+
+    UNION ALL
+  
+    SELECT 
+        x.ursprung, 
+        x.hinweis, 
+        parents||t1.hinweis, 
+        t1.hinweis AS last_ursprung, 
+        x."depth" + 1
+    FROM 
+        x 
+        INNER JOIN arp_nutzungsplanung_import_v1.rechtsvorschrften_hinweisweiteredokumente t1 
+        ON (last_ursprung = t1.ursprung)
+    WHERE 
+        t1.hinweis IS NOT NULL
+    -- Dito. Siehe oben.
+)
+,
+zusaetzliche_dokumente AS 
+(
+    SELECT 
+        DISTINCT ON (x.last_ursprung, x.ursprung)
+        x.ursprung AS top_level_dokument,
+        x.last_ursprung AS t_id
+    FROM 
+        x
+)
+INSERT INTO 
+    arp_nutzungsplanung_transfer_v1.nutzungsplanung_typ_ueberlagernd_flaeche_dokument 
+    (
+        t_basket,
+        t_datasetname,
+        typ_ueberlagernd_flaeche,
+        dokument 
+    )
+    SELECT 
+        DISTINCT 
+        typ_ueberlagernd_flaeche_dokument.t_basket,
+        typ_ueberlagernd_flaeche_dokument.t_datasetname,
+        typ_ueberlagernd_flaeche_dokument.typ_ueberlagernd_flaeche,
+        zusaetzliche_dokumente.t_id AS vorschrift_vorschriften_dokument
+    FROM 
+        zusaetzliche_dokumente
+        LEFT JOIN arp_nutzungsplanung_transfer_v1.nutzungsplanung_typ_ueberlagernd_flaeche_dokument AS typ_ueberlagernd_flaeche_dokument
+        ON typ_ueberlagernd_flaeche_dokument.dokument = zusaetzliche_dokumente.top_level_dokument
+    WHERE
+        NOT EXISTS 
+        (
+            SELECT 
+                typ_ueberlagernd_flaeche,
+                dokument
+            FROM 
+                arp_nutzungsplanung_transfer_v1.nutzungsplanung_typ_ueberlagernd_flaeche_dokument
+            WHERE 
+                typ_ueberlagernd_flaeche = nutzungsplanung_typ_ueberlagernd_flaeche_dokument.typ_ueberlagernd_flaeche 
+                AND
+                dokument = zusaetzliche_dokumente.t_id
+        )
+        AND
+        typ_ueberlagernd_flaeche_dokument.typ_ueberlagernd_flaeche IS NOT NULL
+;
+
+--überlagernde Linie
+INSERT INTO arp_nutzungsplanung_transfer_v1.nutzungsplanung_typ_ueberlagernd_linie
+SELECT
+    t_id,
+    t_basket,
+    t_datasetname,
+    t_ili_tid,
+    typ_kt,
+    code_kommunal,
+    bezeichnung,
+    abkuerzung,
+    verbindlichkeit,
+    bemerkungen
+FROM
+    arp_nutzungsplanung_import_v1.nutzungsplanung_typ_ueberlagernd_linie
+WHERE
+    typ_kt = 'N799_weitere_linienbezogene_Festlegungen_NP'
+;
+
+INSERT INTO arp_nutzungsplanung_transfer_v1.nutzungsplanung_ueberlagernd_linie
+
+SELECT
+    ueberlagernd_linie.t_id,
+    ueberlagernd_linie.t_basket,
+    ueberlagernd_linie.t_datasetname,
+    ueberlagernd_linie.t_ili_tid,
+    ueberlagernd_linie.geometrie,
+    ueberlagernd_linie.name_nummer AS geschaefts_nummer,
+    CASE ueberlagernd_linie.rechtsstatus
+        WHEN 'laufendeAenderung'
+            THEN 'AenderungMitVorwirkung'
+        ELSE 'inKraft'
+    END AS rechtsstatus,
+    ueberlagernd_linie.publiziertab,
+    ueberlagernd_linie.bemerkungen,
+    ueberlagernd_linie.erfasser,
+    ueberlagernd_linie.datum,
+    NULL AS publiziertbis,
+    ueberlagernd_linie.typ_ueberlagernd_linie
+FROM
+    arp_nutzungsplanung_import_v1.nutzungsplanung_ueberlagernd_linie AS ueberlagernd_linie
+    LEFT JOIN arp_nutzungsplanung_import_v1.nutzungsplanung_typ_ueberlagernd_linie AS typ
+    ON typ.t_id = ueberlagernd_linie.typ_ueberlagernd_linie
+WHERE
+    typ.typ_kt = 'N799_weitere_linienbezogene_Festlegungen_NP'
+;
+
+/*
+ * Beziehung Dokument überlagernde Linie. Auflösung Verknüpfung Dokument zu Dokument
+ * Es werden von der Zwischentabelle nur diejenigen Verknüpfungen kopiert,
+ * deren Typ tatsächlich auch im Zielschema bei den Typen vorhanden ist.
+ * Das hilft zwar bei Typen, die zum Kantons-Basket gehören würden und
+ * so nicht fälschlicherweise der Gemeinde zugewiesen werden. Es führt
+ * aber dazu, dass eventuell Dokumente kopiert wurden, die dann mit nix
+ * verküpft sind.
+ *
+ */
+ 
+INSERT INTO 
+    arp_nutzungsplanung_transfer_v1.nutzungsplanung_typ_ueberlagernd_linie_dokument 
+(
+    t_id,
+    t_basket,
+    t_datasetname,
+    typ_ueberlagernd_linie,
+    dokument
+)
+SELECT
+    ueberlagernd_linie_dokument.t_id,
+    ueberlagernd_linie_dokument.t_basket,
+    ueberlagernd_linie_dokument.t_datasetname,
+    ueberlagernd_linie_dokument.typ_ueberlagernd_linie,
+    ueberlagernd_linie_dokument.dokument
+FROM
+    arp_nutzungsplanung_import_v1.nutzungsplanung_typ_ueberlagernd_linie_dokument AS ueberlagernd_linie_dokument
+    LEFT JOIN arp_nutzungsplanung_import_v1.nutzungsplanung_typ_ueberlagernd_linie AS typ
+    ON typ.t_id = ueberlagernd_linie_dokument.typ_ueberlagernd_linie
+WHERE 
+    typ_ueberlagernd_linie IN 
+    (
+        SELECT  
+            t_id 
+        FROM 
+            arp_nutzungsplanung_transfer_v1.nutzungsplanung_typ_ueberlagernd_linie
+    )
+;    
+    
+WITH RECURSIVE x(ursprung, hinweis, parents, last_ursprung, depth) AS 
+(
+    SELECT 
+        ursprung, 
+        hinweis, 
+        ARRAY[ursprung] AS parents, 
+        ursprung AS last_ursprung, 
+        0 AS "depth" 
+    FROM 
+        arp_nutzungsplanung_import_v1.rechtsvorschrften_hinweisweiteredokumente
+    WHERE
+        ursprung != hinweis
+    -- Hier könnte zusätzlich nach Basket gefilter werden.
+    -- Dann müssen aber die bereits kopierten Dokumente
+    -- korrekt zugewiesen sein, was momentan nicht ist.
+
+    UNION ALL
+  
+    SELECT 
+        x.ursprung, 
+        x.hinweis, 
+        parents||t1.hinweis, 
+        t1.hinweis AS last_ursprung, 
+        x."depth" + 1
+    FROM 
+        x 
+        INNER JOIN arp_nutzungsplanung_import_v1.rechtsvorschrften_hinweisweiteredokumente t1 
+        ON (last_ursprung = t1.ursprung)
+    WHERE 
+        t1.hinweis IS NOT NULL
+    -- Dito. Siehe oben.
+)
+,
+zusaetzliche_dokumente AS 
+(
+    SELECT 
+        DISTINCT ON (x.last_ursprung, x.ursprung)
+        x.ursprung AS top_level_dokument,
+        x.last_ursprung AS t_id
+    FROM 
+        x
+)
+INSERT INTO 
+    arp_nutzungsplanung_transfer_v1.nutzungsplanung_typ_ueberlagernd_linie_dokument 
+    (
+        t_basket,
+        t_datasetname,
+        typ_ueberlagernd_linie,
+        dokument 
+    )
+    SELECT 
+        DISTINCT 
+        typ_ueberlagernd_linie_dokument.t_basket,
+        typ_ueberlagernd_linie_dokument.t_datasetname,
+        typ_ueberlagernd_linie_dokument.typ_ueberlagernd_linie,
+        zusaetzliche_dokumente.t_id AS vorschrift_vorschriften_dokument
+    FROM 
+        zusaetzliche_dokumente
+        LEFT JOIN arp_nutzungsplanung_transfer_v1.nutzungsplanung_typ_ueberlagernd_linie_dokument AS typ_ueberlagernd_linie_dokument
+        ON typ_ueberlagernd_linie_dokument.dokument = zusaetzliche_dokumente.top_level_dokument
+    WHERE
+        NOT EXISTS 
+        (
+            SELECT 
+                typ_ueberlagernd_linie,
+                dokument
+            FROM 
+                arp_nutzungsplanung_transfer_v1.nutzungsplanung_typ_ueberlagernd_linie_dokument
+            WHERE 
+                typ_ueberlagernd_linie = nutzungsplanung_typ_ueberlagernd_linie_dokument.typ_ueberlagernd_linie 
+                AND
+                dokument = zusaetzliche_dokumente.t_id
+        )
+        AND
+        typ_ueberlagernd_linie_dokument.typ_ueberlagernd_linie IS NOT NULL
+;
+
+--überlagernde Punkt
+INSERT INTO arp_nutzungsplanung_transfer_v1.nutzungsplanung_typ_ueberlagernd_punkt
+SELECT
+    t_id,
+    t_basket,
+    t_datasetname,
+    t_ili_tid,
+    typ_kt,
+    code_kommunal,
+    bezeichnung,
+    abkuerzung,
+    verbindlichkeit,
+    bemerkungen
+FROM
+    arp_nutzungsplanung_import_v1.nutzungsplanung_typ_ueberlagernd_punkt
+WHERE
+    typ_kt!= 'N812_geologisches_Objekt'
+    AND
+    typ_kt!= 'N820_kantonal_geschuetztes_Kulturobjekt'
+;
+
+INSERT INTO arp_nutzungsplanung_transfer_v1.nutzungsplanung_ueberlagernd_punkt
+
+SELECT
+    ueberlagernd_punkt.t_id,
+    ueberlagernd_punkt.t_basket,
+    ueberlagernd_punkt.t_datasetname,
+    ueberlagernd_punkt.t_ili_tid,
+    ueberlagernd_punkt.geometrie,
+    ueberlagernd_punkt.name_nummer AS geschaefts_nummer,
+    CASE ueberlagernd_punkt.rechtsstatus
+        WHEN 'laufendeAenderung'
+            THEN 'AenderungMitVorwirkung'
+        ELSE 'inKraft'
+    END AS rechtsstatus,
+    ueberlagernd_punkt.publiziertab,
+    ueberlagernd_punkt.bemerkungen,
+    ueberlagernd_punkt.erfasser,
+    ueberlagernd_punkt.datum,
+    NULL AS publiziertbis,
+    ueberlagernd_punkt.typ_ueberlagernd_punkt
+FROM
+    arp_nutzungsplanung_import_v1.nutzungsplanung_ueberlagernd_punkt AS ueberlagernd_punkt
+    LEFT JOIN arp_nutzungsplanung_import_v1.nutzungsplanung_typ_ueberlagernd_punkt AS typ
+    ON typ.t_id = ueberlagernd_punkt.typ_ueberlagernd_punkt
+WHERE
+    typ.typ_kt!= 'N812_geologisches_Objekt'
+    AND
+    typ.typ_kt!= 'N820_kantonal_geschuetztes_Kulturobjekt'
+;
+
+/*
+ * Beziehung Dokument überlagernde Punkt. Auflösung Verknüpfung Dokument zu Dokument
+ * Es werden von der Zwischentabelle nur diejenigen Verknüpfungen kopiert,
+ * deren Typ tatsächlich auch im Zielschema bei den Typen vorhanden ist.
+ * Das hilft zwar bei Typen, die zum Kantons-Basket gehören würden und
+ * so nicht fälschlicherweise der Gemeinde zugewiesen werden. Es führt
+ * aber dazu, dass eventuell Dokumente kopiert wurden, die dann mit nix
+ * verküpft sind.
+ *
+ */
+ 
+INSERT INTO 
+    arp_nutzungsplanung_transfer_v1.nutzungsplanung_typ_ueberlagernd_punkt_dokument 
+(
+    t_id,
+    t_basket,
+    t_datasetname,
+    typ_ueberlagernd_punkt,
+    dokument
+)
+SELECT
+    ueberlagernd_punkt_dokument.t_id,
+    ueberlagernd_punkt_dokument.t_basket,
+    ueberlagernd_punkt_dokument.t_datasetname,
+    ueberlagernd_punkt_dokument.typ_ueberlagernd_punkt,
+    ueberlagernd_punkt_dokument.dokument
+FROM
+    arp_nutzungsplanung_import_v1.nutzungsplanung_typ_ueberlagernd_punkt_dokument AS ueberlagernd_punkt_dokument
+    LEFT JOIN arp_nutzungsplanung_import_v1.nutzungsplanung_typ_ueberlagernd_punkt AS typ
+    ON typ.t_id = ueberlagernd_punkt_dokument.typ_ueberlagernd_punkt
+WHERE 
+    typ_ueberlagernd_punkt IN 
+    (
+        SELECT  
+            t_id 
+        FROM 
+            arp_nutzungsplanung_transfer_v1.nutzungsplanung_typ_ueberlagernd_punkt
+    )
+;    
+    
+WITH RECURSIVE x(ursprung, hinweis, parents, last_ursprung, depth) AS 
+(
+    SELECT 
+        ursprung, 
+        hinweis, 
+        ARRAY[ursprung] AS parents, 
+        ursprung AS last_ursprung, 
+        0 AS "depth" 
+    FROM 
+        arp_nutzungsplanung_import_v1.rechtsvorschrften_hinweisweiteredokumente
+    WHERE
+        ursprung != hinweis
+    -- Hier könnte zusätzlich nach Basket gefilter werden.
+    -- Dann müssen aber die bereits kopierten Dokumente
+    -- korrekt zugewiesen sein, was momentan nicht ist.
+
+    UNION ALL
+  
+    SELECT 
+        x.ursprung, 
+        x.hinweis, 
+        parents||t1.hinweis, 
+        t1.hinweis AS last_ursprung, 
+        x."depth" + 1
+    FROM 
+        x 
+        INNER JOIN arp_nutzungsplanung_import_v1.rechtsvorschrften_hinweisweiteredokumente t1 
+        ON (last_ursprung = t1.ursprung)
+    WHERE 
+        t1.hinweis IS NOT NULL
+    -- Dito. Siehe oben.
+)
+,
+zusaetzliche_dokumente AS 
+(
+    SELECT 
+        DISTINCT ON (x.last_ursprung, x.ursprung)
+        x.ursprung AS top_level_dokument,
+        x.last_ursprung AS t_id
+    FROM 
+        x
+)
+INSERT INTO 
+    arp_nutzungsplanung_transfer_v1.nutzungsplanung_typ_ueberlagernd_punkt_dokument 
+    (
+        t_basket,
+        t_datasetname,
+        typ_ueberlagernd_punkt,
+        dokument 
+    )
+    SELECT 
+        DISTINCT 
+        typ_ueberlagernd_punkt_dokument.t_basket,
+        typ_ueberlagernd_punkt_dokument.t_datasetname,
+        typ_ueberlagernd_punkt_dokument.typ_ueberlagernd_punkt,
+        zusaetzliche_dokumente.t_id AS vorschrift_vorschriften_dokument
+    FROM 
+        zusaetzliche_dokumente
+        LEFT JOIN arp_nutzungsplanung_transfer_v1.nutzungsplanung_typ_ueberlagernd_punkt_dokument AS typ_ueberlagernd_punkt_dokument
+        ON typ_ueberlagernd_punkt_dokument.dokument = zusaetzliche_dokumente.top_level_dokument
+    WHERE
+        NOT EXISTS 
+        (
+            SELECT 
+                typ_ueberlagernd_punkt,
+                dokument
+            FROM 
+                arp_nutzungsplanung_transfer_v1.nutzungsplanung_typ_ueberlagernd_punkt_dokument
+            WHERE 
+                typ_ueberlagernd_punkt = nutzungsplanung_typ_ueberlagernd_punkt_dokument.typ_ueberlagernd_punkt 
+                AND
+                dokument = zusaetzliche_dokumente.t_id
+        )
+        AND
+        typ_ueberlagernd_punkt_dokument.typ_ueberlagernd_punkt IS NOT NULL
+;
+
+-- Erschliessung Fläche
+INSERT INTO arp_nutzungsplanung_transfer_v1.erschlssngsplnung_typ_erschliessung_flaechenobjekt
+SELECT
+    t_id,
+-- Für Nachführungseinheit "Kanton" gibt es einen eigenen Basket
+    CASE typ_kt
+        WHEN 'E560_Nationalstrasse'
+            THEN
+                (SELECT
+                    t_id
+                FROM
+                    arp_nutzungsplanung_transfer_v1.t_ili2db_basket
+                WHERE
+                    topic ='SO_ARP_Nutzungsplanung_Nachfuehrung_20201005.Erschliessungsplanung'
+                    AND
+                    attachmentkey = 'Nachfuehrung_Kanton')
+        WHEN 'E561_Kantonsstrasse'
+            THEN
+                (SELECT
+                    t_id
+                FROM
+                    arp_nutzungsplanung_transfer_v1.t_ili2db_basket
+                WHERE 
+                    topic ='SO_ARP_Nutzungsplanung_Nachfuehrung_20201005.Erschliessungsplanung'
+                    AND
+                    attachmentkey = 'Nachfuehrung_Kanton')
+        ELSE t_basket
+    END AS t_basket,
+-- Für Nachführungseinheit "Kanton" gibt es einen eigenes Dataset
+    CASE typ_kt
+        WHEN 'E560_Nationalstrasse'
+            THEN 'Kanton'
+        WHEN 'E561_Kantonsstrasse'
+            THEN 'Kanton'
+        ELSE t_datasetname
+    END AS t_datasetname,
+    t_ili_tid,
+    typ_kt,
+    code_kommunal,
+    bezeichnung,
+    abkuerzung,
+    verbindlichkeit,
+    bemerkungen
+FROM
+    arp_nutzungsplanung_import_v1.erschlssngsplnung_typ_erschliessung_flaechenobjekt
+;
+
+INSERT INTO arp_nutzungsplanung_transfer_v1.erschlssngsplnung_erschliessung_flaechenobjekt
+SELECT
+    erschliessung_flaechenobjekt.t_id,
+-- Für Nachführungseinheit "Kanton" gibt es einen eigenen Basket
+    CASE typ.typ_kt
+        WHEN 'E560_Nationalstrasse'
+            THEN
+                (SELECT
+                    t_id
+                FROM
+                     arp_nutzungsplanung_transfer_v1.t_ili2db_basket
+                WHERE  
+                    topic ='SO_ARP_Nutzungsplanung_Nachfuehrung_20201005.Erschliessungsplanung'
+                    AND
+                    attachmentkey = 'Nachfuehrung_Kanton')
+        WHEN 'E561_Kantonsstrasse'
+            THEN
+                (SELECT
+                    t_id
+                FROM
+                    arp_nutzungsplanung_transfer_v1.t_ili2db_basket
+                WHERE 
+                    topic ='SO_ARP_Nutzungsplanung_Nachfuehrung_20201005.Erschliessungsplanung'
+                    AND
+                    attachmentkey = 'Nachfuehrung_Kanton')
+        ELSE erschliessung_flaechenobjekt.t_basket
+    END AS t_basket,
+-- Für Nachführungseinheit "Kanton" gibt es einen eigenes Dataset
+    CASE typ_kt
+        WHEN 'E560_Nationalstrasse'
+            THEN 'Kanton'
+        WHEN 'E561_Kantonsstrasse'
+            THEN 'Kanton'
+        ELSE erschliessung_flaechenobjekt.t_datasetname
+    END AS t_datasetname,
+    erschliessung_flaechenobjekt.t_ili_tid,
+    erschliessung_flaechenobjekt.geometrie,
+    erschliessung_flaechenobjekt.name_nummer AS geschaefts_nummer,
+    CASE rechtsstatus
+        WHEN 'laufendeAenderung'
+            THEN 'AenderungMitVorwirkung'
+        ELSE 'inKraft'
+    END AS rechtsstatus,
+    erschliessung_flaechenobjekt.publiziertab,
+    erschliessung_flaechenobjekt.bemerkungen,
+    erschliessung_flaechenobjekt.erfasser,
+    erschliessung_flaechenobjekt.datum,
+    NULL AS publiziertbis,
+    erschliessung_flaechenobjekt.typ_erschliessung_flaechenobjekt
+FROM
+    arp_nutzungsplanung_import_v1.erschlssngsplnung_erschliessung_flaechenobjekt AS erschliessung_flaechenobjekt
+    LEFT JOIN arp_nutzungsplanung_import_v1.erschlssngsplnung_typ_erschliessung_flaechenobjekt AS typ
+    ON typ.t_id = erschliessung_flaechenobjekt.typ_erschliessung_flaechenobjekt
+;
+
+/*
+ * Beziehung Dokument Erschliessung Flächenobjekte. Auflösung Verknüpfung Dokument zu Dokument
+ * Es werden von der Zwischentabelle nur diejenigen Verknüpfungen kopiert,
+ * deren Typ tatsächlich auch im Zielschema bei den Typen vorhanden ist.
+ * Das hilft zwar bei Typen, die zum Kantons-Basket gehören würden und
+ * so nicht fälschlicherweise der Gemeinde zugewiesen werden. Es führt
+ * aber dazu, dass eventuell Dokumente kopiert wurden, die dann mit nix
+ * verküpft sind.
+ *
+ */
+ 
+INSERT INTO 
+    arp_nutzungsplanung_transfer_v1.erschlssngsplnung_typ_erschliessung_flaechenobjekt_dokument 
+(
+    t_id,
+    t_basket,
+    t_datasetname,
+    typ_erschliessung_flaechenobjekt,
+    dokument
+)
+SELECT
+    erschliessung_flaechenobjekt_dokument.t_id,
+-- Für Nachführungseinheit "Kanton" gibt es einen eigenen Basket
+    CASE typ.typ_kt
+        WHEN 'E560_Nationalstrasse'
+            THEN
+               (SELECT
+                    t_id
+                FROM
+                    arp_nutzungsplanung_transfer_v1.t_ili2db_basket
+                WHERE  
+                    topic ='SO_ARP_Nutzungsplanung_Nachfuehrung_20201005.Erschliessungsplanung'
+                    AND
+                    attachmentkey = 'Nachfuehrung_Kanton')
+        WHEN 'E561_Kantonsstrasse'
+            THEN
+                (SELECT
+                    t_id
+                FROM
+                    arp_nutzungsplanung_transfer_v1.t_ili2db_basket
+                WHERE 
+                    topic ='SO_ARP_Nutzungsplanung_Nachfuehrung_20201005.Erschliessungsplanung'
+                    AND
+                    attachmentkey = 'Nachfuehrung_Kanton')
+        ELSE erschliessung_flaechenobjekt_dokument.t_basket
+    END AS t_basket,
+-- Für Nachführungseinheit "Kanton" gibt es einen eigenes Dataset
+    CASE typ_kt
+        WHEN 'E560_Nationalstrasse'
+            THEN 'Kanton'
+        WHEN 'E561_Kantonsstrasse'
+            THEN 'Kanton'
+        ELSE erschliessung_flaechenobjekt_dokument.t_datasetname
+    END AS t_datasetname,
+    erschliessung_flaechenobjekt_dokument.typ_erschliessung_flaechenobjekt,
+    erschliessung_flaechenobjekt_dokument.dokument
+FROM
+    arp_nutzungsplanung_import_v1.erschlssngsplnung_typ_erschliessung_flaechenobjekt_dokument AS erschliessung_flaechenobjekt_dokument
+    LEFT JOIN arp_nutzungsplanung_import_v1.erschlssngsplnung_typ_erschliessung_flaechenobjekt AS typ
+    ON typ.t_id = erschliessung_flaechenobjekt_dokument.typ_erschliessung_flaechenobjekt
+WHERE 
+    typ_erschliessung_flaechenobjekt IN 
+    (
+        SELECT  
+            t_id 
+        FROM 
+            arp_nutzungsplanung_transfer_v1.erschlssngsplnung_typ_erschliessung_flaechenobjekt
+    )
+;    
+    
+WITH RECURSIVE x(ursprung, hinweis, parents, last_ursprung, depth) AS 
+(
+    SELECT 
+        ursprung, 
+        hinweis, 
+        ARRAY[ursprung] AS parents, 
+        ursprung AS last_ursprung, 
+        0 AS "depth" 
+    FROM 
+        arp_nutzungsplanung_import_v1.rechtsvorschrften_hinweisweiteredokumente
+    WHERE
+        ursprung != hinweis
+    -- Hier könnte zusätzlich nach Basket gefilter werden.
+    -- Dann müssen aber die bereits kopierten Dokumente
+    -- korrekt zugewiesen sein, was momentan nicht ist.
+
+    UNION ALL
+  
+    SELECT 
+        x.ursprung, 
+        x.hinweis, 
+        parents||t1.hinweis, 
+        t1.hinweis AS last_ursprung, 
+        x."depth" + 1
+    FROM 
+        x 
+        INNER JOIN arp_nutzungsplanung_import_v1.rechtsvorschrften_hinweisweiteredokumente t1 
+        ON (last_ursprung = t1.ursprung)
+    WHERE 
+        t1.hinweis IS NOT NULL
+    -- Dito. Siehe oben.
+)
+,
+zusaetzliche_dokumente AS 
+(
+    SELECT 
+        DISTINCT ON (x.last_ursprung, x.ursprung)
+        x.ursprung AS top_level_dokument,
+        x.last_ursprung AS t_id
+    FROM 
+        x
+)
+INSERT INTO 
+    arp_nutzungsplanung_transfer_v1.erschlssngsplnung_typ_erschliessung_flaechenobjekt_dokument 
+    (
+        t_basket,
+        t_datasetname,
+        typ_erschliessung_flaechenobjekt,
+        dokument 
+    )
+    SELECT 
+        DISTINCT 
+        typ_erschliessung_flaechenobjekt_dokument.t_basket,
+        typ_erschliessung_flaechenobjekt_dokument.t_datasetname,
+        typ_erschliessung_flaechenobjekt_dokument.typ_erschliessung_flaechenobjekt,
+        zusaetzliche_dokumente.t_id AS vorschrift_vorschriften_dokument
+    FROM 
+        zusaetzliche_dokumente
+        LEFT JOIN arp_nutzungsplanung_transfer_v1.erschlssngsplnung_typ_erschliessung_flaechenobjekt_dokument AS typ_erschliessung_flaechenobjekt_dokument
+        ON typ_erschliessung_flaechenobjekt_dokument.dokument = zusaetzliche_dokumente.top_level_dokument
+    WHERE
+        NOT EXISTS 
+        (
+            SELECT 
+                typ_erschliessung_flaechenobjekt,
+                dokument
+            FROM 
+                arp_nutzungsplanung_transfer_v1.erschlssngsplnung_typ_erschliessung_flaechenobjekt_dokument
+            WHERE 
+                typ_erschliessung_flaechenobjekt = erschlssngsplnung_typ_erschliessung_flaechenobjekt_dokument.typ_erschliessung_flaechenobjekt 
+                AND
+                dokument = zusaetzliche_dokumente.t_id
+        )
+        AND
+        typ_erschliessung_flaechenobjekt_dokument.typ_erschliessung_flaechenobjekt IS NOT NULL
+;
+
+-- Erschliessung Linie
+INSERT INTO arp_nutzungsplanung_transfer_v1.erschlssngsplnung_typ_erschliessung_linienobjekt
+SELECT
+    t_id,
+    -- Für Nachführungseinheit "Kanton" gibt es einen eigenen Basket
+    CASE typ_kt
+        WHEN 'E711_Baulinie_Strasse_kantonal'
+            THEN
+                (SELECT
+                    t_id
+                FROM
+                    arp_nutzungsplanung_transfer_v1.t_ili2db_basket
+                WHERE 
+                    topic ='SO_ARP_Nutzungsplanung_Nachfuehrung_20201005.Erschliessungsplanung'
+                    AND
+                    attachmentkey = 'Nachfuehrung_Kanton')
+        WHEN 'E712_Vorbaulinie_kantonal'
+            THEN
+                (SELECT
+                    t_id
+                FROM
+                    arp_nutzungsplanung_transfer_v1.t_ili2db_basket
+                WHERE 
+                    topic ='SO_ARP_Nutzungsplanung_Nachfuehrung_20201005.Erschliessungsplanung'
+                    AND
+                    attachmentkey = 'Nachfuehrung_Kanton')
+        WHEN 'E713_Gestaltungsbaulinie_kantonal'
+            THEN
+                (SELECT
+                    t_id
+                FROM
+                    arp_nutzungsplanung_transfer_v1.t_ili2db_basket
+                WHERE 
+                    topic ='SO_ARP_Nutzungsplanung_Nachfuehrung_20201005.Erschliessungsplanung'
+                    AND
+                    attachmentkey = 'Nachfuehrung_Kanton')
+        WHEN 'E714_Rueckwaertige_Baulinie_kantonal'
+            THEN
+                (SELECT
+                    t_id
+                FROM
+                    arp_nutzungsplanung_transfer_v1.t_ili2db_basket
+                WHERE 
+                    topic ='SO_ARP_Nutzungsplanung_Nachfuehrung_20201005.Erschliessungsplanung'
+                    AND
+                    attachmentkey = 'Nachfuehrung_Kanton')
+        WHEN 'E715_Baulinie_Infrastruktur_kantonal'
+            THEN
+                (SELECT
+                    t_id
+                FROM
+                    arp_nutzungsplanung_transfer_v1.t_ili2db_basket
+                WHERE 
+                    topic ='SO_ARP_Nutzungsplanung_Nachfuehrung_20201005.Erschliessungsplanung'
+                    AND
+                    attachmentkey = 'Nachfuehrung_Kanton')
+        WHEN 'E719_weitere_nationale_und_kantonale_Baulinien'
+            THEN
+                (SELECT
+                    t_id
+                FROM
+                    arp_nutzungsplanung_transfer_v1.t_ili2db_basket
+                WHERE 
+                    topic ='SO_ARP_Nutzungsplanung_Nachfuehrung_20201005.Erschliessungsplanung'
+                    AND
+                    attachmentkey = 'Nachfuehrung_Kanton')
+        ELSE t_basket
+    END AS t_basket,
+-- Für Nachführungseinheit "Kanton" gibt es einen eigenes Dataset
+    CASE typ_kt
+        WHEN 'E711_Baulinie_Strasse_kantonal'
+            THEN 'Kanton'
+        WHEN 'E712_Vorbaulinie_kantonal'
+            THEN 'Kanton'
+        WHEN 'E713_Gestaltungsbaulinie_kantonal'
+            THEN 'Kanton'
+        WHEN 'E714_Rueckwaertige_Baulinie_kantonal'
+            THEN 'Kanton'
+        WHEN 'E715_Baulinie_Infrastruktur_kantonal'
+            THEN 'Kanton'
+        WHEN 'E719_weitere_nationale_und_kantonale_Baulinien'
+            THEN 'Kanton'
+        ELSE t_datasetname
+    END AS t_datasetname,
+    t_ili_tid,
+    typ_kt,
+    code_kommunal,
+    bezeichnung,
+    abkuerzung,
+    verbindlichkeit,
+    bemerkungen
+FROM
+    arp_nutzungsplanung_import_v1.erschlssngsplnung_typ_erschliessung_linienobjekt
+WHERE
+    typ_kt != 'E710_nationale_Baulinie'
+;
+
+INSERT INTO arp_nutzungsplanung_transfer_v1.erschlssngsplnung_erschliessung_linienobjekt
+SELECT
+    erschliessung_linienobjekt.t_id,
+  -- Für Nachführungseinheit "Kanton" gibt es einen eigenen Basket
+    CASE typ.typ_kt
+        WHEN 'E711_Baulinie_Strasse_kantonal'
+            THEN
+                (SELECT
+                    t_id
+                FROM
+                    arp_nutzungsplanung_transfer_v1.t_ili2db_basket
+                WHERE
+                    topic ='SO_ARP_Nutzungsplanung_Nachfuehrung_20201005.Erschliessungsplanung'
+                    AND
+                    attachmentkey = 'Nachfuehrung_Kanton')
+        WHEN 'E712_Vorbaulinie_kantonal'
+            THEN
+                (SELECT
+                    t_id
+                FROM
+                    arp_nutzungsplanung_transfer_v1.t_ili2db_basket
+                WHERE 
+                    topic ='SO_ARP_Nutzungsplanung_Nachfuehrung_20201005.Erschliessungsplanung'
+                    AND
+                    attachmentkey = 'Nachfuehrung_Kanton')
+        WHEN 'E713_Gestaltungsbaulinie_kantonal'
+            THEN
+                (SELECT
+                    t_id
+                FROM
+                    arp_nutzungsplanung_transfer_v1.t_ili2db_basket
+                WHERE 
+                    topic ='SO_ARP_Nutzungsplanung_Nachfuehrung_20201005.Erschliessungsplanung'
+                    AND
+                    attachmentkey = 'Nachfuehrung_Kanton')
+        WHEN 'E714_Rueckwaertige_Baulinie_kantonal'
+            THEN
+                (SELECT
+                    t_id
+                FROM
+                    arp_nutzungsplanung_transfer_v1.t_ili2db_basket
+                WHERE 
+                    topic ='SO_ARP_Nutzungsplanung_Nachfuehrung_20201005.Erschliessungsplanung'
+                    AND
+                    attachmentkey = 'Nachfuehrung_Kanton')
+        WHEN 'E715_Baulinie_Infrastruktur_kantonal'
+            THEN
+                (SELECT
+                    t_id
+                FROM
+                    arp_nutzungsplanung_transfer_v1.t_ili2db_basket
+                WHERE 
+                    topic ='SO_ARP_Nutzungsplanung_Nachfuehrung_20201005.Erschliessungsplanung'
+                    AND
+                    attachmentkey = 'Nachfuehrung_Kanton')
+        WHEN 'E719_weitere_nationale_und_kantonale_Baulinien'
+            THEN
+                (SELECT
+                    t_id
+                FROM
+                    arp_nutzungsplanung_transfer_v1.t_ili2db_basket
+                WHERE
+                    topic ='SO_ARP_Nutzungsplanung_Nachfuehrung_20201005.Erschliessungsplanung'
+                    AND
+                    attachmentkey = 'Nachfuehrung_Kanton')
+        ELSE  erschliessung_linienobjekt.t_basket
+    END AS t_basket,
+  -- Für Nachführungseinheit "Kanton" gibt es einen eigenes Dataset
+    CASE typ.typ_kt
+        WHEN 'E711_Baulinie_Strasse_kantonal'
+            THEN 'Kanton'
+        WHEN 'E712_Vorbaulinie_kantonal'
+            THEN 'Kanton'
+        WHEN 'E713_Gestaltungsbaulinie_kantonal'
+            THEN 'Kanton'
+        WHEN 'E714_Rueckwaertige_Baulinie_kantonal'
+            THEN 'Kanton'
+        WHEN 'E715_Baulinie_Infrastruktur_kantonal'
+            THEN 'Kanton'
+        WHEN 'E719_weitere_nationale_und_kantonale_Baulinien'
+            THEN 'Kanton'
+        ELSE erschliessung_linienobjekt.t_datasetname
+    END AS t_datasetname,
+    erschliessung_linienobjekt.t_ili_tid,
+    erschliessung_linienobjekt.geometrie,
+    erschliessung_linienobjekt.name_nummer AS geschaefts_nummer,
+    CASE rechtsstatus
+        WHEN 'laufendeAenderung'
+            THEN 'AenderungMitVorwirkung'
+        ELSE 'inKraft'
+    END AS rechtsstatus,
+    erschliessung_linienobjekt.publiziertab,
+    erschliessung_linienobjekt.bemerkungen,
+    erschliessung_linienobjekt.erfasser,
+    erschliessung_linienobjekt.datum,
+    NULL AS publiziertbis,
+    erschliessung_linienobjekt.typ_erschliessung_linienobjekt
+FROM
+    arp_nutzungsplanung_import_v1.erschlssngsplnung_erschliessung_linienobjekt AS erschliessung_linienobjekt
+    LEFT JOIN arp_nutzungsplanung_import_v1.erschlssngsplnung_typ_erschliessung_linienobjekt AS typ
+    ON typ.t_id = erschliessung_linienobjekt.typ_erschliessung_linienobjekt
+WHERE
+    typ_kt != 'E710_nationale_Baulinie'
+;
+
+/*
+ * Beziehung Dokument Erschliessung_Linienobjek. Auflösung Verknüpfung Dokument zu Dokument
+ * Es werden von der Zwischentabelle nur diejenigen Verknüpfungen kopiert,
+ * deren Typ tatsächlich auch im Zielschema bei den Typen vorhanden ist.
+ * Das hilft zwar bei Typen, die zum Kantons-Basket gehören würden und
+ * so nicht fälschlicherweise der Gemeinde zugewiesen werden. Es führt
+ * aber dazu, dass eventuell Dokumente kopiert wurden, die dann mit nix
+ * verküpft sind.
+ *
+ */
+ 
+INSERT INTO 
+    arp_nutzungsplanung_transfer_v1.erschlssngsplnung_typ_erschliessung_linienobjekt_dokument 
+(
+    t_id,
+    t_basket,
+    t_datasetname,
+    typ_erschliessung_linienobjekt,
+    dokument
+)
+
+SELECT
+    erschliessung_linienobjekt_dokument.t_id,
+  -- Für Nachführungseinheit "Kanton" gibt es einen eigenen Basket
+    CASE typ.typ_kt
+        WHEN 'E711_Baulinie_Strasse_kantonal'
+            THEN
+                (SELECT
+                    t_id
+                FROM
+                    arp_nutzungsplanung_transfer_v1.t_ili2db_basket
+                WHERE 
+                    topic ='SO_ARP_Nutzungsplanung_Nachfuehrung_20201005.Erschliessungsplanung'
+                    AND
+                    attachmentkey = 'Nachfuehrung_Kanton')
+        WHEN 'E712_Vorbaulinie_kantonal'
+            THEN
+                (SELECT
+                    t_id
+                FROM
+                    arp_nutzungsplanung_transfer_v1.t_ili2db_basket
+                WHERE 
+                    topic ='SO_ARP_Nutzungsplanung_Nachfuehrung_20201005.Erschliessungsplanung'
+                    AND
+                    attachmentkey = 'Nachfuehrung_Kanton')
+        WHEN 'E713_Gestaltungsbaulinie_kantonal'
+            THEN
+                (SELECT
+                    t_id
+                FROM
+                    arp_nutzungsplanung_transfer_v1.t_ili2db_basket
+                WHERE
+                    topic ='SO_ARP_Nutzungsplanung_Nachfuehrung_20201005.Erschliessungsplanung'
+                    AND
+                    attachmentkey = 'Nachfuehrung_Kanton')
+        WHEN 'E714_Rueckwaertige_Baulinie_kantonal'
+            THEN
+                (SELECT
+                    t_id
+                FROM
+                    arp_nutzungsplanung_transfer_v1.t_ili2db_basket
+                WHERE 
+                    topic ='SO_ARP_Nutzungsplanung_Nachfuehrung_20201005.Erschliessungsplanung'
+                    AND
+                    attachmentkey = 'Nachfuehrung_Kanton')
+        WHEN 'E715_Baulinie_Infrastruktur_kantonal'
+            THEN
+                (SELECT
+                    t_id
+                FROM
+                    arp_nutzungsplanung_transfer_v1.t_ili2db_basket
+                WHERE 
+                    topic ='SO_ARP_Nutzungsplanung_Nachfuehrung_20201005.Erschliessungsplanung'
+                    AND
+                    attachmentkey = 'Nachfuehrung_Kanton')
+        WHEN 'E719_weitere_nationale_und_kantonale_Baulinien'
+            THEN
+                (SELECT
+                    t_id
+                FROM
+                    arp_nutzungsplanung_transfer_v1.t_ili2db_basket
+                WHERE 
+                    topic ='SO_ARP_Nutzungsplanung_Nachfuehrung_20201005.Erschliessungsplanung'
+                    AND
+                    attachmentkey = 'Nachfuehrung_Kanton')
+        ELSE  erschliessung_linienobjekt_dokument.t_basket
+    END AS t_basket,
+  -- Für Nachführungseinheit "Kanton" gibt es einen eigenes Dataset
+    CASE typ.typ_kt
+        WHEN 'E711_Baulinie_Strasse_kantonal'
+            THEN 'Kanton'
+        WHEN 'E712_Vorbaulinie_kantonal'
+            THEN 'Kanton'
+        WHEN 'E713_Gestaltungsbaulinie_kantonal'
+            THEN 'Kanton'
+        WHEN 'E714_Rueckwaertige_Baulinie_kantonal'
+            THEN 'Kanton'
+        WHEN 'E715_Baulinie_Infrastruktur_kantonal'
+            THEN 'Kanton'
+        WHEN 'E719_weitere_nationale_und_kantonale_Baulinien'
+            THEN 'Kanton'
+        ELSE erschliessung_linienobjekt_dokument.t_datasetname
+    END AS t_datasetname,
+    erschliessung_linienobjekt_dokument.typ_erschliessung_linienobjekt,
+    erschliessung_linienobjekt_dokument.dokument
+FROM
+    arp_nutzungsplanung_import_v1.erschlssngsplnung_typ_erschliessung_linienobjekt_dokument AS erschliessung_linienobjekt_dokument
+    LEFT JOIN arp_nutzungsplanung_import_v1.erschlssngsplnung_typ_erschliessung_linienobjekt AS typ
+    ON typ.t_id = erschliessung_linienobjekt_dokument.typ_erschliessung_linienobjekt
+WHERE 
+    typ_erschliessung_linienobjekt IN 
+    (
+        SELECT  
+            t_id 
+        FROM 
+            arp_nutzungsplanung_transfer_v1.erschlssngsplnung_typ_erschliessung_linienobjekt
+    )
+;    
+    
+WITH RECURSIVE x(ursprung, hinweis, parents, last_ursprung, depth) AS 
+(
+    SELECT 
+        ursprung, 
+        hinweis, 
+        ARRAY[ursprung] AS parents, 
+        ursprung AS last_ursprung, 
+        0 AS "depth" 
+    FROM 
+        arp_nutzungsplanung_import_v1.rechtsvorschrften_hinweisweiteredokumente
+    WHERE
+        ursprung != hinweis
+    -- Hier könnte zusätzlich nach Basket gefilter werden.
+    -- Dann müssen aber die bereits kopierten Dokumente
+    -- korrekt zugewiesen sein, was momentan nicht ist.
+
+    UNION ALL
+  
+    SELECT 
+        x.ursprung, 
+        x.hinweis, 
+        parents||t1.hinweis, 
+        t1.hinweis AS last_ursprung, 
+        x."depth" + 1
+    FROM 
+        x 
+        INNER JOIN arp_nutzungsplanung_import_v1.rechtsvorschrften_hinweisweiteredokumente t1 
+        ON (last_ursprung = t1.ursprung)
+    WHERE 
+        t1.hinweis IS NOT NULL
+    -- Dito. Siehe oben.
+)
+,
+zusaetzliche_dokumente AS 
+(
+    SELECT 
+        DISTINCT ON (x.last_ursprung, x.ursprung)
+        x.ursprung AS top_level_dokument,
+        x.last_ursprung AS t_id
+    FROM 
+        x
+)
+INSERT INTO 
+    arp_nutzungsplanung_transfer_v1.erschlssngsplnung_typ_erschliessung_linienobjekt_dokument 
+    (
+        t_basket,
+        t_datasetname,
+        typ_erschliessung_linienobjekt,
+        dokument 
+    )
+    SELECT 
+        DISTINCT 
+        typ_erschliessung_linienobjekt_dokument.t_basket,
+        typ_erschliessung_linienobjekt_dokument.t_datasetname,
+        typ_erschliessung_linienobjekt_dokument.typ_erschliessung_linienobjekt,
+        zusaetzliche_dokumente.t_id AS vorschrift_vorschriften_dokument
+    FROM 
+        zusaetzliche_dokumente
+        LEFT JOIN arp_nutzungsplanung_transfer_v1.erschlssngsplnung_typ_erschliessung_linienobjekt_dokument AS typ_erschliessung_linienobjekt_dokument
+        ON typ_erschliessung_linienobjekt_dokument.dokument = zusaetzliche_dokumente.top_level_dokument
+    WHERE
+        NOT EXISTS 
+        (
+            SELECT 
+                typ_erschliessung_linienobjekt,
+                dokument
+            FROM 
+                arp_nutzungsplanung_transfer_v1.erschlssngsplnung_typ_erschliessung_linienobjekt_dokument
+            WHERE 
+                typ_erschliessung_linienobjekt = erschlssngsplnung_typ_erschliessung_linienobjekt_dokument.typ_erschliessung_linienobjekt 
+                AND
+                dokument = zusaetzliche_dokumente.t_id
+        )
+        AND
+        typ_erschliessung_linienobjekt_dokument.typ_erschliessung_linienobjekt IS NOT NULL
+;
+
+-- Erschliessung Punkt
+INSERT INTO arp_nutzungsplanung_transfer_v1.erschlssngsplnung_typ_erschliessung_punktobjekt
+SELECT
+    t_id,
+    t_basket,
+    t_datasetname,
+    t_ili_tid,
+    typ_kt,
+    code_kommunal,
+    bezeichnung,
+    abkuerzung,
+    verbindlichkeit,
+    bemerkungen
+FROM
+    arp_nutzungsplanung_import_v1.erschlssngsplnung_typ_erschliessung_punktobjekt
+;
+
+INSERT INTO arp_nutzungsplanung_transfer_v1.erschlssngsplnung_erschliessung_punktobjekt
+SELECT
+    t_id,
+    t_basket,
+    t_datasetname,
+    t_ili_tid,
+    geometrie,
+    name_nummer AS geschaefts_nummer,
+    CASE rechtsstatus
+        WHEN 'laufendeAenderung'
+            THEN 'AenderungMitVorwirkung'
+        ELSE 'inKraft'
+    END AS rechtsstatus,
+    publiziertab,
+    bemerkungen,
+    erfasser,
+    datum,
+    NULL AS publiziertbis,
+    typ_erschliessung_punktobjekt
+FROM
+    arp_nutzungsplanung_import_v1.erschlssngsplnung_erschliessung_punktobjekt
+;
+
+/*
+ *Beziehung Dokument Erschliessung Punktobjekt. Auflösung Verknüpfung Dokument zu Dokument
+ * Es werden von der Zwischentabelle nur diejenigen Verknüpfungen kopiert,
+ * deren Typ tatsächlich auch im Zielschema bei den Typen vorhanden ist.
+ * Das hilft zwar bei Typen, die zum Kantons-Basket gehören würden und
+ * so nicht fälschlicherweise der Gemeinde zugewiesen werden. Es führt
+ * aber dazu, dass eventuell Dokumente kopiert wurden, die dann mit nix
+ * verküpft sind.
+ *
+ */
+ 
+INSERT INTO 
+    arp_nutzungsplanung_transfer_v1.erschlssngsplnung_typ_erschliessung_punktobjekt_dokument 
+(
+    t_id,
+    t_basket,
+    t_datasetname,
+    typ_erschliessung_punktobjekt,
+    dokument
+)
+
+SELECT
+    t_id,
+    t_basket,
+    t_datasetname,
+    typ_erschliessung_punktobjekt,
+    dokument
+FROM
+    arp_nutzungsplanung_import_v1.erschlssngsplnung_typ_erschliessung_punktobjekt_dokument
+WHERE 
+    typ_erschliessung_punktobjekt IN 
+    (
+        SELECT  
+            t_id 
+        FROM 
+            arp_nutzungsplanung_transfer_v1.erschlssngsplnung_typ_erschliessung_punktobjekt
+    )
+;    
+    
+WITH RECURSIVE x(ursprung, hinweis, parents, last_ursprung, depth) AS 
+(
+    SELECT 
+        ursprung, 
+        hinweis, 
+        ARRAY[ursprung] AS parents, 
+        ursprung AS last_ursprung, 
+        0 AS "depth" 
+    FROM 
+        arp_nutzungsplanung_import_v1.rechtsvorschrften_hinweisweiteredokumente
+    WHERE
+        ursprung != hinweis
+    -- Hier könnte zusätzlich nach Basket gefilter werden.
+    -- Dann müssen aber die bereits kopierten Dokumente
+    -- korrekt zugewiesen sein, was momentan nicht ist.
+
+    UNION ALL
+  
+    SELECT 
+        x.ursprung, 
+        x.hinweis, 
+        parents||t1.hinweis, 
+        t1.hinweis AS last_ursprung, 
+        x."depth" + 1
+    FROM 
+        x 
+        INNER JOIN arp_nutzungsplanung_import_v1.rechtsvorschrften_hinweisweiteredokumente t1 
+        ON (last_ursprung = t1.ursprung)
+    WHERE 
+        t1.hinweis IS NOT NULL
+    -- Dito. Siehe oben.
+)
+,
+zusaetzliche_dokumente AS 
+(
+    SELECT 
+        DISTINCT ON (x.last_ursprung, x.ursprung)
+        x.ursprung AS top_level_dokument,
+        x.last_ursprung AS t_id
+    FROM 
+        x
+)
+INSERT INTO 
+    arp_nutzungsplanung_transfer_v1.erschlssngsplnung_typ_erschliessung_punktobjekt_dokument 
+    (
+        t_basket,
+        t_datasetname,
+        typ_erschliessung_punktobjekt,
+        dokument 
+    )
+    SELECT 
+        DISTINCT 
+        typ_erschliessung_punktobjekt_dokument.t_basket,
+        typ_erschliessung_punktobjekt_dokument.t_datasetname,
+        typ_erschliessung_punktobjekt_dokument.typ_erschliessung_punktobjekt,
+        zusaetzliche_dokumente.t_id AS vorschrift_vorschriften_dokument
+    FROM 
+        zusaetzliche_dokumente
+        LEFT JOIN arp_nutzungsplanung_transfer_v1.erschlssngsplnung_typ_erschliessung_punktobjekt_dokument AS typ_erschliessung_punktobjekt_dokument
+        ON typ_erschliessung_punktobjekt_dokument.dokument = zusaetzliche_dokumente.top_level_dokument
+    WHERE
+        NOT EXISTS 
+        (
+            SELECT 
+                typ_erschliessung_punktobjekt,
+                dokument
+            FROM 
+                arp_nutzungsplanung_transfer_v1.erschlssngsplnung_typ_erschliessung_punktobjekt_dokument
+            WHERE 
+                typ_erschliessung_punktobjekt = erschlssngsplnung_typ_erschliessung_punktobjekt_dokument.typ_erschliessung_punktobjekt 
+                AND
+                dokument = zusaetzliche_dokumente.t_id
+        )
+        AND
+        typ_erschliessung_punktobjekt_dokument.typ_erschliessung_punktobjekt IS NOT NULL
+;
+
+-- Lärmempfindlichkeitsstufen
+INSERT INTO arp_nutzungsplanung_transfer_v1.laermmpfhktsstfen_typ_empfindlichkeitsstufe
+SELECT
+    t_id,
+--  Neuer Basket für Lärmempfindlichkeitsstufen Basket
+    (
+        SELECT
+            t_id
+        FROM
+            arp_nutzungsplanung_transfer_v1.t_ili2db_basket
+        WHERE  
+            topic ='SO_ARP_Nutzungsplanung_Nachfuehrung_20201005.Laermempfindlichkeitsstufen'
+    ) AS t_basket,
+    t_datasetname,
+    t_ili_tid,
+    typ_kt,
+    bezeichnung,
+    abkuerzung,
+    verbindlichkeit,
+    bemerkungen
+FROM
+    arp_nutzungsplanung_import_v1.nutzungsplanung_typ_ueberlagernd_flaeche
+WHERE
+    typ_kt= 'N680_Empfindlichkeitsstufe_I'
+    OR
+    typ_kt= 'N681_Empfindlichkeitsstufe_II'
+    OR
+    typ_kt= 'N682_Empfindlichkeitsstufe_II_aufgestuft'
+    OR
+    typ_kt= 'N683_Empfindlichkeitsstufe_III'
+    OR
+    typ_kt= 'N684_Empfindlichkeitsstufe_III_aufgestuft'
+    OR
+    typ_kt= 'N685_Empfindlichkeitsstufe_IV'
+    OR
+    typ_kt= 'N686_keine_Empfindlichkeitsstufe'
+;
+
+INSERT INTO arp_nutzungsplanung_transfer_v1.laermmpfhktsstfen_empfindlichkeitsstufe
+SELECT
+    ueberlagernd_flaeche.t_id,
+--  Neuer Basket für Lärmempfindlichkeitsstufen Basket
+    (
+        SELECT
+            t_id
+        FROM
+            arp_nutzungsplanung_transfer_v1.t_ili2db_basket
+        WHERE  
+            topic ='SO_ARP_Nutzungsplanung_Nachfuehrung_20201005.Laermempfindlichkeitsstufen'
+    ) AS t_basket,
+    ueberlagernd_flaeche.t_datasetname,
+    ueberlagernd_flaeche.t_ili_tid,
+    ueberlagernd_flaeche.geometrie,
+    ueberlagernd_flaeche.name_nummer AS geschaefts_nummer,
+    CASE ueberlagernd_flaeche.rechtsstatus
+        WHEN 'laufendeAenderung'
+            THEN 'AenderungMitVorwirkung'
+        ELSE 'inKraft'
+    END AS rechtsstatus,
+    ueberlagernd_flaeche.publiziertab,
+    ueberlagernd_flaeche.bemerkungen,
+    ueberlagernd_flaeche.erfasser,
+    ueberlagernd_flaeche.datum,
+    NULL AS publiziertbis,
+    ueberlagernd_flaeche.typ_ueberlagernd_flaeche AS typ_empfindlichkeitsstufen
+FROM
+    arp_nutzungsplanung_import_v1.nutzungsplanung_ueberlagernd_flaeche AS ueberlagernd_flaeche
+    LEFT JOIN arp_nutzungsplanung_import_v1.nutzungsplanung_typ_ueberlagernd_flaeche AS typ
+    ON typ.t_id = ueberlagernd_flaeche.typ_ueberlagernd_flaeche
+WHERE
+    typ.typ_kt= 'N680_Empfindlichkeitsstufe_I'
+    OR
+    typ.typ_kt= 'N681_Empfindlichkeitsstufe_II'
+    OR
+    typ.typ_kt= 'N682_Empfindlichkeitsstufe_II_aufgestuft'
+    OR
+    typ.typ_kt= 'N683_Empfindlichkeitsstufe_III'
+    OR
+    typ.typ_kt= 'N684_Empfindlichkeitsstufe_III_aufgestuft'
+    OR
+    typ.typ_kt= 'N685_Empfindlichkeitsstufe_IV'
+    OR
+    typ.typ_kt= 'N686_keine_Empfindlichkeitsstufe'
+;
+
+/*
+ * Beziehung Dokument Empfindlichkeitsstufen. Auflösung Verknüpfung Dokument zu Dokument
+ * Es werden von der Zwischentabelle nur diejenigen Verknüpfungen kopiert,
+ * deren Typ tatsächlich auch im Zielschema bei den Typen vorhanden ist.
+ * Das hilft zwar bei Typen, die zum Kantons-Basket gehören würden und
+ * so nicht fälschlicherweise der Gemeinde zugewiesen werden. Es führt
+ * aber dazu, dass eventuell Dokumente kopiert wurden, die dann mit nix
+ * verküpft sind.
+ *
+ */
+ 
+INSERT INTO 
+    arp_nutzungsplanung_transfer_v1.laermmpfhktsstfen_typ_empfindlichkeitsstufe_dokument
+(
+    t_id,
+    t_basket,
+    t_datasetname,
+    typ_empfindlichkeitsstufen,
+    dokument
+)
+
+SELECT
+    ueberlagernd_flaeche_dokument.t_id,
+--  Neuer Basket für Lärmempfindlichkeitsstufen Basket
+    (
+        SELECT
+            t_id
+        FROM
+            arp_nutzungsplanung_transfer_v1.t_ili2db_basket
+        WHERE  
+            topic ='SO_ARP_Nutzungsplanung_Nachfuehrung_20201005.Laermempfindlichkeitsstufen'
+    ) AS t_basket,
+    ueberlagernd_flaeche_dokument.t_datasetname,
+    ueberlagernd_flaeche_dokument.typ_ueberlagernd_flaeche,
+    ueberlagernd_flaeche_dokument.dokument
+
+FROM
+    arp_nutzungsplanung_import_v1.nutzungsplanung_typ_ueberlagernd_flaeche_dokument AS ueberlagernd_flaeche_dokument
+    LEFT JOIN arp_nutzungsplanung_import_v1.nutzungsplanung_typ_ueberlagernd_flaeche AS typ
+    ON typ.t_id = ueberlagernd_flaeche_dokument.typ_ueberlagernd_flaeche
+WHERE 
+    typ_ueberlagernd_flaeche IN 
+    (
+        SELECT  
+            t_id 
+        FROM 
+            arp_nutzungsplanung_transfer_v1.laermmpfhktsstfen_typ_empfindlichkeitsstufe
+    )
+;    
+    
+WITH RECURSIVE x(ursprung, hinweis, parents, last_ursprung, depth) AS 
+(
+    SELECT 
+        ursprung, 
+        hinweis, 
+        ARRAY[ursprung] AS parents, 
+        ursprung AS last_ursprung, 
+        0 AS "depth" 
+    FROM 
+        arp_nutzungsplanung_import_v1.rechtsvorschrften_hinweisweiteredokumente
+    WHERE
+        ursprung != hinweis
+    -- Hier könnte zusätzlich nach Basket gefilter werden.
+    -- Dann müssen aber die bereits kopierten Dokumente
+    -- korrekt zugewiesen sein, was momentan nicht ist.
+
+    UNION ALL
+  
+    SELECT 
+        x.ursprung, 
+        x.hinweis, 
+        parents||t1.hinweis, 
+        t1.hinweis AS last_ursprung, 
+        x."depth" + 1
+    FROM 
+        x 
+        INNER JOIN arp_nutzungsplanung_import_v1.rechtsvorschrften_hinweisweiteredokumente t1 
+        ON (last_ursprung = t1.ursprung)
+    WHERE 
+        t1.hinweis IS NOT NULL
+    -- Dito. Siehe oben.
+)
+,
+zusaetzliche_dokumente AS 
+(
+    SELECT 
+        DISTINCT ON (x.last_ursprung, x.ursprung)
+        x.ursprung AS top_level_dokument,
+        x.last_ursprung AS t_id
+    FROM 
+        x
+)
+INSERT INTO 
+    arp_nutzungsplanung_transfer_v1.laermmpfhktsstfen_typ_empfindlichkeitsstufe_dokument
+    (
+        t_basket,
+        t_datasetname,
+        typ_empfindlichkeitsstufen,
+        dokument 
+    )
+    SELECT 
+        DISTINCT 
+       --  Neuer Basket für Lärmempfindlichkeitsstufen Basket
+       (
+        SELECT
+            t_id
+        FROM
+            arp_nutzungsplanung_transfer_v1.t_ili2db_basket
+        WHERE  
+            topic ='SO_ARP_Nutzungsplanung_Nachfuehrung_20201005.Laermempfindlichkeitsstufen'
+        ) AS t_basket,
+        typ_empfindlichkeitsstufe_dokument.t_datasetname,
+        typ_empfindlichkeitsstufe_dokument.typ_empfindlichkeitsstufen,
+        zusaetzliche_dokumente.t_id AS vorschrift_vorschriften_dokument
+    FROM 
+        zusaetzliche_dokumente
+        LEFT JOIN arp_nutzungsplanung_transfer_v1.laermmpfhktsstfen_typ_empfindlichkeitsstufe_dokument AS typ_empfindlichkeitsstufe_dokument
+        ON typ_empfindlichkeitsstufe_dokument.dokument = zusaetzliche_dokumente.top_level_dokument
+    WHERE
+        NOT EXISTS 
+        (
+            SELECT 
+                typ_empfindlichkeitsstufen,
+                dokument
+            FROM 
+                arp_nutzungsplanung_transfer_v1.laermmpfhktsstfen_typ_empfindlichkeitsstufe_dokument
+            WHERE 
+                typ_empfindlichkeitsstufen = laermmpfhktsstfen_typ_empfindlichkeitsstufe_dokument.typ_empfindlichkeitsstufen
+                AND
+                dokument = zusaetzliche_dokumente.t_id
+        )
+        AND
+        typ_empfindlichkeitsstufe_dokument.typ_empfindlichkeitsstufen IS NOT NULL
+;
+
+--Datasetname "Kanton" und der entsprechenden Basket bei Dokumente aktuallisieren
+--nutzungsplanung_typ_ueberlagernd_flaeche_dokument
+UPDATE arp_nutzungsplanung_transfer_v1.rechtsvorschrften_dokument
+SET
+    t_datasetname =ueberlagernd_flaeche_dokument.t_datasetname,
+    t_basket=basket.t_id
+FROM
+    arp_nutzungsplanung_transfer_v1.nutzungsplanung_typ_ueberlagernd_flaeche_dokument AS ueberlagernd_flaeche_dokument,
+    arp_nutzungsplanung_transfer_v1.t_ili2db_basket AS basket,
+    arp_nutzungsplanung_transfer_v1.t_ili2db_dataset AS dataset
+WHERE
+    ueberlagernd_flaeche_dokument.dokument=arp_nutzungsplanung_transfer_v1.rechtsvorschrften_dokument.t_id
+    AND
+    ueberlagernd_flaeche_dokument.t_datasetname=dataset.datasetname
+    AND
+    basket.topic = 'SO_ARP_Nutzungsplanung_Nachfuehrung_20201005.Rechtsvorschriften'
+    AND
+    dataset.t_id=basket.dataset
+;
+--erschlssngsplnung_typ_erschliessung_flaechenobjekt_dokument
+UPDATE arp_nutzungsplanung_transfer_v1.rechtsvorschrften_dokument
+SET
+    t_datasetname =erschliessung_flaechenobjekt_dokument.t_datasetname,
+    t_basket=basket.t_id
+FROM
+    arp_nutzungsplanung_transfer_v1.erschlssngsplnung_typ_erschliessung_flaechenobjekt_dokument AS erschliessung_flaechenobjekt_dokument,
+    arp_nutzungsplanung_transfer_v1.t_ili2db_basket AS basket,
+    arp_nutzungsplanung_transfer_v1.t_ili2db_dataset AS dataset
+WHERE
+    erschliessung_flaechenobjekt_dokument.dokument=arp_nutzungsplanung_transfer_v1.rechtsvorschrften_dokument.t_id
+    AND
+    erschliessung_flaechenobjekt_dokument.t_datasetname=dataset.datasetname
+    AND
+    basket.topic = 'SO_ARP_Nutzungsplanung_Nachfuehrung_20201005.Rechtsvorschriften'
+    AND
+    dataset.t_id=basket.dataset
+;
+--erschlssngsplnung_typ_erschliessung_linienobjekt_dokument
+UPDATE arp_nutzungsplanung_transfer_v1.rechtsvorschrften_dokument
+SET
+     t_datasetname =erschliessung_linienobjekt_dokument.t_datasetname,
+     t_basket=basket.t_id
+FROM
+    arp_nutzungsplanung_transfer_v1.erschlssngsplnung_typ_erschliessung_linienobjekt_dokument AS erschliessung_linienobjekt_dokument,
+    arp_nutzungsplanung_transfer_v1.t_ili2db_basket AS basket,
+    arp_nutzungsplanung_transfer_v1.t_ili2db_dataset AS dataset
+WHERE
+    erschliessung_linienobjekt_dokument.dokument=arp_nutzungsplanung_transfer_v1.rechtsvorschrften_dokument.t_id
+    AND
+    erschliessung_linienobjekt_dokument.t_datasetname=dataset.datasetname
+    AND
+    basket.topic = 'SO_ARP_Nutzungsplanung_Nachfuehrung_20201005.Rechtsvorschriften'
+    AND
+    dataset.t_id=basket.dataset
+;
+
+--Dokument verdoppeln für Dataset Kanton
+--überlagernde Fläche
+INSERT INTO arp_nutzungsplanung_transfer_v1.rechtsvorschrften_dokument
+SELECT
+    DISTINCT ON (dokument.t_id + 1000000)
+    dokument.t_id + 1000000 AS t_id,
+    (
+        SELECT
+            t_id
+        FROM
+            arp_nutzungsplanung_transfer_v1.t_ili2db_basket
+        WHERE 
+            topic ='SO_ARP_Nutzungsplanung_Nachfuehrung_20201005.Erschliessungsplanung'
+            AND
+            attachmentkey = 'Nachfuehrung_Kanton'
+    ) AS t_basket,
+    'Kanton' AS t_datasetname,
+    gen_random_uuid () AS t_ili_tid,
+    dokument.dokumentid,
+    dokument.titel,
+    dokument.offiziellertitel,
+    dokument.abkuerzung,
+    dokument.offiziellenr,
+    dokument.kanton,
+    dokument.gemeinde,
+    dokument.publiziertab,
+    dokument.rechtsstatus,
+    dokument.textimweb,
+    dokument.bemerkungen,
+    dokument.rechtsvorschrift
+FROM
+    arp_nutzungsplanung_transfer_v1.rechtsvorschrften_dokument AS dokument
+    LEFT JOIN arp_nutzungsplanung_transfer_v1.nutzungsplanung_typ_ueberlagernd_flaeche_dokument AS ueberlagernd_flaeche_dokument
+    ON dokument.t_id = ueberlagernd_flaeche_dokument.dokument
+WHERE
+    ueberlagernd_flaeche_dokument.t_datasetname= 'Kanton' 
+    AND 
+    dokument.t_datasetname!= 'Kanton'
+;
+
+UPDATE arp_nutzungsplanung_transfer_v1.nutzungsplanung_typ_ueberlagernd_flaeche_dokument AS ueberlagernd_flaeche_dokument
+SET
+    dokument = dokument+1000000
+FROM arp_nutzungsplanung_transfer_v1.rechtsvorschrften_dokument AS dokument_table
+WHERE
+   (dokument+1000000)=dokument_table.t_id
+    AND 
+    ueberlagernd_flaeche_dokument.t_datasetname= 'Kanton' 
+;
+
+--Dokument verdoppeln für Dataset Kanton
+--Erschliessung Fläche
+INSERT INTO arp_nutzungsplanung_transfer_v1.rechtsvorschrften_dokument
+SELECT
+    DISTINCT ON (dokument.t_id + 2000000)
+    dokument.t_id + 2000000 AS t_id,
+    (
+        SELECT
+            t_id
+        FROM
+            arp_nutzungsplanung_transfer_v1.t_ili2db_basket
+        WHERE 
+            topic ='SO_ARP_Nutzungsplanung_Nachfuehrung_20201005.Erschliessungsplanung'
+        AND
+            attachmentkey = 'Nachfuehrung_Kanton'
+    ) AS t_basket,
+    'Kanton' AS t_datasetname,
+    gen_random_uuid () AS t_ili_tid,
+    dokument.dokumentid,
+    dokument.titel,
+    dokument.offiziellertitel,
+    dokument.abkuerzung,
+    dokument.offiziellenr,
+    dokument.kanton,
+    dokument.gemeinde,
+    dokument.publiziertab,
+    dokument.rechtsstatus,
+    dokument.textimweb,
+    dokument.bemerkungen,
+    dokument.rechtsvorschrift
+FROM
+    arp_nutzungsplanung_transfer_v1.rechtsvorschrften_dokument AS dokument
+    LEFT JOIN arp_nutzungsplanung_transfer_v1.erschlssngsplnung_typ_erschliessung_flaechenobjekt_dokument AS erschliessung_flaechenobjekt_dokument
+    ON dokument.t_id = erschliessung_flaechenobjekt_dokument.dokument
+WHERE
+    erschliessung_flaechenobjekt_dokument.t_datasetname= 'Kanton'
+    AND 
+    dokument.t_datasetname!= 'Kanton'
+;
+
+UPDATE arp_nutzungsplanung_transfer_v1.erschlssngsplnung_typ_erschliessung_flaechenobjekt_dokument AS erschliessung_flaechenobjekt_dokument
+SET
+    dokument = dokument+2000000
+FROM arp_nutzungsplanung_transfer_v1.rechtsvorschrften_dokument AS dokument_table
+WHERE
+   (dokument+2000000)=dokument_table.t_id
+    AND 
+    erschliessung_flaechenobjekt_dokument.t_datasetname= 'Kanton'
+;
+
+--Dokument verdoppeln für Dataset Kanton
+--Erschliessung Linie
+INSERT INTO arp_nutzungsplanung_transfer_v1.rechtsvorschrften_dokument
+SELECT
+    DISTINCT ON (dokument.t_id + 3000000)
+    dokument.t_id + 3000000 AS t_id,
+    (
+        SELECT
+            t_id
+        FROM
+            arp_nutzungsplanung_transfer_v1.t_ili2db_basket
+        WHERE 
+            topic ='SO_ARP_Nutzungsplanung_Nachfuehrung_20201005.Erschliessungsplanung'
+        AND
+            attachmentkey = 'Nachfuehrung_Kanton'
+    ) AS t_basket, 
+    'Kanton' AS t_datasetname,
+    gen_random_uuid () AS t_ili_tid,
+    dokument.dokumentid,
+    dokument.titel,
+    dokument.offiziellertitel,
+    dokument.abkuerzung,
+    dokument.offiziellenr,
+    dokument.kanton,
+    dokument.gemeinde,
+    dokument.publiziertab,
+    dokument.rechtsstatus,
+    dokument.textimweb,
+    dokument.bemerkungen,
+    dokument.rechtsvorschrift
+FROM
+    arp_nutzungsplanung_transfer_v1.rechtsvorschrften_dokument AS dokument
+    LEFT JOIN arp_nutzungsplanung_transfer_v1.erschlssngsplnung_typ_erschliessung_linienobjekt_dokument AS erschliessung_linienobjekt_dokument
+    ON dokument.t_id = erschliessung_linienobjekt_dokument.dokument
+WHERE
+    erschliessung_linienobjekt_dokument.t_datasetname= 'Kanton'
+    AND 
+    dokument.t_datasetname!= 'Kanton'
+;
+
+UPDATE arp_nutzungsplanung_transfer_v1.erschlssngsplnung_typ_erschliessung_linienobjekt_dokument AS erschliessung_linienobjekt_dokument
+SET
+    dokument = dokument+3000000
+FROM arp_nutzungsplanung_transfer_v1.rechtsvorschrften_dokument AS dokument_table
+WHERE
+   (dokument+3000000)=dokument_table.t_id
+    AND 
+    erschliessung_linienobjekt_dokument.t_datasetname= 'Kanton'
+;

--- a/arp_nutzungsplanung_import/insert_arp_nutzungsplanung_transfer.sql
+++ b/arp_nutzungsplanung_import/insert_arp_nutzungsplanung_transfer.sql
@@ -117,7 +117,8 @@ SELECT
     END AS rechtsstatus,
     'https://geo.so.ch/docs/ch.so.arp.zonenplaene/Zonenplaene_pdf/' || textimweb AS textimweb,
     bemerkungen,
-    rechtsvorschrift
+    rechtsvorschrift,
+    NULL AS publiziertbis
 FROM
     arp_nutzungsplanung_import_v1.rechtsvorschrften_dokument
 ;

--- a/arp_nutzungsplanung_pub/Jenkinsfile
+++ b/arp_nutzungsplanung_pub/Jenkinsfile
@@ -26,7 +26,7 @@ pipeline {
                 emailext (
                     recipientProviders: [requestor()],
                     subject: "Nutzungsplanung zum Review bereit (GRETL-Job ${JOB_NAME} ${BUILD_DISPLAY_NAME})",
-                    body: "Mit dem GRETL-Job ${JOB_NAME} (${BUILD_DISPLAY_NAME}) wurden Daten der Nutzungsplanung mit der BFS-Nr. ${params.bfsnr} nachgeführt, die ein Review erfordern. Nach dem Review unter https://${BUILD_URL.split('/')[2].replace('gretl', 'geo')}/map?t=oereb_review können Sie unter folgendem Link die Publikation der Daten veranlassen oder abbrechen: ${RUN_DISPLAY_URL}."
+                    body: "Mit dem GRETL-Job ${JOB_NAME} (${BUILD_DISPLAY_NAME}) wurden Daten der Nutzungsplanung mit der BFS-Nr. ${params.bfsnr} nachgeführt, die ein Review erfordern. Nach dem Review unter https://${BUILD_URL.split('/')[2].replace('gretl', 'geo')}/map?t=nutzungsplanung_review können Sie unter folgendem Link die Publikation der Daten veranlassen oder abbrechen: ${RUN_DISPLAY_URL}."
                 )
             }
         }

--- a/arp_nutzungsplanung_pub/Jenkinsfile
+++ b/arp_nutzungsplanung_pub/Jenkinsfile
@@ -16,16 +16,18 @@ pipeline {
             agent { label 'gretl-ili2pg4' }
             steps {
                 git url: gretlJobRepoUrl, branch: "${params.BRANCH ?: 'master'}", changelog: false
-                dir(env.JOB_BASE_NAME) {
-                    sh "gretl -Pbfsnr=${params.bfsnr}"
-                    sh 'gretl importXTF_stage'
-                    zip zipFile: 'xtfdata.zip', glob: '*.xtf', archive: true
-               }
+                container('gretl') {
+                    dir(env.JOB_BASE_NAME) {
+                        sh "gretl -Pbfsnr=${params.bfsnr}"
+                        sh 'gretl importXTF_stage'
+                        zip zipFile: 'xtfdata.zip', glob: '*.xtf', archive: true
+                    }
+                }
                 stash name: "gretljob"
                 emailext (
                     recipientProviders: [requestor()],
                     subject: "Nutzungsplanung zum Review bereit (GRETL-Job ${JOB_NAME} ${BUILD_DISPLAY_NAME})",
-                    body: "Mit dem GRETL-Job ${JOB_NAME} (${BUILD_DISPLAY_NAME}) wurden Daten der Nutzungsplanung mit der BFS-Nr. ${params.bfsnr} nachgeführt, die ein Review erfordern. Nach dem Review unter https://${ORG_GRADLE_PROJECT_geoservicesHostName}/map?t=oereb_review können Sie unter folgendem Link die Publikation der Daten veranlassen oder abbrechen: ${RUN_DISPLAY_URL}."
+                    body: "Mit dem GRETL-Job ${JOB_NAME} (${BUILD_DISPLAY_NAME}) wurden Daten der Nutzungsplanung mit der BFS-Nr. ${params.bfsnr} nachgeführt, die ein Review erfordern. Nach dem Review unter https://${BUILD_URL.split('/')[2].replace('gretl', 'geo')}/map?t=oereb_review können Sie unter folgendem Link die Publikation der Daten veranlassen oder abbrechen: ${RUN_DISPLAY_URL}."
                 )
             }
         }
@@ -39,8 +41,10 @@ pipeline {
             agent { label 'gretl-ili2pg4' }
             steps {
                 unstash name: "gretljob"
-                dir(env.JOB_BASE_NAME) {
-                    sh 'gretl importXTF_pub'
+                container('gretl') {
+                    dir(env.JOB_BASE_NAME) {
+                        sh 'gretl importXTF_pub'
+                    }
                 }
             }
         }

--- a/arp_nutzungsplanung_pub/Jenkinsfile
+++ b/arp_nutzungsplanung_pub/Jenkinsfile
@@ -18,8 +18,7 @@ pipeline {
                 git url: gretlJobRepoUrl, branch: "${params.BRANCH ?: 'master'}", changelog: false
                 container('gretl') {
                     dir(env.JOB_BASE_NAME) {
-                        sh "gretl -Pbfsnr=${params.bfsnr}"
-                        sh 'gretl importXTF_stage'
+                        sh "gretl -Pbfsnr=${params.bfsnr} importXTF_stage"
                         zip zipFile: 'xtfdata.zip', glob: '*.xtf', archive: true
                     }
                 }
@@ -43,7 +42,7 @@ pipeline {
                 unstash name: "gretljob"
                 container('gretl') {
                     dir(env.JOB_BASE_NAME) {
-                        sh 'gretl importXTF_pub'
+                        sh "gretl -Pbfsnr=${params.bfsnr} importXTF_pub"
                     }
                 }
             }

--- a/arp_nutzungsplanung_pub/Jenkinsfile
+++ b/arp_nutzungsplanung_pub/Jenkinsfile
@@ -1,0 +1,53 @@
+// Start with a scripted pipeline part
+node('master') {
+    stage('Prepare') {
+        gretlJobRepoUrl = env.GRETL_JOB_REPO_URL
+        uploadDirName = 'upload'
+        uploadFileName = 'uploadFile'
+        // By default the uploaded file is stored in the following directory:
+        buildDir = "$JENKINS_HOME/jobs/$JOB_BASE_NAME/builds/$BUILD_NUMBER"
+        // Create a subdirectory for the uploaded file:
+        sh "mkdir $buildDir/$uploadDirName"
+        inputFile = input (
+            message: 'Datei hochladen',
+            parameters: [
+                file(name: "$uploadDirName/$uploadFileName", description: 'Hochzuladende Datei auswählen'),
+                string(name: 'ili2pgDataset', description: 'BFS-Nummer (Dataset) der Daten angeben')
+            ]
+        )
+        dir(buildDir) {
+            stash name: 'uploadDir', includes: "upload/**"
+        }
+        sh "rm -r $buildDir/$uploadDirName"
+    }
+}
+
+// Declarative pipeline starts here
+pipeline {
+    agent { label params.nodeLabel ?: 'gretl' }
+    options {
+        timeout(time: 6, unit: 'HOURS')
+    }
+    stages {
+        stage('Run GRETL-Job') {
+            steps {
+                git url: gretlJobRepoUrl, branch: "${params.BRANCH ?: 'master'}", changelog: false
+                dir(env.JOB_BASE_NAME) {
+                    unstash name: 'uploadDir'
+                    sh "gretl -Pili2pgDataset=$inputFile.ili2pgDataset"
+                }
+            }
+        }
+    }
+    post {
+        unsuccessful {
+            emailext (
+                to: '${DEFAULT_RECIPIENTS}',
+                recipientProviders: [requestor()],
+                subject: "GRETL-Job ${JOB_NAME} (${BUILD_DISPLAY_NAME}) ist fehlgeschlagen",
+                body: "Die Ausführung des GRETL-Jobs ${JOB_NAME} (${BUILD_DISPLAY_NAME}) war nicht erfolgreich. Details dazu finden Sie in den Log-Meldungen unter ${RUN_DISPLAY_URL}."
+            )
+        }
+    }
+}
+

--- a/arp_nutzungsplanung_pub/Jenkinsfile
+++ b/arp_nutzungsplanung_pub/Jenkinsfile
@@ -2,23 +2,6 @@
 node('master') {
     stage('Prepare') {
         gretlJobRepoUrl = env.GRETL_JOB_REPO_URL
-        uploadDirName = 'upload'
-        uploadFileName = 'uploadFile'
-        // By default the uploaded file is stored in the following directory:
-        buildDir = "$JENKINS_HOME/jobs/$JOB_BASE_NAME/builds/$BUILD_NUMBER"
-        // Create a subdirectory for the uploaded file:
-        sh "mkdir $buildDir/$uploadDirName"
-        inputFile = input (
-            message: 'Datei hochladen',
-            parameters: [
-                file(name: "$uploadDirName/$uploadFileName", description: 'Hochzuladende Datei auswählen'),
-                string(name: 'ili2pgDataset', description: 'BFS-Nummer (Dataset) der Daten angeben')
-            ]
-        )
-        dir(buildDir) {
-            stash name: 'uploadDir', includes: "upload/**"
-        }
-        sh "rm -r $buildDir/$uploadDirName"
     }
 }
 
@@ -29,17 +12,48 @@ pipeline {
         timeout(time: 6, unit: 'HOURS')
     }
     stages {
-        stage('Run GRETL-Job') {
+        stage('Import into staging schema') {
+            agent { label 'gretl-ili2pg4' }
             steps {
                 git url: gretlJobRepoUrl, branch: "${params.BRANCH ?: 'master'}", changelog: false
                 dir(env.JOB_BASE_NAME) {
-                    unstash name: 'uploadDir'
-                    sh "gretl -Pili2pgDataset=$inputFile.ili2pgDataset"
+                    sh "gretl -Pbfsnr=${params.bfsnr}"
+                    sh 'gretl importXTF_stage'
+                    zip zipFile: 'xtfdata.zip', glob: '*.xtf', archive: true
+               }
+                stash name: "gretljob"
+                emailext (
+                    recipientProviders: [requestor()],
+                    subject: "Nutzungsplanung zum Review bereit (GRETL-Job ${JOB_NAME} ${BUILD_DISPLAY_NAME})",
+                    body: "Mit dem GRETL-Job ${JOB_NAME} (${BUILD_DISPLAY_NAME}) wurden Daten der Nutzungsplanung mit der BFS-Nr. ${params.bfsnr} nachgeführt, die ein Review erfordern. Nach dem Review unter https://${ORG_GRADLE_PROJECT_geoservicesHostName}/map?t=oereb_review können Sie unter folgendem Link die Publikation der Daten veranlassen oder abbrechen: ${RUN_DISPLAY_URL}."
+                )
+            }
+        }
+        stage('Validation') {
+            agent { label 'master' }
+            steps {
+                input message: "Fortfahren und die Daten publizieren?", ok: "OK"
+            }
+        }
+        stage('Import into pub schema') {
+            agent { label 'gretl-ili2pg4' }
+            steps {
+                unstash name: "gretljob"
+                dir(env.JOB_BASE_NAME) {
+                    sh 'gretl importXTF_pub'
                 }
             }
         }
+       
     }
     post {
+        success {
+            emailext (
+                recipientProviders: [requestor()],
+                subject: "Daten der Nutzungsplanung für BFS-Nr. ${params.bfsnr} sind publiziert (GRETL-Job ${JOB_NAME} ${BUILD_DISPLAY_NAME})",
+                body: "Die Daten der Nutzungsplanung für BFS-Nr. ${params.bfsnr} des GRETL-Jobs ${JOB_NAME} (${BUILD_DISPLAY_NAME}) wurden erfolgreich publiziert. Die Log-Meldungen dazu finden Sie unter ${RUN_DISPLAY_URL}."
+            )
+        }
         unsuccessful {
             emailext (
                 to: '${DEFAULT_RECIPIENTS}',
@@ -50,4 +64,3 @@ pipeline {
         }
     }
 }
-

--- a/arp_nutzungsplanung_pub/README.md
+++ b/arp_nutzungsplanung_pub/README.md
@@ -1,0 +1,28 @@
+## Information zum GRETL-Job "pub"
+## Allgemein
+Die Daten aus dem Schema «arp_nutzungsplanung» (Datenmodell «SO_ARP_Nutzungsplanung_Nachfuehrung_20201005») werden pro Dataset (BFS-Nr.) publiziert. Die Daten werden zuerst mit dem Validierungsmodell geprüft. 
+Falls die Prüfung in Ordnung ist, werden die Daten in das Schema «arp_nutzungsplanung_staging» importiert. Mittels Bestätigung durch die zuständigen Geschäftsverantwortlichen (z.B. Gemeinde, Kreisplanende oder Nachführungsstelle Nutzungsplanung) 
+wird der Job weitergeführt und die Daten werden in das Publikationsschema «arp_nutzungsplanung_pub» importiert. Das Schema «arp_nutzungsplanung_staging» wird geleert. Die INTERLIS-Transferdatei wird zudem archiviert (Artefakte). 
+Die Publikation wird pro Dataset (BFS-Nr.) ausgeführt. So kann definiert werden, von welcher Gemeinde die Publikation erfolgen sollen.
+
+Hinweis für Publikation Kanton gibt es ein eignener GRETL-Job.
+
+## Job Ablauf
+1. xxxx
+
+
+## GRETL
+Lokales arbeiten:
+Parameter:
+```
+export ORG_GRADLE_PROJECT_dbUriEdit=jdbc:postgresql://edit-db/edit
+export ORG_GRADLE_PROJECT_dbUserEdit=gretl
+export ORG_GRADLE_PROJECT_dbPwdEdit=gretl
+export ORG_GRADLE_PROJECT_dbUriPub=jdbc:postgresql://pub-db/pub
+export ORG_GRADLE_PROJECT_dbUserPub=gretl
+export ORG_GRADLE_PROJECT_dbPwdPub=gretl
+```
+nur Lokal ein Ordner "upload" anlegen im Gretljob Verzeichnis. XTF-Datei in das Verzeichnis kopieren mit der Benennung "uploadFile" 
+```
+./start-gretl.sh --docker-image sogis/gretl-runtime:latest --docker-network schema-jobs_default --job-directory $PWD/arp_nutzungsplanung_pub -Pili2pgDataset='2457'
+```

--- a/arp_nutzungsplanung_pub/README.md
+++ b/arp_nutzungsplanung_pub/README.md
@@ -8,8 +8,14 @@ Die Publikation wird pro Dataset (BFS-Nr.) ausgeführt. So kann definiert werden
 Hinweis für Publikation Kanton gibt es ein eignener GRETL-Job.
 
 ## Job Ablauf
-1. xxxx
-
+1. Schema «arp_nutzungsplanung_transfer_pub» 
+2. Datenumabu vom Schema «arp_nutzungsplanung» (Datenmodell «SO_ARP_Nutzungsplanung_Nachfuehrung_20201005») ins Schema «arp_nutzungsplanung_transfer_pub» (Datenmodell «SO_ARP_Nutzungsplanung_Publikation_20201005»)
+3. Export der XTF-Datei
+4. Validation der INTERLIS-Dateien mit dem Validierungsmodell
+5. Import XTF in Schema «arp_nutzungsplanung_staging»
+6. Bestätigung (manuell) Review ist i.O. 
+7. Import/Replace XTF in Schema «arp_nutzungsplanung_pub»
+8. Dataset aus Schema «arp_nutzungsplanung_staging» löschen
 
 ## GRETL
 Lokales arbeiten:
@@ -24,5 +30,5 @@ export ORG_GRADLE_PROJECT_dbPwdPub=gretl
 ```
 nur Lokal ein Ordner "upload" anlegen im Gretljob Verzeichnis. XTF-Datei in das Verzeichnis kopieren mit der Benennung "uploadFile" 
 ```
-./start-gretl.sh --docker-image sogis/gretl-runtime:latest --docker-network schema-jobs_default --job-directory $PWD/arp_nutzungsplanung_pub -Pili2pgDataset='2457'
+./start-gretl.sh --docker-image sogis/gretl-runtime:latest --docker-network schema-jobs_default --job-directory $PWD/arp_nutzungsplanung_pub -Pbfsnr='2457'
 ```

--- a/arp_nutzungsplanung_pub/build.gradle
+++ b/arp_nutzungsplanung_pub/build.gradle
@@ -7,7 +7,7 @@ import ch.so.agi.gretl.api.TransferSet
 
 apply plugin: 'ch.so.agi.gretl'
 
-defaultTasks "importXTF_pub"
+defaultTasks 'importXTF_stage', 'importXTF_pub'
 
 task deleteData_transfer_pub (type: SqlExecutor) {
     description = "Löscht/leert die Daten aus dem Schema arp_nutzungsplanung_transfer_pub."
@@ -54,7 +54,7 @@ task delete_Dataset_stage(type: Ili2pgDelete) {
     dataset = bfsnr
 }
 
-task importXTF_pub(type: Ili2pgReplace, dependsOn: 'importXTF_stage') {
+task importXTF_pub(type: Ili2pgReplace) {
     description = 'Import der umgebaute INTERLIS-Datei einer Gemeinde (BFS-Nr.) in das Schema arp_nutzungsplanung_pub.'
     database = [dbUriPub, dbUserPub, dbPwdPub]
     dbschema = 'arp_nutzungsplanung_pub_v1'

--- a/arp_nutzungsplanung_pub/build.gradle
+++ b/arp_nutzungsplanung_pub/build.gradle
@@ -1,0 +1,59 @@
+
+// Macht ein Datenumbau in die Struktur des Publikationsmodells (Schema "arp_nutzungsplanung_transfer_pub"). 
+// Das resultierende XTF wird ins Schema "arp_nutzungsplanung_pub" importiert.
+
+import ch.so.agi.gretl.tasks.*
+import ch.so.agi.gretl.api.TransferSet
+
+
+apply plugin: 'ch.so.agi.gretl'
+
+defaultTasks "importXTF_Dataset_BFSNr", "importXTF_Kanton"
+
+task deleteData_transfer_pub (type: SqlExecutor) {
+    description = "Löscht/leert die Daten aus dem Schema arp_nutzungsplanung_transfer_pub."
+    database = [dbUriEdit, dbUserEdit, dbPwdEdit]
+    sqlFiles = ["delete_arp_nutzungsplanung_transfer_pub.sql"]
+}
+
+task transferData(type: SqlExecutor, dependsOn: 'deleteData_transfer_pub') {
+    description = "Führt den Datenumbau in das Schema arp_nutzungsplanung_transfer_pub durch. Das braucht es, damit ein XFT pro Dataser ins Schema arp_nutzungsplanung_pub importiert resp. ersetzt werden kann"
+    database = [dbUriEdit, dbUserEdit, dbPwdEdit]
+    sqlFiles = ["insert_arp_nutzungsplanung_transfer_pub.sql"]
+}
+
+task exportData (type: Ili2pgExport, dependsOn: 'transferData') {
+    description = "Exportiert die umgebauten Daten mit DataSet= BFSNr aus dem Schema arp_nutzungsplanung_transfer_pub in ein INTERLIS-Datei."
+    database = [dbUriEdit, dbUserEdit, dbPwdEdit]
+    dbschema = 'arp_nutzungsplanung_transfer_pub_v1'
+    models = 'SO_ARP_Nutzungsplanung_Publikation_20201005'
+    dataFile= file(ili2pgDataset + "_pub.xtf")
+    disableValidation = true
+}
+
+task validateData(type: IliValidator, dependsOn: 'exportData') {
+    description = "Validiert die exportierten INTERLIS-Datei gegen das Modell."
+    dataFiles = file(ili2pgDataset + ".xtf")
+    failOnError = true
+}
+
+task importXTF_stage(type: Ili2pgImport, dependsOn: 'validateData') {
+    description = 'Import der umgebaute INTERLIS-Datei einer Gemeinde (BFS-Nr.) in das Schema arp_nutzungsplanung_stage.'
+    database = [dbUriPub, dbUserPub, dbPwdPub]
+    dbschema = 'arp_nutzungsplanung_satge_v1'
+    models = 'SO_ARP_Nutzungsplanung_Publikation_20201005'
+    dataset = ili2pgDataset
+    dataFile = file(ili2pgDataset + "_pub.xtf")
+    disableValidation = true
+    finalizedBy deleteXtfFile_BFSNr
+}
+
+task importXTF_pub(type: Ili2pgImport, dependsOn: 'importXTF_stage') {
+    description = 'Import der umgebaute INTERLIS-Datei einer Gemeinde (BFS-Nr.) in das Schema arp_nutzungsplanung_pub.'
+    database = [dbUriPub, dbUserPub, dbPwdPub]
+    dbschema = 'arp_nutzungsplanung_pub_v1'
+    models = 'SO_ARP_Nutzungsplanung_Publikation_20201005'
+    dataset = ili2pgDataset
+    dataFile = file(ili2pgDataset + "_pub.xtf")
+    disableValidation = true
+}

--- a/arp_nutzungsplanung_pub/build.gradle
+++ b/arp_nutzungsplanung_pub/build.gradle
@@ -5,10 +5,9 @@
 import ch.so.agi.gretl.tasks.*
 import ch.so.agi.gretl.api.TransferSet
 
-
 apply plugin: 'ch.so.agi.gretl'
 
-defaultTasks "importXTF_Dataset_BFSNr", "importXTF_Kanton"
+defaultTasks "importXTF_pub"
 
 task deleteData_transfer_pub (type: SqlExecutor) {
     description = "Löscht/leert die Daten aus dem Schema arp_nutzungsplanung_transfer_pub."
@@ -27,33 +26,41 @@ task exportData (type: Ili2pgExport, dependsOn: 'transferData') {
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     dbschema = 'arp_nutzungsplanung_transfer_pub_v1'
     models = 'SO_ARP_Nutzungsplanung_Publikation_20201005'
-    dataFile= file(ili2pgDataset + "_pub.xtf")
+    dataFile= file(bfsnr + "_pub.xtf")
     disableValidation = true
 }
 
 task validateData(type: IliValidator, dependsOn: 'exportData') {
     description = "Validiert die exportierten INTERLIS-Datei gegen das Modell."
-    dataFiles = file(ili2pgDataset + ".xtf")
+    dataFiles = file(bfsnr + "_pub.xtf")
     failOnError = true
 }
 
-task importXTF_stage(type: Ili2pgImport, dependsOn: 'validateData') {
-    description = 'Import der umgebaute INTERLIS-Datei einer Gemeinde (BFS-Nr.) in das Schema arp_nutzungsplanung_stage.'
+task importXTF_stage(type: Ili2pgReplace, dependsOn: 'validateData') {
+    description = 'Import der umgebaute INTERLIS-Datei einer Gemeinde (BFS-Nr.) in das Schema arp_nutzungsplanung_staging.'
     database = [dbUriPub, dbUserPub, dbPwdPub]
-    dbschema = 'arp_nutzungsplanung_satge_v1'
+    dbschema = 'arp_nutzungsplanung_staging_v1'
     models = 'SO_ARP_Nutzungsplanung_Publikation_20201005'
-    dataset = ili2pgDataset
-    dataFile = file(ili2pgDataset + "_pub.xtf")
+    dataset = bfsnr
+    dataFile = file(bfsnr + "_pub.xtf")
     disableValidation = true
-    finalizedBy deleteXtfFile_BFSNr
 }
 
-task importXTF_pub(type: Ili2pgImport, dependsOn: 'importXTF_stage') {
+task delete_Dataset_stage(type: Ili2pgDelete) {
+    description = "Löscht Daten mit dem angegebenen Datasetname (BFS-Nr.) aus dem Schema arp_nutzungsplanung_staging"
+    database = [dbUriPub, dbUserPub, dbPwdPub]
+    models = 'SO_ARP_Nutzungsplanung_Publikation_20201005'
+    dbschema = 'arp_nutzungsplanung_staging_v1'
+    dataset = bfsnr
+}
+
+task importXTF_pub(type: Ili2pgReplace, dependsOn: 'importXTF_stage') {
     description = 'Import der umgebaute INTERLIS-Datei einer Gemeinde (BFS-Nr.) in das Schema arp_nutzungsplanung_pub.'
     database = [dbUriPub, dbUserPub, dbPwdPub]
     dbschema = 'arp_nutzungsplanung_pub_v1'
     models = 'SO_ARP_Nutzungsplanung_Publikation_20201005'
-    dataset = ili2pgDataset
-    dataFile = file(ili2pgDataset + "_pub.xtf")
+    dataset = bfsnr
+    dataFile = file(bfsnr + "_pub.xtf")
     disableValidation = true
+    finalizedBy delete_Dataset_stage
 }

--- a/arp_nutzungsplanung_pub/delete_arp_nutzungsplanung_transfer_pub.sql
+++ b/arp_nutzungsplanung_pub/delete_arp_nutzungsplanung_transfer_pub.sql
@@ -19,21 +19,21 @@ DELETE FROM
 ;
 --Erschliessung Fläche
 DELETE FROM
-    arp_nutzungsplanung_transfer_pub_v1.erschlssngsplnung_erschliessung_flaechenobjekt
+    arp_nutzungsplanung_transfer_pub_v1.nutzungsplanung_erschliessung_flaechenobjekt
 ;
 --Erschliessung Linie
 DELETE FROM
-    arp_nutzungsplanung_transfer_pub_v1.erschlssngsplnung_erschliessung_linienobjekt
+    arp_nutzungsplanung_transfer_pub_v1.nutzungsplanung_erschliessung_linienobjekt
 ;
 
 --Erschliessung Punkt
 DELETE FROM
-    arp_nutzungsplanung_transfer_pub_v1.erschlssngsplnung_erschliessung_punktobjekt
+    arp_nutzungsplanung_transfer_pub_v1.nutzungsplanung_erschliessung_punktobjekt
 ;
 
 -- Lärmempfindlichkeitsstufen
 DELETE FROM
-    arp_nutzungsplanung_transfer_pub_v1.laermmpfhktsstfen_empfindlichkeitsstufe
+    arp_nutzungsplanung_transfer_pub_v1.nutzungsplanung_empfindlichkeitsstufe
 ;
 
 -- Basket / Dataset 

--- a/arp_nutzungsplanung_pub/delete_arp_nutzungsplanung_transfer_pub.sql
+++ b/arp_nutzungsplanung_pub/delete_arp_nutzungsplanung_transfer_pub.sql
@@ -1,0 +1,45 @@
+-- Grundnutzung
+DELETE FROM
+    arp_nutzungsplanung_transfer_pub_v1.nutzungsplanung_grundnutzung
+;
+
+--überlagernde Fläche
+DELETE FROM
+    arp_nutzungsplanung_transfer_pub_v1.nutzungsplanung_ueberlagernd_flaeche
+;
+
+--überlagernde Linie
+DELETE FROM
+    arp_nutzungsplanung_transfer_pub_v1.nutzungsplanung_ueberlagernd_linie
+;
+
+--überlagernde Punkt
+DELETE FROM
+    arp_nutzungsplanung_transfer_pub_v1.nutzungsplanung_ueberlagernd_punkt
+;
+--Erschliessung Fläche
+DELETE FROM
+    arp_nutzungsplanung_transfer_pub_v1.erschlssngsplnung_erschliessung_flaechenobjekt
+;
+--Erschliessung Linie
+DELETE FROM
+    arp_nutzungsplanung_transfer_pub_v1.erschlssngsplnung_erschliessung_linienobjekt
+;
+
+--Erschliessung Punkt
+DELETE FROM
+    arp_nutzungsplanung_transfer_pub_v1.erschlssngsplnung_erschliessung_punktobjekt
+;
+
+-- Lärmempfindlichkeitsstufen
+DELETE FROM
+    arp_nutzungsplanung_transfer_pub_v1.laermmpfhktsstfen_empfindlichkeitsstufe
+;
+
+-- Basket / Dataset 
+DELETE FROM
+    arp_nutzungsplanung_transfer_pub_v1.t_ili2db_basket
+;
+DELETE FROM
+    arp_nutzungsplanung_transfer_pub_v1.t_ili2db_dataset
+;

--- a/arp_nutzungsplanung_pub/insert_arp_nutzungsplanung_transfer_pub.sql
+++ b/arp_nutzungsplanung_pub/insert_arp_nutzungsplanung_transfer_pub.sql
@@ -1,0 +1,1032 @@
+-- Datenumbau ins Modell SO_ARP_Nutzungsplanung_Publikation_20201005.ili
+-- dataset
+INSERT INTO arp_nutzungsplanung_transfer_pub_v1.t_ili2db_dataset
+SELECT
+    t_id,
+    datasetname
+FROM
+    arp_nutzungsplanung_v1.t_ili2db_dataset
+WHERE 
+   datasetname::int4 = $bfsnr
+;
+
+-- basket
+INSERT INTO arp_nutzungsplanung_transfer_pub_v1.t_ili2db_basket
+SELECT
+    basket.t_id,
+    basket.dataset,
+    replace (basket.topic, 'SO_ARP_Nutzungsplanung_Nachfuehrung_20201005', 'SO_ARP_Nutzungsplanung_Publikation_20201005')AS topic,
+    basket.t_ili_tid,
+    basket.attachmentkey,
+    basket.domains
+FROM
+    arp_nutzungsplanung_v1.t_ili2db_basket AS basket 
+    LEFT JOIN arp_nutzungsplanung_v1.t_ili2db_dataset AS dataset
+    ON basket.dataset=dataset.t_id
+WHERE 
+    topic = 'SO_ARP_Nutzungsplanung_Nachfuehrung_20201005.Nutzungsplanung'
+AND
+    dataset.datasetname::int4 = $bfsnr
+;
+
+--Grundnutzung
+WITH dokumente AS (
+    SELECT
+        t_id,
+        dokumentid,
+        titel,
+        offiziellertitel,
+        abkuerzung,
+        offiziellenr,
+        kanton,
+        gemeinde,
+        publiziertAb,
+        rechtsstatus,
+        textimweb,
+        bemerkungen,
+        rechtsvorschrift,
+        publiziertBis
+    FROM
+        arp_nutzungsplanung_v1.rechtsvorschrften_dokument
+    WHERE
+        t_datasetname::int4=$bfsnr
+),
+json_documents AS (
+    SELECT
+  (
+    row_to_json
+    ((
+        SELECT
+            docs
+        FROM 
+        (
+            SELECT
+                dokumentid AS "Dokument_ID", 
+                titel AS "Titel", 
+                offiziellertitel AS "Offizieller_Titel", 
+                abkuerzung AS "Abkuerzung",
+                offiziellenr AS "Offizielle_Nr", 
+                kanton AS "Kanton", 
+                gemeinde AS "Gemeinde", 
+                publiziertab AS "publiziert_ab", 
+                rechtsstatus AS "Rechtsstatus",
+                textimweb AS "Text_im_Web",
+                bemerkungen AS "Bemerkungen", 
+                rechtsvorschrift AS "Rechtsvorschrift", 
+                'SO_Nutzungsplanung_Publikation_20190909.Nutzungsplanung.Dokument' AS "@type"
+        ) docs
+    ))
+  )::text AS json_dok,
+        t_id
+    FROM
+        dokumente
+),
+
+typ_grundnutzung_json_dokument_agg AS (
+    SELECT
+        typ_grundnutzung_t_id,
+        '[' || dokumente::varchar || ']' AS dokumente
+    FROM
+    (
+        SELECT
+            dokument_grundnutzung.typ_grundnutzung AS typ_grundnutzung_t_id,
+            string_agg(json_dok, ',') AS dokumente
+        FROM
+            json_documents
+            LEFT JOIN arp_nutzungsplanung_v1.nutzungsplanung_typ_grundnutzung_dokument AS dokument_grundnutzung
+            ON dokument_grundnutzung.dokument = json_documents.t_id
+        GROUP BY
+        dokument_grundnutzung.typ_grundnutzung
+    ) AS a
+),
+
+grundnutzung AS (
+    SELECT 
+        grundnutzung.t_id,
+        grundnutzung.t_ili_tid,
+        typ.bezeichnung AS typ_bezeichnung,
+        typ.abkuerzung AS typ_abkuerzung,
+        typ.verbindlichkeit AS typ_verbindlichkeit,
+        typ.bemerkungen AS typ_bemerkungen,
+        typ.typ_kt,
+        typ.code_kommunal AS typ_code_kommunal,
+        typ.nutzungsziffer AS typ_nutzungsziffer,
+        typ.nutzungsziffer_art AS typ_nutzungsziffer_art,
+        typ.geschosszahl AS typ_geschosszahl,
+        typ.t_id AS typ_t_id,
+        grundnutzung.geometrie,
+        grundnutzung.geschaefts_nummer,
+        grundnutzung.rechtsstatus,
+        grundnutzung.publiziertab,
+        grundnutzung.bemerkungen,
+        grundnutzung.erfasser,
+        grundnutzung.datum AS datum_erfassung,
+        grundnutzung.t_datasetname AS bfs_nr,
+        grundnutzung.publiziertbis
+    FROM
+        arp_nutzungsplanung_v1.nutzungsplanung_grundnutzung AS grundnutzung
+        LEFT JOIN arp_nutzungsplanung_v1.nutzungsplanung_typ_grundnutzung AS typ
+        ON grundnutzung.typ_grundnutzung = typ.t_id
+    WHERE
+        grundnutzung.t_datasetname::int4=$bfsnr
+)
+
+INSERT INTO arp_nutzungsplanung_transfer_pub_v1.nutzungsplanung_grundnutzung
+SELECT
+    grundnutzung.t_id,
+    grundnutzung.t_ili_tid,
+    grundnutzung.typ_bezeichnung,
+    grundnutzung.typ_abkuerzung,
+    grundnutzung.typ_verbindlichkeit,
+    grundnutzung.typ_bemerkungen,
+    grundnutzung.typ_kt,
+    grundnutzung.typ_code_kommunal::int4,
+    grundnutzung.typ_nutzungsziffer,
+    grundnutzung.typ_nutzungsziffer_art,
+    grundnutzung.typ_geschosszahl,
+    grundnutzung.geometrie,
+    grundnutzung.geschaefts_nummer,
+    grundnutzung.rechtsstatus,
+    grundnutzung.publiziertab,
+    grundnutzung.bemerkungen,
+    grundnutzung.erfasser,
+    grundnutzung.datum_erfassung,
+    typ_grundnutzung_json_dokument_agg.dokumente::jsonb AS dokumente,
+    $bfsnr AS bfs_nr,
+    grundnutzung.publiziertbis
+FROM
+    grundnutzung
+    LEFT JOIN typ_grundnutzung_json_dokument_agg
+    ON grundnutzung.typ_t_id= typ_grundnutzung_json_dokument_agg.typ_grundnutzung_t_id
+;
+--überlagernd Fläche
+WITH dokumente AS (
+    SELECT
+        t_id,
+        dokumentid,
+        titel,
+        offiziellertitel,
+        abkuerzung,
+        offiziellenr,
+        kanton,
+        gemeinde,
+        publiziertAb,
+        rechtsstatus,
+        textimweb,
+        bemerkungen,
+        rechtsvorschrift,
+        publiziertBis
+    FROM
+        arp_nutzungsplanung_v1.rechtsvorschrften_dokument
+    WHERE
+        t_datasetname::int4=$bfsnr    
+),
+json_documents AS (
+    SELECT
+  (
+    row_to_json
+    ((
+        SELECT
+            docs
+        FROM 
+        (
+            SELECT
+                dokumentid AS "Dokument_ID", 
+                titel AS "Titel", 
+                offiziellertitel AS "Offizieller_Titel", 
+                abkuerzung AS "Abkuerzung",
+                offiziellenr AS "Offizielle_Nr", 
+                kanton AS "Kanton", 
+                gemeinde AS "Gemeinde", 
+                publiziertab AS "publiziert_ab", 
+                rechtsstatus AS "Rechtsstatus",
+                textimweb AS "Text_im_Web",
+                bemerkungen AS "Bemerkungen", 
+                rechtsvorschrift AS "Rechtsvorschrift", 
+                'SO_Nutzungsplanung_Publikation_20190909.Nutzungsplanung.Dokument' AS "@type"
+        ) docs
+    ))
+  )::text AS json_dok,
+        t_id
+    FROM
+        dokumente
+),
+
+typ_ueberlagernd_flaeche_json_dokument_agg AS (
+    SELECT
+        typ_ueberlagernd_flaeche_t_id,
+        '[' || dokumente::varchar || ']' AS dokumente
+    FROM
+    (
+        SELECT
+            dokument_ueberlagernd_flaeche.typ_ueberlagernd_flaeche AS typ_ueberlagernd_flaeche_t_id,
+            string_agg(json_dok, ',') AS dokumente
+        FROM
+            json_documents
+            LEFT JOIN arp_nutzungsplanung_v1.nutzungsplanung_typ_ueberlagernd_flaeche_dokument AS dokument_ueberlagernd_flaeche
+            ON dokument_ueberlagernd_flaeche.dokument = json_documents.t_id
+        GROUP BY
+        dokument_ueberlagernd_flaeche.typ_ueberlagernd_flaeche
+    ) AS a
+),
+
+ueberlagernd_flaeche AS (
+    SELECT 
+        ueberlagernd_flaeche.t_id,
+        ueberlagernd_flaeche.t_ili_tid,
+        typ.bezeichnung AS typ_bezeichnung,
+        typ.abkuerzung AS typ_abkuerzung,
+        typ.verbindlichkeit AS typ_verbindlichkeit,
+        typ.bemerkungen AS typ_bemerkungen,
+        typ.typ_kt,
+        typ.code_kommunal AS typ_code_kommunal,
+        typ.t_id AS typ_t_id,
+        ueberlagernd_flaeche.geometrie,
+        ueberlagernd_flaeche.geschaefts_nummer,
+        ueberlagernd_flaeche.rechtsstatus,
+        ueberlagernd_flaeche.publiziertab,
+        ueberlagernd_flaeche.bemerkungen,
+        ueberlagernd_flaeche.erfasser,
+        ueberlagernd_flaeche.datum AS datum_erfassung,
+        ueberlagernd_flaeche.t_datasetname AS bfs_nr,
+        ueberlagernd_flaeche.publiziertbis
+    FROM
+        arp_nutzungsplanung_v1.nutzungsplanung_ueberlagernd_flaeche AS ueberlagernd_flaeche
+        LEFT JOIN arp_nutzungsplanung_v1.nutzungsplanung_typ_ueberlagernd_flaeche AS typ
+        ON ueberlagernd_flaeche.typ_ueberlagernd_flaeche= typ.t_id
+    WHERE
+        ueberlagernd_flaeche.t_datasetname::int4=$bfsnr
+)
+
+INSERT INTO arp_nutzungsplanung_transfer_pub_v1.nutzungsplanung_ueberlagernd_flaeche
+SELECT
+    ueberlagernd_flaeche.t_id,
+    ueberlagernd_flaeche.t_ili_tid,
+    ueberlagernd_flaeche.typ_bezeichnung,
+    ueberlagernd_flaeche.typ_abkuerzung,
+    ueberlagernd_flaeche.typ_verbindlichkeit,
+    ueberlagernd_flaeche.typ_bemerkungen,
+    ueberlagernd_flaeche.typ_kt,
+    ueberlagernd_flaeche.typ_code_kommunal::int4,
+    ueberlagernd_flaeche.geometrie,
+    ueberlagernd_flaeche.geschaefts_nummer,
+    ueberlagernd_flaeche.rechtsstatus,
+    ueberlagernd_flaeche.publiziertab,
+    ueberlagernd_flaeche.bemerkungen,
+    ueberlagernd_flaeche.erfasser,
+    ueberlagernd_flaeche.datum_erfassung,
+    typ_ueberlagernd_flaeche_json_dokument_agg.dokumente::jsonb AS dokumente,
+    $bfsnr AS bfs_nr,
+    ueberlagernd_flaeche.publiziertbis
+FROM
+    ueberlagernd_flaeche
+    LEFT JOIN typ_ueberlagernd_flaeche_json_dokument_agg
+    ON ueberlagernd_flaeche.typ_t_id= typ_ueberlagernd_flaeche_json_dokument_agg.typ_ueberlagernd_flaeche_t_id
+;
+
+--überlagernd Linie
+WITH dokumente AS (
+    SELECT
+        t_id,
+        dokumentid,
+        titel,
+        offiziellertitel,
+        abkuerzung,
+        offiziellenr,
+        kanton,
+        gemeinde,
+        publiziertAb,
+        rechtsstatus,
+        textimweb,
+        bemerkungen,
+        rechtsvorschrift,
+        publiziertBis
+    FROM
+        arp_nutzungsplanung_v1.rechtsvorschrften_dokument
+    WHERE
+        t_datasetname::int4=$bfsnr    
+),
+json_documents AS (
+    SELECT
+  (
+    row_to_json
+    ((
+        SELECT
+            docs
+        FROM 
+        (
+            SELECT
+                dokumentid AS "Dokument_ID", 
+                titel AS "Titel", 
+                offiziellertitel AS "Offizieller_Titel", 
+                abkuerzung AS "Abkuerzung",
+                offiziellenr AS "Offizielle_Nr", 
+                kanton AS "Kanton", 
+                gemeinde AS "Gemeinde", 
+                publiziertab AS "publiziert_ab", 
+                rechtsstatus AS "Rechtsstatus",
+                textimweb AS "Text_im_Web",
+                bemerkungen AS "Bemerkungen", 
+                rechtsvorschrift AS "Rechtsvorschrift", 
+                'SO_Nutzungsplanung_Publikation_20190909.Nutzungsplanung.Dokument' AS "@type"
+        ) docs
+    ))
+  )::text AS json_dok,
+        t_id
+    FROM
+        dokumente
+),
+
+typ_ueberlagernd_linie_json_dokument_agg AS (
+    SELECT
+        typ_ueberlagernd_linie_t_id,
+        '[' || dokumente::varchar || ']' AS dokumente
+    FROM
+    (
+        SELECT
+            dokument_ueberlagernd_linie.typ_ueberlagernd_linie AS typ_ueberlagernd_linie_t_id,
+            string_agg(json_dok, ',') AS dokumente
+        FROM
+            json_documents
+            LEFT JOIN arp_nutzungsplanung_v1.nutzungsplanung_typ_ueberlagernd_linie_dokument AS dokument_ueberlagernd_linie
+            ON dokument_ueberlagernd_linie.dokument = json_documents.t_id
+        GROUP BY
+        dokument_ueberlagernd_linie.typ_ueberlagernd_linie
+    ) AS a
+),
+
+ueberlagernd_linie AS (
+    SELECT 
+        ueberlagernd_linie.t_id,
+        ueberlagernd_linie.t_ili_tid,
+        typ.bezeichnung AS typ_bezeichnung,
+        typ.abkuerzung AS typ_abkuerzung,
+        typ.verbindlichkeit AS typ_verbindlichkeit,
+        typ.bemerkungen AS typ_bemerkungen,
+        typ.typ_kt,
+        typ.code_kommunal AS typ_code_kommunal,
+        typ.t_id AS typ_t_id,
+        ueberlagernd_linie.geometrie,
+        ueberlagernd_linie.geschaefts_nummer,
+        ueberlagernd_linie.rechtsstatus,
+        ueberlagernd_linie.publiziertab,
+        ueberlagernd_linie.bemerkungen,
+        ueberlagernd_linie.erfasser,
+        ueberlagernd_linie.datum AS datum_erfassung,
+        ueberlagernd_linie.t_datasetname AS bfs_nr,
+        ueberlagernd_linie.publiziertbis
+    FROM
+        arp_nutzungsplanung_v1.nutzungsplanung_ueberlagernd_linie AS ueberlagernd_linie
+        LEFT JOIN arp_nutzungsplanung_v1.nutzungsplanung_typ_ueberlagernd_linie AS typ
+        ON ueberlagernd_linie.typ_ueberlagernd_linie= typ.t_id
+    WHERE
+        ueberlagernd_linie.t_datasetname::int4=$bfsnr
+)
+
+INSERT INTO arp_nutzungsplanung_transfer_pub_v1.nutzungsplanung_ueberlagernd_linie
+SELECT
+    ueberlagernd_linie.t_id,
+    ueberlagernd_linie.t_ili_tid,
+    ueberlagernd_linie.typ_bezeichnung,
+    ueberlagernd_linie.typ_abkuerzung,
+    ueberlagernd_linie.typ_verbindlichkeit,
+    ueberlagernd_linie.typ_bemerkungen,
+    ueberlagernd_linie.typ_kt,
+    ueberlagernd_linie.typ_code_kommunal::int4,
+    ueberlagernd_linie.geometrie,
+    ueberlagernd_linie.geschaefts_nummer,
+    ueberlagernd_linie.rechtsstatus,
+    ueberlagernd_linie.publiziertab,
+    ueberlagernd_linie.bemerkungen,
+    ueberlagernd_linie.erfasser,
+    ueberlagernd_linie.datum_erfassung,
+    typ_ueberlagernd_linie_json_dokument_agg.dokumente::jsonb AS dokumente,
+    $bfsnr AS bfs_nr,
+    ueberlagernd_linie.publiziertbis
+FROM
+    ueberlagernd_linie
+    LEFT JOIN typ_ueberlagernd_linie_json_dokument_agg
+    ON ueberlagernd_linie.typ_t_id= typ_ueberlagernd_linie_json_dokument_agg.typ_ueberlagernd_linie_t_id
+;
+
+--überlagernd Punkt
+WITH dokumente AS (
+    SELECT
+        t_id,
+        dokumentid,
+        titel,
+        offiziellertitel,
+        abkuerzung,
+        offiziellenr,
+        kanton,
+        gemeinde,
+        publiziertAb,
+        rechtsstatus,
+        textimweb,
+        bemerkungen,
+        rechtsvorschrift,
+        publiziertBis
+    FROM
+        arp_nutzungsplanung_v1.rechtsvorschrften_dokument
+    WHERE
+        t_datasetname::int4=$bfsnr    
+),
+json_documents AS (
+    SELECT
+  (
+    row_to_json
+    ((
+        SELECT
+            docs
+        FROM 
+        (
+            SELECT
+                dokumentid AS "Dokument_ID", 
+                titel AS "Titel", 
+                offiziellertitel AS "Offizieller_Titel", 
+                abkuerzung AS "Abkuerzung",
+                offiziellenr AS "Offizielle_Nr", 
+                kanton AS "Kanton", 
+                gemeinde AS "Gemeinde", 
+                publiziertab AS "publiziert_ab", 
+                rechtsstatus AS "Rechtsstatus",
+                textimweb AS "Text_im_Web",
+                bemerkungen AS "Bemerkungen", 
+                rechtsvorschrift AS "Rechtsvorschrift", 
+                'SO_Nutzungsplanung_Publikation_20190909.Nutzungsplanung.Dokument' AS "@type"
+        ) docs
+    ))
+  )::text AS json_dok,
+        t_id
+    FROM
+        dokumente
+),
+
+typ_ueberlagernd_punkt_json_dokument_agg AS (
+    SELECT
+        typ_ueberlagernd_punkt_t_id,
+        '[' || dokumente::varchar || ']' AS dokumente
+    FROM
+    (
+        SELECT
+            dokument_ueberlagernd_punkt.typ_ueberlagernd_punkt AS typ_ueberlagernd_punkt_t_id,
+            string_agg(json_dok, ',') AS dokumente
+        FROM
+            json_documents
+            LEFT JOIN arp_nutzungsplanung_v1.nutzungsplanung_typ_ueberlagernd_punkt_dokument AS dokument_ueberlagernd_punkt
+            ON dokument_ueberlagernd_punkt.dokument = json_documents.t_id
+        GROUP BY
+        dokument_ueberlagernd_punkt.typ_ueberlagernd_punkt
+    ) AS a
+),
+
+ueberlagernd_punkt AS (
+    SELECT 
+        ueberlagernd_punkt.t_id,
+        ueberlagernd_punkt.t_ili_tid,
+        typ.bezeichnung AS typ_bezeichnung,
+        typ.abkuerzung AS typ_abkuerzung,
+        typ.verbindlichkeit AS typ_verbindlichkeit,
+        typ.bemerkungen AS typ_bemerkungen,
+        typ.typ_kt,
+        typ.code_kommunal AS typ_code_kommunal,
+        typ.t_id AS typ_t_id,
+        ueberlagernd_punkt.geometrie,
+        ueberlagernd_punkt.geschaefts_nummer,
+        ueberlagernd_punkt.rechtsstatus,
+        ueberlagernd_punkt.publiziertab,
+        ueberlagernd_punkt.bemerkungen,
+        ueberlagernd_punkt.erfasser,
+        ueberlagernd_punkt.datum AS datum_erfassung,
+        ueberlagernd_punkt.t_datasetname AS bfs_nr,
+        ueberlagernd_punkt.publiziertbis
+    FROM
+        arp_nutzungsplanung_v1.nutzungsplanung_ueberlagernd_punkt AS ueberlagernd_punkt
+        LEFT JOIN arp_nutzungsplanung_v1.nutzungsplanung_typ_ueberlagernd_punkt AS typ
+        ON ueberlagernd_punkt.typ_ueberlagernd_punkt= typ.t_id
+    WHERE
+        ueberlagernd_punkt.t_datasetname::int4=$bfsnr
+)
+
+INSERT INTO arp_nutzungsplanung_transfer_pub_v1.nutzungsplanung_ueberlagernd_punkt
+SELECT
+    ueberlagernd_punkt.t_id,
+    ueberlagernd_punkt.t_ili_tid,
+    ueberlagernd_punkt.typ_bezeichnung,
+    ueberlagernd_punkt.typ_abkuerzung,
+    ueberlagernd_punkt.typ_verbindlichkeit,
+    ueberlagernd_punkt.typ_bemerkungen,
+    ueberlagernd_punkt.typ_kt,
+    ueberlagernd_punkt.typ_code_kommunal::int4,
+    ueberlagernd_punkt.geometrie,
+    ueberlagernd_punkt.geschaefts_nummer,
+    ueberlagernd_punkt.rechtsstatus,
+    ueberlagernd_punkt.publiziertab,
+    ueberlagernd_punkt.bemerkungen,
+    ueberlagernd_punkt.erfasser,
+    ueberlagernd_punkt.datum_erfassung,
+    typ_ueberlagernd_punkt_json_dokument_agg.dokumente::jsonb AS dokumente,
+    $bfsnr AS bfs_nr,
+    ueberlagernd_punkt.publiziertbis
+FROM
+    ueberlagernd_punkt
+    LEFT JOIN typ_ueberlagernd_punkt_json_dokument_agg
+    ON ueberlagernd_punkt.typ_t_id= typ_ueberlagernd_punkt_json_dokument_agg.typ_ueberlagernd_punkt_t_id
+;
+
+
+--Erschliesung Fläche
+WITH dokumente AS (
+    SELECT
+        t_id,
+        dokumentid,
+        titel,
+        offiziellertitel,
+        abkuerzung,
+        offiziellenr,
+        kanton,
+        gemeinde,
+        publiziertAb,
+        rechtsstatus,
+        textimweb,
+        bemerkungen,
+        rechtsvorschrift,
+        publiziertBis
+    FROM
+        arp_nutzungsplanung_v1.rechtsvorschrften_dokument
+    WHERE
+        t_datasetname::int4=$bfsnr    
+),
+json_documents AS (
+    SELECT
+  (
+    row_to_json
+    ((
+        SELECT
+            docs
+        FROM 
+        (
+            SELECT
+                dokumentid AS "Dokument_ID", 
+                titel AS "Titel", 
+                offiziellertitel AS "Offizieller_Titel", 
+                abkuerzung AS "Abkuerzung",
+                offiziellenr AS "Offizielle_Nr", 
+                kanton AS "Kanton", 
+                gemeinde AS "Gemeinde", 
+                publiziertab AS "publiziert_ab", 
+                rechtsstatus AS "Rechtsstatus",
+                textimweb AS "Text_im_Web",
+                bemerkungen AS "Bemerkungen", 
+                rechtsvorschrift AS "Rechtsvorschrift", 
+                'SO_Nutzungsplanung_Publikation_20190909.Nutzungsplanung.Dokument' AS "@type"
+        ) docs
+    ))
+  )::text AS json_dok,
+        t_id
+    FROM
+        dokumente
+),
+
+typ_erschliessung_flaechenobjekt_json_dokument_agg AS (
+    SELECT
+        typ_erschliessung_flaechenobjekt_t_id,
+        '[' || dokumente::varchar || ']' AS dokumente
+    FROM
+    (
+        SELECT
+            dokument_erschliessung_flaechenobjekt.typ_erschliessung_flaechenobjekt AS typ_erschliessung_flaechenobjekt_t_id,
+            string_agg(json_dok, ',') AS dokumente
+        FROM
+            json_documents
+            LEFT JOIN arp_nutzungsplanung_v1.erschlssngsplnung_typ_erschliessung_flaechenobjekt_dokument AS dokument_erschliessung_flaechenobjekt
+            ON dokument_erschliessung_flaechenobjekt.dokument = json_documents.t_id
+        GROUP BY
+        dokument_erschliessung_flaechenobjekt.typ_erschliessung_flaechenobjekt
+    ) AS a
+),
+
+erschliessung_flaechenobjekt AS (
+    SELECT 
+        erschliessung_flaechenobjekt.t_id,
+        erschliessung_flaechenobjekt.t_ili_tid,
+        typ.bezeichnung AS typ_bezeichnung,
+        typ.abkuerzung AS typ_abkuerzung,
+        typ.verbindlichkeit AS typ_verbindlichkeit,
+        typ.bemerkungen AS typ_bemerkungen,
+        typ.typ_kt,
+        typ.code_kommunal AS typ_code_kommunal,
+        typ.t_id AS typ_t_id,
+        erschliessung_flaechenobjekt.geometrie,
+        erschliessung_flaechenobjekt.geschaefts_nummer,
+        erschliessung_flaechenobjekt.rechtsstatus,
+        erschliessung_flaechenobjekt.publiziertab,
+        erschliessung_flaechenobjekt.bemerkungen,
+        erschliessung_flaechenobjekt.erfasser,
+        erschliessung_flaechenobjekt.datum AS datum_erfassung,
+        erschliessung_flaechenobjekt.t_datasetname AS bfs_nr,
+        erschliessung_flaechenobjekt.publiziertbis
+    FROM
+        arp_nutzungsplanung_v1.erschlssngsplnung_erschliessung_flaechenobjekt AS erschliessung_flaechenobjekt
+        LEFT JOIN arp_nutzungsplanung_v1.erschlssngsplnung_typ_erschliessung_flaechenobjekt AS typ
+        ON erschliessung_flaechenobjekt.typ_erschliessung_flaechenobjekt= typ.t_id
+    WHERE
+        erschliessung_flaechenobjekt.t_datasetname::int4=$bfsnr
+)
+
+INSERT INTO arp_nutzungsplanung_transfer_pub_v1.nutzungsplanung_erschliessung_flaechenobjekt
+SELECT
+    erschliessung_flaechenobjekt.t_id,
+    erschliessung_flaechenobjekt.t_ili_tid,
+    erschliessung_flaechenobjekt.typ_bezeichnung,
+    erschliessung_flaechenobjekt.typ_abkuerzung,
+    erschliessung_flaechenobjekt.typ_verbindlichkeit,
+    erschliessung_flaechenobjekt.typ_bemerkungen,
+    erschliessung_flaechenobjekt.typ_kt,
+    erschliessung_flaechenobjekt.typ_code_kommunal::int4,
+    erschliessung_flaechenobjekt.geometrie,
+    erschliessung_flaechenobjekt.geschaefts_nummer,
+    erschliessung_flaechenobjekt.rechtsstatus,
+    erschliessung_flaechenobjekt.publiziertab,
+    erschliessung_flaechenobjekt.bemerkungen,
+    erschliessung_flaechenobjekt.erfasser,
+    erschliessung_flaechenobjekt.datum_erfassung,
+    typ_erschliessung_flaechenobjekt_json_dokument_agg.dokumente::jsonb AS dokumente,
+    $bfsnr AS bfs_nr,
+    erschliessung_flaechenobjekt.publiziertbis
+FROM
+    erschliessung_flaechenobjekt
+    LEFT JOIN typ_erschliessung_flaechenobjekt_json_dokument_agg
+    ON erschliessung_flaechenobjekt.typ_t_id= typ_erschliessung_flaechenobjekt_json_dokument_agg.typ_erschliessung_flaechenobjekt_t_id
+;
+
+--Erschliesung Linie
+WITH dokumente AS (
+    SELECT
+        t_id,
+        dokumentid,
+        titel,
+        offiziellertitel,
+        abkuerzung,
+        offiziellenr,
+        kanton,
+        gemeinde,
+        publiziertAb,
+        rechtsstatus,
+        textimweb,
+        bemerkungen,
+        rechtsvorschrift,
+        publiziertBis
+    FROM
+        arp_nutzungsplanung_v1.rechtsvorschrften_dokument
+    WHERE
+        t_datasetname::int4=$bfsnr    
+),
+json_documents AS (
+    SELECT
+  (
+    row_to_json
+    ((
+        SELECT
+            docs
+        FROM 
+        (
+            SELECT
+                dokumentid AS "Dokument_ID", 
+                titel AS "Titel", 
+                offiziellertitel AS "Offizieller_Titel", 
+                abkuerzung AS "Abkuerzung",
+                offiziellenr AS "Offizielle_Nr", 
+                kanton AS "Kanton", 
+                gemeinde AS "Gemeinde", 
+                publiziertab AS "publiziert_ab", 
+                rechtsstatus AS "Rechtsstatus",
+                textimweb AS "Text_im_Web",
+                bemerkungen AS "Bemerkungen", 
+                rechtsvorschrift AS "Rechtsvorschrift", 
+                'SO_Nutzungsplanung_Publikation_20190909.Nutzungsplanung.Dokument' AS "@type"
+        ) docs
+    ))
+  )::text AS json_dok,
+        t_id
+    FROM
+        dokumente
+),
+
+typ_erschliessung_linienobjekt_json_dokument_agg AS (
+    SELECT
+        typ_erschliessung_linienobjekt_t_id,
+        '[' || dokumente::varchar || ']' AS dokumente
+    FROM
+    (
+        SELECT
+            dokument_erschliessung_linienobjekt.typ_erschliessung_linienobjekt AS typ_erschliessung_linienobjekt_t_id,
+            string_agg(json_dok, ',') AS dokumente
+        FROM
+            json_documents
+            LEFT JOIN arp_nutzungsplanung_v1.erschlssngsplnung_typ_erschliessung_linienobjekt_dokument AS dokument_erschliessung_linienobjekt
+            ON dokument_erschliessung_linienobjekt.dokument = json_documents.t_id
+        GROUP BY
+        dokument_erschliessung_linienobjekt.typ_erschliessung_linienobjekt
+    ) AS a
+),
+
+erschliessung_linienobjekt AS (
+    SELECT 
+        erschliessung_linienobjekt.t_id,
+        erschliessung_linienobjekt.t_ili_tid,
+        typ.bezeichnung AS typ_bezeichnung,
+        typ.abkuerzung AS typ_abkuerzung,
+        typ.verbindlichkeit AS typ_verbindlichkeit,
+        typ.bemerkungen AS typ_bemerkungen,
+        typ.typ_kt,
+        typ.code_kommunal AS typ_code_kommunal,
+        typ.t_id AS typ_t_id,
+        erschliessung_linienobjekt.geometrie,
+        erschliessung_linienobjekt.geschaefts_nummer,
+        erschliessung_linienobjekt.rechtsstatus,
+        erschliessung_linienobjekt.publiziertab,
+        erschliessung_linienobjekt.bemerkungen,
+        erschliessung_linienobjekt.erfasser,
+        erschliessung_linienobjekt.datum AS datum_erfassung,
+        erschliessung_linienobjekt.t_datasetname AS bfs_nr,
+        erschliessung_linienobjekt.publiziertbis
+    FROM
+        arp_nutzungsplanung_v1.erschlssngsplnung_erschliessung_linienobjekt AS erschliessung_linienobjekt
+        LEFT JOIN arp_nutzungsplanung_v1.erschlssngsplnung_typ_erschliessung_linienobjekt AS typ
+        ON erschliessung_linienobjekt.typ_erschliessung_linienobjekt= typ.t_id
+    WHERE
+        erschliessung_linienobjekt.t_datasetname::int4=$bfsnr
+)
+
+INSERT INTO arp_nutzungsplanung_transfer_pub_v1.nutzungsplanung_erschliessung_linienobjekt
+SELECT
+    erschliessung_linienobjekt.t_id,
+    erschliessung_linienobjekt.t_ili_tid,
+    erschliessung_linienobjekt.typ_bezeichnung,
+    erschliessung_linienobjekt.typ_abkuerzung,
+    erschliessung_linienobjekt.typ_verbindlichkeit,
+    erschliessung_linienobjekt.typ_bemerkungen,
+    erschliessung_linienobjekt.typ_kt,
+    erschliessung_linienobjekt.typ_code_kommunal::int4,
+    erschliessung_linienobjekt.geometrie,
+    erschliessung_linienobjekt.geschaefts_nummer,
+    erschliessung_linienobjekt.rechtsstatus,
+    erschliessung_linienobjekt.publiziertab,
+    erschliessung_linienobjekt.bemerkungen,
+    erschliessung_linienobjekt.erfasser,
+    erschliessung_linienobjekt.datum_erfassung,
+    typ_erschliessung_linienobjekt_json_dokument_agg.dokumente::jsonb AS dokumente,
+    $bfsnr AS bfs_nr,
+    erschliessung_linienobjekt.publiziertbis
+FROM
+    erschliessung_linienobjekt
+    LEFT JOIN typ_erschliessung_linienobjekt_json_dokument_agg
+    ON erschliessung_linienobjekt.typ_t_id= typ_erschliessung_linienobjekt_json_dokument_agg.typ_erschliessung_linienobjekt_t_id
+;
+-- Erschliesung Punkt
+WITH dokumente AS (
+    SELECT
+        t_id,
+        dokumentid,
+        titel,
+        offiziellertitel,
+        abkuerzung,
+        offiziellenr,
+        kanton,
+        gemeinde,
+        publiziertAb,
+        rechtsstatus,
+        textimweb,
+        bemerkungen,
+        rechtsvorschrift,
+        publiziertBis
+    FROM
+        arp_nutzungsplanung_v1.rechtsvorschrften_dokument
+    WHERE
+        t_datasetname::int4=$bfsnr    
+),
+json_documents AS (
+    SELECT
+  (
+    row_to_json
+    ((
+        SELECT
+            docs
+        FROM 
+        (
+            SELECT
+                dokumentid AS "Dokument_ID", 
+                titel AS "Titel", 
+                offiziellertitel AS "Offizieller_Titel", 
+                abkuerzung AS "Abkuerzung",
+                offiziellenr AS "Offizielle_Nr", 
+                kanton AS "Kanton", 
+                gemeinde AS "Gemeinde", 
+                publiziertab AS "publiziert_ab", 
+                rechtsstatus AS "Rechtsstatus",
+                textimweb AS "Text_im_Web",
+                bemerkungen AS "Bemerkungen", 
+                rechtsvorschrift AS "Rechtsvorschrift", 
+                'SO_Nutzungsplanung_Publikation_20190909.Nutzungsplanung.Dokument' AS "@type"
+        ) docs
+    ))
+  )::text AS json_dok,
+        t_id
+    FROM
+        dokumente
+),
+
+typ_erschliessung_punktobjekt_json_dokument_agg AS (
+    SELECT
+        typ_erschliessung_punktobjekt_t_id,
+        '[' || dokumente::varchar || ']' AS dokumente
+    FROM
+    (
+        SELECT
+            dokument_erschliessung_punktobjekt.typ_erschliessung_punktobjekt AS typ_erschliessung_punktobjekt_t_id,
+            string_agg(json_dok, ',') AS dokumente
+        FROM
+            json_documents
+            LEFT JOIN arp_nutzungsplanung_v1.erschlssngsplnung_typ_erschliessung_punktobjekt_dokument AS dokument_erschliessung_punktobjekt
+            ON dokument_erschliessung_punktobjekt.dokument = json_documents.t_id
+        GROUP BY
+        dokument_erschliessung_punktobjekt.typ_erschliessung_punktobjekt
+    ) AS a
+),
+
+erschliessung_punktobjekt AS (
+    SELECT 
+        erschliessung_punktobjekt.t_id,
+        erschliessung_punktobjekt.t_ili_tid,
+        typ.bezeichnung AS typ_bezeichnung,
+        typ.abkuerzung AS typ_abkuerzung,
+        typ.verbindlichkeit AS typ_verbindlichkeit,
+        typ.bemerkungen AS typ_bemerkungen,
+        typ.typ_kt,
+        typ.code_kommunal AS typ_code_kommunal,
+        typ.t_id AS typ_t_id,
+        erschliessung_punktobjekt.geometrie,
+        erschliessung_punktobjekt.geschaefts_nummer,
+        erschliessung_punktobjekt.rechtsstatus,
+        erschliessung_punktobjekt.publiziertab,
+        erschliessung_punktobjekt.bemerkungen,
+        erschliessung_punktobjekt.erfasser,
+        erschliessung_punktobjekt.datum AS datum_erfassung,
+        erschliessung_punktobjekt.t_datasetname AS bfs_nr,
+        erschliessung_punktobjekt.publiziertbis
+    FROM
+        arp_nutzungsplanung_v1.erschlssngsplnung_erschliessung_punktobjekt AS erschliessung_punktobjekt
+        LEFT JOIN arp_nutzungsplanung_v1.erschlssngsplnung_typ_erschliessung_punktobjekt AS typ
+        ON erschliessung_punktobjekt.typ_erschliessung_punktobjekt= typ.t_id
+    WHERE
+        erschliessung_punktobjekt.t_datasetname::int4=$bfsnr
+)
+
+INSERT INTO arp_nutzungsplanung_transfer_pub_v1.nutzungsplanung_erschliessung_punktobjekt
+SELECT
+    erschliessung_punktobjekt.t_id,
+    erschliessung_punktobjekt.t_ili_tid,
+    erschliessung_punktobjekt.typ_bezeichnung,
+    erschliessung_punktobjekt.typ_abkuerzung,
+    erschliessung_punktobjekt.typ_verbindlichkeit,
+    erschliessung_punktobjekt.typ_bemerkungen,
+    erschliessung_punktobjekt.typ_kt,
+    erschliessung_punktobjekt.typ_code_kommunal::int4,
+    erschliessung_punktobjekt.geometrie,
+    erschliessung_punktobjekt.geschaefts_nummer,
+    erschliessung_punktobjekt.rechtsstatus,
+    erschliessung_punktobjekt.publiziertab,
+    erschliessung_punktobjekt.bemerkungen,
+    erschliessung_punktobjekt.erfasser,
+    erschliessung_punktobjekt.datum_erfassung,
+    typ_erschliessung_punktobjekt_json_dokument_agg.dokumente::jsonb AS dokumente,
+    $bfsnr AS bfs_nr,
+    erschliessung_punktobjekt.publiziertbis
+FROM
+    erschliessung_punktobjekt
+    LEFT JOIN typ_erschliessung_punktobjekt_json_dokument_agg
+    ON erschliessung_punktobjekt.typ_t_id= typ_erschliessung_punktobjekt_json_dokument_agg.typ_erschliessung_punktobjekt_t_id
+;
+-- Lärmempfindlichkeit
+WITH dokumente AS (
+    SELECT
+        t_id,
+        dokumentid,
+        titel,
+        offiziellertitel,
+        abkuerzung,
+        offiziellenr,
+        kanton,
+        gemeinde,
+        publiziertAb,
+        rechtsstatus,
+        textimweb,
+        bemerkungen,
+        rechtsvorschrift,
+        publiziertBis
+    FROM
+        arp_nutzungsplanung_v1.rechtsvorschrften_dokument
+    WHERE
+        t_datasetname::int4=$bfsnr    
+),
+json_documents AS (
+    SELECT
+  (
+    row_to_json
+    ((
+        SELECT
+            docs
+        FROM 
+        (
+            SELECT
+                dokumentid AS "Dokument_ID", 
+                titel AS "Titel", 
+                offiziellertitel AS "Offizieller_Titel", 
+                abkuerzung AS "Abkuerzung",
+                offiziellenr AS "Offizielle_Nr", 
+                kanton AS "Kanton", 
+                gemeinde AS "Gemeinde", 
+                publiziertab AS "publiziert_ab", 
+                rechtsstatus AS "Rechtsstatus",
+                textimweb AS "Text_im_Web",
+                bemerkungen AS "Bemerkungen", 
+                rechtsvorschrift AS "Rechtsvorschrift", 
+                'SO_Nutzungsplanung_Publikation_20190909.Nutzungsplanung.Dokument' AS "@type"
+        ) docs
+    ))
+  )::text AS json_dok,
+        t_id
+    FROM
+        dokumente
+),
+
+typ_empfindlichkeitsstufe_json_dokument_agg AS (
+    SELECT
+        typ_empfindlichkeitsstufe_t_id,
+        '[' || dokumente::varchar || ']' AS dokumente
+    FROM
+    (
+        SELECT
+            dokument_empfindlichkeitsstufe.typ_empfindlichkeitsstufen AS typ_empfindlichkeitsstufe_t_id,
+            string_agg(json_dok, ',') AS dokumente
+        FROM
+            json_documents
+            LEFT JOIN arp_nutzungsplanung_v1.laermmpfhktsstfen_typ_empfindlichkeitsstufe_dokument AS dokument_empfindlichkeitsstufe
+            ON dokument_empfindlichkeitsstufe.dokument = json_documents.t_id
+        GROUP BY
+        dokument_empfindlichkeitsstufe.typ_empfindlichkeitsstufen
+    ) AS a
+),
+
+empfindlichkeitsstufe AS (
+    SELECT 
+        empfindlichkeitsstufe.t_id,
+        empfindlichkeitsstufe.t_ili_tid,
+        typ.bezeichnung AS typ_bezeichnung,
+        typ.abkuerzung AS typ_abkuerzung,
+        typ.verbindlichkeit AS typ_verbindlichkeit,
+        typ.bemerkungen AS typ_bemerkungen,
+        typ.typ_kt,
+        typ.t_id AS typ_t_id,
+        empfindlichkeitsstufe.geometrie,
+        empfindlichkeitsstufe.geschaefts_nummer,
+        empfindlichkeitsstufe.rechtsstatus,
+        empfindlichkeitsstufe.publiziertab,
+        empfindlichkeitsstufe.bemerkungen,
+        empfindlichkeitsstufe.erfasser,
+        empfindlichkeitsstufe.datum AS datum_erfassung,
+        empfindlichkeitsstufe.t_datasetname AS bfs_nr,
+        empfindlichkeitsstufe.publiziertbis
+    FROM
+        arp_nutzungsplanung_v1.laermmpfhktsstfen_empfindlichkeitsstufe AS empfindlichkeitsstufe
+        LEFT JOIN arp_nutzungsplanung_v1.laermmpfhktsstfen_typ_empfindlichkeitsstufe AS typ
+        ON empfindlichkeitsstufe.typ_empfindlichkeitsstufen= typ.t_id
+    WHERE
+        empfindlichkeitsstufe.t_datasetname::int4=$bfsnr
+)
+
+INSERT INTO arp_nutzungsplanung_transfer_pub_v1.nutzungsplanung_empfindlichkeitsstufe
+SELECT
+    empfindlichkeitsstufe.t_id,
+    empfindlichkeitsstufe.t_ili_tid,
+    empfindlichkeitsstufe.geometrie,
+    empfindlichkeitsstufe.geschaefts_nummer,
+    empfindlichkeitsstufe.rechtsstatus,
+    empfindlichkeitsstufe.publiziertab,
+    empfindlichkeitsstufe.bemerkungen,
+    empfindlichkeitsstufe.erfasser,
+    empfindlichkeitsstufe.datum_erfassung,
+    empfindlichkeitsstufe.publiziertbis,
+    empfindlichkeitsstufe.typ_bezeichnung,
+    empfindlichkeitsstufe.typ_abkuerzung,
+    empfindlichkeitsstufe.typ_verbindlichkeit,
+    empfindlichkeitsstufe.typ_bemerkungen,
+    empfindlichkeitsstufe.typ_kt,
+    $bfsnr AS bfs_nr,
+    typ_empfindlichkeitsstufe_json_dokument_agg.dokumente::jsonb AS dokumente
+FROM
+    empfindlichkeitsstufe
+    LEFT JOIN typ_empfindlichkeitsstufe_json_dokument_agg
+    ON empfindlichkeitsstufe.typ_t_id= typ_empfindlichkeitsstufe_json_dokument_agg.typ_empfindlichkeitsstufe_t_id
+;

--- a/arp_nutzungsplanung_pub/insert_arp_nutzungsplanung_transfer_pub.sql
+++ b/arp_nutzungsplanung_pub/insert_arp_nutzungsplanung_transfer_pub.sql
@@ -6,8 +6,8 @@ SELECT
     datasetname
 FROM
     arp_nutzungsplanung_v1.t_ili2db_dataset
-WHERE 
-   datasetname::int4 = $bfsnr
+WHERE
+   datasetname::int4 = 2457
 ;
 
 -- basket
@@ -20,13 +20,13 @@ SELECT
     basket.attachmentkey,
     basket.domains
 FROM
-    arp_nutzungsplanung_v1.t_ili2db_basket AS basket 
+    arp_nutzungsplanung_v1.t_ili2db_basket AS basket
     LEFT JOIN arp_nutzungsplanung_v1.t_ili2db_dataset AS dataset
     ON basket.dataset=dataset.t_id
-WHERE 
+WHERE
     topic = 'SO_ARP_Nutzungsplanung_Nachfuehrung_20201005.Nutzungsplanung'
 AND
-    dataset.datasetname::int4 = $bfsnr
+    dataset.datasetname::int4 = 2457
 ;
 
 --Grundnutzung
@@ -49,7 +49,7 @@ WITH dokumente AS (
     FROM
         arp_nutzungsplanung_v1.rechtsvorschrften_dokument
     WHERE
-        t_datasetname::int4=$bfsnr
+        t_datasetname::int4=2457
 ),
 json_documents AS (
     SELECT
@@ -58,22 +58,23 @@ json_documents AS (
     ((
         SELECT
             docs
-        FROM 
+        FROM
         (
             SELECT
-                dokumentid AS "Dokument_ID", 
-                titel AS "Titel", 
-                offiziellertitel AS "Offizieller_Titel", 
+                dokumentid AS "DokumentID",
+                titel AS "Titel",
+                offiziellertitel AS "OffiziellerTitel",
                 abkuerzung AS "Abkuerzung",
-                offiziellenr AS "Offizielle_Nr", 
-                kanton AS "Kanton", 
-                gemeinde AS "Gemeinde", 
-                publiziertab AS "publiziert_ab", 
+                offiziellenr AS "OffizielleNr",
+                kanton AS "Kanton",
+                gemeinde AS "Gemeinde",
+                publiziertab AS "publiziertAb",
                 rechtsstatus AS "Rechtsstatus",
-                textimweb AS "Text_im_Web",
-                bemerkungen AS "Bemerkungen", 
-                rechtsvorschrift AS "Rechtsvorschrift", 
-                'SO_Nutzungsplanung_Publikation_20190909.Nutzungsplanung.Dokument' AS "@type"
+                textimweb AS "TextimWeb",
+                bemerkungen AS "Bemerkungen",
+                rechtsvorschrift AS "Rechtsvorschrift",
+                publiziertbis AS "publiziertBis",
+                'SO_ARP_Nutzungsplanung_Publikation_20201005.Nutzungsplanung.Dokument' AS "@type"
         ) docs
     ))
   )::text AS json_dok,
@@ -101,7 +102,7 @@ typ_grundnutzung_json_dokument_agg AS (
 ),
 
 grundnutzung AS (
-    SELECT 
+    SELECT
         grundnutzung.t_id,
         grundnutzung.t_ili_tid,
         typ.bezeichnung AS typ_bezeichnung,
@@ -128,7 +129,7 @@ grundnutzung AS (
         LEFT JOIN arp_nutzungsplanung_v1.nutzungsplanung_typ_grundnutzung AS typ
         ON grundnutzung.typ_grundnutzung = typ.t_id
     WHERE
-        grundnutzung.t_datasetname::int4=$bfsnr
+        grundnutzung.t_datasetname::int4=2457
 )
 
 INSERT INTO arp_nutzungsplanung_transfer_pub_v1.nutzungsplanung_grundnutzung
@@ -152,7 +153,7 @@ SELECT
     grundnutzung.erfasser,
     grundnutzung.datum_erfassung,
     typ_grundnutzung_json_dokument_agg.dokumente::jsonb AS dokumente,
-    $bfsnr AS bfs_nr,
+    2457 AS bfs_nr,
     grundnutzung.publiziertbis
 FROM
     grundnutzung
@@ -179,7 +180,7 @@ WITH dokumente AS (
     FROM
         arp_nutzungsplanung_v1.rechtsvorschrften_dokument
     WHERE
-        t_datasetname::int4=$bfsnr    
+        t_datasetname::int4=2457
 ),
 json_documents AS (
     SELECT
@@ -188,22 +189,23 @@ json_documents AS (
     ((
         SELECT
             docs
-        FROM 
+        FROM
         (
             SELECT
-                dokumentid AS "Dokument_ID", 
-                titel AS "Titel", 
-                offiziellertitel AS "Offizieller_Titel", 
+                dokumentid AS "DokumentID",
+                titel AS "Titel",
+                offiziellertitel AS "OffiziellerTitel",
                 abkuerzung AS "Abkuerzung",
-                offiziellenr AS "Offizielle_Nr", 
-                kanton AS "Kanton", 
-                gemeinde AS "Gemeinde", 
-                publiziertab AS "publiziert_ab", 
+                offiziellenr AS "OffizielleNr",
+                kanton AS "Kanton",
+                gemeinde AS "Gemeinde",
+                publiziertab AS "publiziertAb",
                 rechtsstatus AS "Rechtsstatus",
-                textimweb AS "Text_im_Web",
-                bemerkungen AS "Bemerkungen", 
-                rechtsvorschrift AS "Rechtsvorschrift", 
-                'SO_Nutzungsplanung_Publikation_20190909.Nutzungsplanung.Dokument' AS "@type"
+                textimweb AS "TextimWeb",
+                bemerkungen AS "Bemerkungen",
+                rechtsvorschrift AS "Rechtsvorschrift",
+                publiziertbis AS "publiziertBis",
+                'SO_ARP_Nutzungsplanung_Publikation_20201005.Nutzungsplanung.Dokument' AS "@type"
         ) docs
     ))
   )::text AS json_dok,
@@ -231,7 +233,7 @@ typ_ueberlagernd_flaeche_json_dokument_agg AS (
 ),
 
 ueberlagernd_flaeche AS (
-    SELECT 
+    SELECT
         ueberlagernd_flaeche.t_id,
         ueberlagernd_flaeche.t_ili_tid,
         typ.bezeichnung AS typ_bezeichnung,
@@ -255,7 +257,7 @@ ueberlagernd_flaeche AS (
         LEFT JOIN arp_nutzungsplanung_v1.nutzungsplanung_typ_ueberlagernd_flaeche AS typ
         ON ueberlagernd_flaeche.typ_ueberlagernd_flaeche= typ.t_id
     WHERE
-        ueberlagernd_flaeche.t_datasetname::int4=$bfsnr
+        ueberlagernd_flaeche.t_datasetname::int4=2457
 )
 
 INSERT INTO arp_nutzungsplanung_transfer_pub_v1.nutzungsplanung_ueberlagernd_flaeche
@@ -276,7 +278,7 @@ SELECT
     ueberlagernd_flaeche.erfasser,
     ueberlagernd_flaeche.datum_erfassung,
     typ_ueberlagernd_flaeche_json_dokument_agg.dokumente::jsonb AS dokumente,
-    $bfsnr AS bfs_nr,
+    2457 AS bfs_nr,
     ueberlagernd_flaeche.publiziertbis
 FROM
     ueberlagernd_flaeche
@@ -304,7 +306,7 @@ WITH dokumente AS (
     FROM
         arp_nutzungsplanung_v1.rechtsvorschrften_dokument
     WHERE
-        t_datasetname::int4=$bfsnr    
+        t_datasetname::int4=2457
 ),
 json_documents AS (
     SELECT
@@ -313,22 +315,23 @@ json_documents AS (
     ((
         SELECT
             docs
-        FROM 
+        FROM
         (
             SELECT
-                dokumentid AS "Dokument_ID", 
-                titel AS "Titel", 
-                offiziellertitel AS "Offizieller_Titel", 
+                dokumentid AS "DokumentID",
+                titel AS "Titel",
+                offiziellertitel AS "OffiziellerTitel",
                 abkuerzung AS "Abkuerzung",
-                offiziellenr AS "Offizielle_Nr", 
-                kanton AS "Kanton", 
-                gemeinde AS "Gemeinde", 
-                publiziertab AS "publiziert_ab", 
+                offiziellenr AS "OffizielleNr",
+                kanton AS "Kanton",
+                gemeinde AS "Gemeinde",
+                publiziertab AS "publiziertAb",
                 rechtsstatus AS "Rechtsstatus",
-                textimweb AS "Text_im_Web",
-                bemerkungen AS "Bemerkungen", 
-                rechtsvorschrift AS "Rechtsvorschrift", 
-                'SO_Nutzungsplanung_Publikation_20190909.Nutzungsplanung.Dokument' AS "@type"
+                textimweb AS "TextimWeb",
+                bemerkungen AS "Bemerkungen",
+                rechtsvorschrift AS "Rechtsvorschrift",
+                publiziertbis AS "publiziertBis",
+                'SO_ARP_Nutzungsplanung_Publikation_20201005.Nutzungsplanung.Dokument' AS "@type"
         ) docs
     ))
   )::text AS json_dok,
@@ -356,7 +359,7 @@ typ_ueberlagernd_linie_json_dokument_agg AS (
 ),
 
 ueberlagernd_linie AS (
-    SELECT 
+    SELECT
         ueberlagernd_linie.t_id,
         ueberlagernd_linie.t_ili_tid,
         typ.bezeichnung AS typ_bezeichnung,
@@ -380,7 +383,7 @@ ueberlagernd_linie AS (
         LEFT JOIN arp_nutzungsplanung_v1.nutzungsplanung_typ_ueberlagernd_linie AS typ
         ON ueberlagernd_linie.typ_ueberlagernd_linie= typ.t_id
     WHERE
-        ueberlagernd_linie.t_datasetname::int4=$bfsnr
+        ueberlagernd_linie.t_datasetname::int4=2457
 )
 
 INSERT INTO arp_nutzungsplanung_transfer_pub_v1.nutzungsplanung_ueberlagernd_linie
@@ -401,7 +404,7 @@ SELECT
     ueberlagernd_linie.erfasser,
     ueberlagernd_linie.datum_erfassung,
     typ_ueberlagernd_linie_json_dokument_agg.dokumente::jsonb AS dokumente,
-    $bfsnr AS bfs_nr,
+    2457 AS bfs_nr,
     ueberlagernd_linie.publiziertbis
 FROM
     ueberlagernd_linie
@@ -429,8 +432,9 @@ WITH dokumente AS (
     FROM
         arp_nutzungsplanung_v1.rechtsvorschrften_dokument
     WHERE
-        t_datasetname::int4=$bfsnr    
+        t_datasetname::int4=2457
 ),
+
 json_documents AS (
     SELECT
   (
@@ -438,22 +442,23 @@ json_documents AS (
     ((
         SELECT
             docs
-        FROM 
+        FROM
         (
             SELECT
-                dokumentid AS "Dokument_ID", 
-                titel AS "Titel", 
-                offiziellertitel AS "Offizieller_Titel", 
+                dokumentid AS "DokumentID",
+                titel AS "Titel",
+                offiziellertitel AS "OffiziellerTitel",
                 abkuerzung AS "Abkuerzung",
-                offiziellenr AS "Offizielle_Nr", 
-                kanton AS "Kanton", 
-                gemeinde AS "Gemeinde", 
-                publiziertab AS "publiziert_ab", 
+                offiziellenr AS "OffizielleNr",
+                kanton AS "Kanton",
+                gemeinde AS "Gemeinde",
+                publiziertab AS "publiziertAb",
                 rechtsstatus AS "Rechtsstatus",
-                textimweb AS "Text_im_Web",
-                bemerkungen AS "Bemerkungen", 
-                rechtsvorschrift AS "Rechtsvorschrift", 
-                'SO_Nutzungsplanung_Publikation_20190909.Nutzungsplanung.Dokument' AS "@type"
+                textimweb AS "TextimWeb",
+                bemerkungen AS "Bemerkungen",
+                rechtsvorschrift AS "Rechtsvorschrift",
+                publiziertbis AS "publiziertBis",
+                'SO_ARP_Nutzungsplanung_Publikation_20201005.Nutzungsplanung.Dokument' AS "@type"
         ) docs
     ))
   )::text AS json_dok,
@@ -481,7 +486,7 @@ typ_ueberlagernd_punkt_json_dokument_agg AS (
 ),
 
 ueberlagernd_punkt AS (
-    SELECT 
+    SELECT
         ueberlagernd_punkt.t_id,
         ueberlagernd_punkt.t_ili_tid,
         typ.bezeichnung AS typ_bezeichnung,
@@ -505,7 +510,7 @@ ueberlagernd_punkt AS (
         LEFT JOIN arp_nutzungsplanung_v1.nutzungsplanung_typ_ueberlagernd_punkt AS typ
         ON ueberlagernd_punkt.typ_ueberlagernd_punkt= typ.t_id
     WHERE
-        ueberlagernd_punkt.t_datasetname::int4=$bfsnr
+        ueberlagernd_punkt.t_datasetname::int4=2457
 )
 
 INSERT INTO arp_nutzungsplanung_transfer_pub_v1.nutzungsplanung_ueberlagernd_punkt
@@ -526,7 +531,7 @@ SELECT
     ueberlagernd_punkt.erfasser,
     ueberlagernd_punkt.datum_erfassung,
     typ_ueberlagernd_punkt_json_dokument_agg.dokumente::jsonb AS dokumente,
-    $bfsnr AS bfs_nr,
+    2457 AS bfs_nr,
     ueberlagernd_punkt.publiziertbis
 FROM
     ueberlagernd_punkt
@@ -555,7 +560,7 @@ WITH dokumente AS (
     FROM
         arp_nutzungsplanung_v1.rechtsvorschrften_dokument
     WHERE
-        t_datasetname::int4=$bfsnr    
+        t_datasetname::int4=2457
 ),
 json_documents AS (
     SELECT
@@ -564,22 +569,23 @@ json_documents AS (
     ((
         SELECT
             docs
-        FROM 
+        FROM
         (
             SELECT
-                dokumentid AS "Dokument_ID", 
-                titel AS "Titel", 
-                offiziellertitel AS "Offizieller_Titel", 
+                dokumentid AS "DokumentID",
+                titel AS "Titel",
+                offiziellertitel AS "OffiziellerTitel",
                 abkuerzung AS "Abkuerzung",
-                offiziellenr AS "Offizielle_Nr", 
-                kanton AS "Kanton", 
-                gemeinde AS "Gemeinde", 
-                publiziertab AS "publiziert_ab", 
+                offiziellenr AS "OffizielleNr",
+                kanton AS "Kanton",
+                gemeinde AS "Gemeinde",
+                publiziertab AS "publiziertAb",
                 rechtsstatus AS "Rechtsstatus",
-                textimweb AS "Text_im_Web",
-                bemerkungen AS "Bemerkungen", 
-                rechtsvorschrift AS "Rechtsvorschrift", 
-                'SO_Nutzungsplanung_Publikation_20190909.Nutzungsplanung.Dokument' AS "@type"
+                textimweb AS "TextimWeb",
+                bemerkungen AS "Bemerkungen",
+                rechtsvorschrift AS "Rechtsvorschrift",
+                publiziertbis AS "publiziertBis",
+                'SO_ARP_Nutzungsplanung_Publikation_20201005.Nutzungsplanung.Dokument' AS "@type"
         ) docs
     ))
   )::text AS json_dok,
@@ -607,7 +613,7 @@ typ_erschliessung_flaechenobjekt_json_dokument_agg AS (
 ),
 
 erschliessung_flaechenobjekt AS (
-    SELECT 
+    SELECT
         erschliessung_flaechenobjekt.t_id,
         erschliessung_flaechenobjekt.t_ili_tid,
         typ.bezeichnung AS typ_bezeichnung,
@@ -631,7 +637,7 @@ erschliessung_flaechenobjekt AS (
         LEFT JOIN arp_nutzungsplanung_v1.erschlssngsplnung_typ_erschliessung_flaechenobjekt AS typ
         ON erschliessung_flaechenobjekt.typ_erschliessung_flaechenobjekt= typ.t_id
     WHERE
-        erschliessung_flaechenobjekt.t_datasetname::int4=$bfsnr
+        erschliessung_flaechenobjekt.t_datasetname::int4=2457
 )
 
 INSERT INTO arp_nutzungsplanung_transfer_pub_v1.nutzungsplanung_erschliessung_flaechenobjekt
@@ -652,7 +658,7 @@ SELECT
     erschliessung_flaechenobjekt.erfasser,
     erschliessung_flaechenobjekt.datum_erfassung,
     typ_erschliessung_flaechenobjekt_json_dokument_agg.dokumente::jsonb AS dokumente,
-    $bfsnr AS bfs_nr,
+    2457 AS bfs_nr,
     erschliessung_flaechenobjekt.publiziertbis
 FROM
     erschliessung_flaechenobjekt
@@ -680,7 +686,7 @@ WITH dokumente AS (
     FROM
         arp_nutzungsplanung_v1.rechtsvorschrften_dokument
     WHERE
-        t_datasetname::int4=$bfsnr    
+        t_datasetname::int4=2457
 ),
 json_documents AS (
     SELECT
@@ -689,22 +695,23 @@ json_documents AS (
     ((
         SELECT
             docs
-        FROM 
+        FROM
         (
             SELECT
-                dokumentid AS "Dokument_ID", 
-                titel AS "Titel", 
-                offiziellertitel AS "Offizieller_Titel", 
+                dokumentid AS "DokumentID",
+                titel AS "Titel",
+                offiziellertitel AS "OffiziellerTitel",
                 abkuerzung AS "Abkuerzung",
-                offiziellenr AS "Offizielle_Nr", 
-                kanton AS "Kanton", 
-                gemeinde AS "Gemeinde", 
-                publiziertab AS "publiziert_ab", 
+                offiziellenr AS "OffizielleNr",
+                kanton AS "Kanton",
+                gemeinde AS "Gemeinde",
+                publiziertab AS "publiziertAb",
                 rechtsstatus AS "Rechtsstatus",
-                textimweb AS "Text_im_Web",
-                bemerkungen AS "Bemerkungen", 
-                rechtsvorschrift AS "Rechtsvorschrift", 
-                'SO_Nutzungsplanung_Publikation_20190909.Nutzungsplanung.Dokument' AS "@type"
+                textimweb AS "TextimWeb",
+                bemerkungen AS "Bemerkungen",
+                rechtsvorschrift AS "Rechtsvorschrift",
+                publiziertbis AS "publiziertBis",
+                'SO_ARP_Nutzungsplanung_Publikation_20201005.Nutzungsplanung.Dokument' AS "@type"
         ) docs
     ))
   )::text AS json_dok,
@@ -732,7 +739,7 @@ typ_erschliessung_linienobjekt_json_dokument_agg AS (
 ),
 
 erschliessung_linienobjekt AS (
-    SELECT 
+    SELECT
         erschliessung_linienobjekt.t_id,
         erschliessung_linienobjekt.t_ili_tid,
         typ.bezeichnung AS typ_bezeichnung,
@@ -756,7 +763,7 @@ erschliessung_linienobjekt AS (
         LEFT JOIN arp_nutzungsplanung_v1.erschlssngsplnung_typ_erschliessung_linienobjekt AS typ
         ON erschliessung_linienobjekt.typ_erschliessung_linienobjekt= typ.t_id
     WHERE
-        erschliessung_linienobjekt.t_datasetname::int4=$bfsnr
+        erschliessung_linienobjekt.t_datasetname::int4=2457
 )
 
 INSERT INTO arp_nutzungsplanung_transfer_pub_v1.nutzungsplanung_erschliessung_linienobjekt
@@ -777,7 +784,7 @@ SELECT
     erschliessung_linienobjekt.erfasser,
     erschliessung_linienobjekt.datum_erfassung,
     typ_erschliessung_linienobjekt_json_dokument_agg.dokumente::jsonb AS dokumente,
-    $bfsnr AS bfs_nr,
+    2457 AS bfs_nr,
     erschliessung_linienobjekt.publiziertbis
 FROM
     erschliessung_linienobjekt
@@ -804,7 +811,7 @@ WITH dokumente AS (
     FROM
         arp_nutzungsplanung_v1.rechtsvorschrften_dokument
     WHERE
-        t_datasetname::int4=$bfsnr    
+        t_datasetname::int4=2457
 ),
 json_documents AS (
     SELECT
@@ -813,22 +820,23 @@ json_documents AS (
     ((
         SELECT
             docs
-        FROM 
+        FROM
         (
             SELECT
-                dokumentid AS "Dokument_ID", 
-                titel AS "Titel", 
-                offiziellertitel AS "Offizieller_Titel", 
+                dokumentid AS "DokumentID",
+                titel AS "Titel",
+                offiziellertitel AS "OffiziellerTitel",
                 abkuerzung AS "Abkuerzung",
-                offiziellenr AS "Offizielle_Nr", 
-                kanton AS "Kanton", 
-                gemeinde AS "Gemeinde", 
-                publiziertab AS "publiziert_ab", 
+                offiziellenr AS "OffizielleNr",
+                kanton AS "Kanton",
+                gemeinde AS "Gemeinde",
+                publiziertab AS "publiziertAb",
                 rechtsstatus AS "Rechtsstatus",
-                textimweb AS "Text_im_Web",
-                bemerkungen AS "Bemerkungen", 
-                rechtsvorschrift AS "Rechtsvorschrift", 
-                'SO_Nutzungsplanung_Publikation_20190909.Nutzungsplanung.Dokument' AS "@type"
+                textimweb AS "TextimWeb",
+                bemerkungen AS "Bemerkungen",
+                rechtsvorschrift AS "Rechtsvorschrift",
+                publiziertbis AS "publiziertBis",
+                'SO_ARP_Nutzungsplanung_Publikation_20201005.Nutzungsplanung.Dokument' AS "@type"
         ) docs
     ))
   )::text AS json_dok,
@@ -856,7 +864,7 @@ typ_erschliessung_punktobjekt_json_dokument_agg AS (
 ),
 
 erschliessung_punktobjekt AS (
-    SELECT 
+    SELECT
         erschliessung_punktobjekt.t_id,
         erschliessung_punktobjekt.t_ili_tid,
         typ.bezeichnung AS typ_bezeichnung,
@@ -880,7 +888,7 @@ erschliessung_punktobjekt AS (
         LEFT JOIN arp_nutzungsplanung_v1.erschlssngsplnung_typ_erschliessung_punktobjekt AS typ
         ON erschliessung_punktobjekt.typ_erschliessung_punktobjekt= typ.t_id
     WHERE
-        erschliessung_punktobjekt.t_datasetname::int4=$bfsnr
+        erschliessung_punktobjekt.t_datasetname::int4=2457
 )
 
 INSERT INTO arp_nutzungsplanung_transfer_pub_v1.nutzungsplanung_erschliessung_punktobjekt
@@ -901,7 +909,7 @@ SELECT
     erschliessung_punktobjekt.erfasser,
     erschliessung_punktobjekt.datum_erfassung,
     typ_erschliessung_punktobjekt_json_dokument_agg.dokumente::jsonb AS dokumente,
-    $bfsnr AS bfs_nr,
+    2457 AS bfs_nr,
     erschliessung_punktobjekt.publiziertbis
 FROM
     erschliessung_punktobjekt
@@ -928,7 +936,7 @@ WITH dokumente AS (
     FROM
         arp_nutzungsplanung_v1.rechtsvorschrften_dokument
     WHERE
-        t_datasetname::int4=$bfsnr    
+        t_datasetname::int4=2457
 ),
 json_documents AS (
     SELECT
@@ -937,22 +945,23 @@ json_documents AS (
     ((
         SELECT
             docs
-        FROM 
+        FROM
         (
             SELECT
-                dokumentid AS "Dokument_ID", 
-                titel AS "Titel", 
-                offiziellertitel AS "Offizieller_Titel", 
+                dokumentid AS "DokumentID",
+                titel AS "Titel",
+                offiziellertitel AS "OffiziellerTitel",
                 abkuerzung AS "Abkuerzung",
-                offiziellenr AS "Offizielle_Nr", 
-                kanton AS "Kanton", 
-                gemeinde AS "Gemeinde", 
-                publiziertab AS "publiziert_ab", 
+                offiziellenr AS "OffizielleNr",
+                kanton AS "Kanton",
+                gemeinde AS "Gemeinde",
+                publiziertab AS "publiziertAb",
                 rechtsstatus AS "Rechtsstatus",
-                textimweb AS "Text_im_Web",
-                bemerkungen AS "Bemerkungen", 
-                rechtsvorschrift AS "Rechtsvorschrift", 
-                'SO_Nutzungsplanung_Publikation_20190909.Nutzungsplanung.Dokument' AS "@type"
+                textimweb AS "TextimWeb",
+                bemerkungen AS "Bemerkungen",
+                rechtsvorschrift AS "Rechtsvorschrift",
+                publiziertbis AS "publiziertBis",
+                'SO_ARP_Nutzungsplanung_Publikation_20201005.Nutzungsplanung.Dokument' AS "@type"
         ) docs
     ))
   )::text AS json_dok,
@@ -980,7 +989,7 @@ typ_empfindlichkeitsstufe_json_dokument_agg AS (
 ),
 
 empfindlichkeitsstufe AS (
-    SELECT 
+    SELECT
         empfindlichkeitsstufe.t_id,
         empfindlichkeitsstufe.t_ili_tid,
         typ.bezeichnung AS typ_bezeichnung,
@@ -1003,7 +1012,7 @@ empfindlichkeitsstufe AS (
         LEFT JOIN arp_nutzungsplanung_v1.laermmpfhktsstfen_typ_empfindlichkeitsstufe AS typ
         ON empfindlichkeitsstufe.typ_empfindlichkeitsstufen= typ.t_id
     WHERE
-        empfindlichkeitsstufe.t_datasetname::int4=$bfsnr
+        empfindlichkeitsstufe.t_datasetname::int4=2457
 )
 
 INSERT INTO arp_nutzungsplanung_transfer_pub_v1.nutzungsplanung_empfindlichkeitsstufe
@@ -1023,7 +1032,7 @@ SELECT
     empfindlichkeitsstufe.typ_verbindlichkeit,
     empfindlichkeitsstufe.typ_bemerkungen,
     empfindlichkeitsstufe.typ_kt,
-    $bfsnr AS bfs_nr,
+    2457 AS bfs_nr,
     typ_empfindlichkeitsstufe_json_dokument_agg.dokumente::jsonb AS dokumente
 FROM
     empfindlichkeitsstufe

--- a/arp_nutzungsplanung_pub/job.properties
+++ b/arp_nutzungsplanung_pub/job.properties
@@ -1,0 +1,3 @@
+logRotator.numToKeep=uunlimited
+parameters.stringParam=bfsnr;;BFS-Nr. der Gemeinde welche publiziert werden soll.
+authorization.permissions=gretl-users-bjsvw

--- a/arp_nutzungsplanung_pub/job.properties
+++ b/arp_nutzungsplanung_pub/job.properties
@@ -1,3 +1,3 @@
-logRotator.numToKeep=uunlimited
+logRotator.numToKeep=unlimited
 parameters.stringParam=bfsnr;;BFS-Nr. der Gemeinde welche publiziert werden soll.
 authorization.permissions=gretl-users-bjsvw


### PR DESCRIPTION
Das Jenkinsfile ist nun, so dass man gefragt wird, ob man fortfahren oder nochmals exportieren möchte, siehe Jenkinsfile Zeile 40.
Bitte beachte auch noch die paar Kommentare unten.

Zudem habe ich noch einen Vorschlag zur Umbenennung der Task-Namen, weil ich sie nicht so verständlich fand. Dieser Vorschlag ist im Pull Request #1057. Falls du damit einverstanden bist, kannst du ihn mergen. (Er wird in diesen Branch hier, arp_nutzungsplanung_nachfuehrung gemergt.) Oder ich mache es für dich.
