### PR TITLE
Retry whole stage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,10 +13,11 @@ pipeline {
     }
     stages {
         stage('Run GRETL-Job') {
+            options {
+                retry(2)
+            }
             steps {
-                retry(2) {
-                    git url: gretlJobRepoUrl, branch: "${params.BRANCH ?: 'master'}", changelog: false
-                }
+                git url: gretlJobRepoUrl, branch: "${params.BRANCH ?: 'master'}", changelog: false
                 container('gretl') {
                     dir(env.JOB_BASE_NAME) {
                         sh 'gretl'


### PR DESCRIPTION
Retry the _git_ **and** the _gretl_ step instead of just the _git_ step. Reason: The _gretl_ step sometimes fails because of e.g. `java.net.UnknownHostException: models.geo.admin.ch`. In these cases it is worth retrying the _gretl_step.

We don't modify the "special" Jenkinsfiles, because all of them are used for jobs that are started manually only. So they just must be started again by the user.

See https://sogis.openproject.com/projects/gretl/work_packages/1081