### PR TITLE
[arp_nutzungsplanung_pub] Disable concurrent builds

### DIFF
--- a/arp_nutzungsplanung_pub/Jenkinsfile
+++ b/arp_nutzungsplanung_pub/Jenkinsfile
@@ -9,6 +9,7 @@ node('master') {
 pipeline {
     agent none
     options {
+        disableConcurrentBuilds()
         timeout(time: 7, unit: 'DAYS')
     }
     stages {


### PR DESCRIPTION
Gleichzeitige Ausführung verhindern, damit es kein Durcheinander gibt, wenn mehrere Ausführungen auf Validierung warten.