### PR TITLE
Fixup: stringParams

### DIFF
--- a/arp_nutzungsplanung_kanton_pub/job.properties
+++ b/arp_nutzungsplanung_kanton_pub/job.properties
@@ -1,3 +1,3 @@
 logRotator.numToKeep=unlimited
-parameters.stringParam:buildDescription;Keine Beschreibung angegeben;Beschreibung/Grund für die Publikation der Daten
+parameters.stringParams:buildDescription;Keine Beschreibung angegeben;Beschreibung/Grund für die Publikation der Daten
 authorization.permissions=gretl-users-bjsvw

--- a/gretl_job_generator.groovy
+++ b/gretl_job_generator.groovy
@@ -40,7 +40,6 @@ for (jobFile in jobFiles) {
     'authorization.permissions':'nobody',
     'logRotator.numToKeep':'15',
     'parameters.fileParam':'none',
-    'parameters.stringParam':'none',
     'parameters.stringParams':'none',
     'triggers.upstream':'none',
     'triggers.cron':''

--- a/jenkinsfile_docs.md
+++ b/jenkinsfile_docs.md
@@ -45,7 +45,7 @@ Damit dieser Job funktioniert, muss zusätzlich in der Datei `job.properties`
 die folgende Zeile stehen:
 
 ```
-parameters.stringParam=afuAbbaustellenAppXtfUrl;;Komplette URL zum Download des XTF
+parameters.stringParams=afuAbbaustellenAppXtfUrl;;Komplette URL zum Download des XTF
 ```
 
 Der Name des Parameters kann frei gewählt werden
@@ -58,6 +58,11 @@ beim Start des GRETL-Jobs angezeigt werden soll.
 
 Im Jenkinsfile muss der Name des Parameters an den
 in `job.properties` definierten Namen angepasst werden.
+
+Es können auch mehrere String-Parameter übergeben werden.
+Hierzu trennt man die einzelnen String-Parameter
+mit dem Zeichen `@` voneinander ab.
+Vorlage: [arp_nutzungsplanung_kanton_pub/job.properties](arp_nutzungsplanung_kanton_pub/job.properties)
 
 ## Im Pod eine temporäre Datenbank für die Verarbeitung von Daten starten
 


### PR DESCRIPTION
Aufräumarbeiten nach der Umbenennung der Property von `stringParam` zu `stringParams` und damit Ermöglichung der Übergabe von mehreren String-Parametern.