### PR TITLE
[agi_check_ili_export] Memory Request auf 3.5Gi erhöhen

### DIFF
--- a/agi_check_ili_export/Jenkinsfile
+++ b/agi_check_ili_export/Jenkinsfile
@@ -1,0 +1,44 @@
+pipeline {
+    agent {
+        kubernetes {
+            inheritFrom params.nodeLabel ?: 'gretl'
+            yamlMergeStrategy merge()
+            yaml '''
+            spec:
+              containers:
+              - name: gretl
+                resources:
+                  requests:
+                    memory: 3.5Gi
+'''
+        }
+    }
+    options {
+        timeout(time: 6, unit: 'HOURS')
+    }
+    stages {
+        stage('Run GRETL-Job') {
+            options {
+                retry(2)
+            }
+            steps {
+                git url: "${env.GIT_REPO_URL}", branch: "${params.BRANCH ?: 'master'}", changelog: false
+                container('gretl') {
+                    dir(env.JOB_BASE_NAME) {
+                        sh 'gretl'
+                    }
+                }
+            }
+        }
+    }
+    post {
+        unsuccessful {
+            emailext (
+                to: '${DEFAULT_RECIPIENTS}',
+                recipientProviders: [requestor()],
+                subject: "GRETL-Job ${JOB_NAME} (${BUILD_DISPLAY_NAME}) ist fehlgeschlagen",
+                body: "Die Ausführung des GRETL-Jobs ${JOB_NAME} (${BUILD_DISPLAY_NAME}) war nicht erfolgreich. Details dazu finden Sie in den Log-Meldungen unter ${RUN_DISPLAY_URL}."
+            )
+        }
+    }
+}


### PR DESCRIPTION
So ist gewährleistet, dass der Pod auch tatsächlich 3.5Gi erhält. Für die Validierung gewisser Datensätze braucht er offenbar zwingend mehr als nur 1Gi.

Beschreibung der Lösung: Der Job kriegt ein eigenes Jenkinsfile, in welchem definiert ist, dass er zwar das normale GRETL-Pod-Template verwenden soll (Zeile 4), aber zusätzlich wird der Memory Request auf 3.5Gi gesetzt (Zeile 12). Der Rest des Jenkinsfiles ist identisch zum Standard-Jenkinsfile.