### PR TITLE
Add modeldir option

### DIFF
--- a/agi_av_import_export/build.gradle
+++ b/agi_av_import_export/build.gradle
@@ -143,6 +143,7 @@ task uploadDxfGeobauFiles(type: S3Upload, dependsOn: 'createDxfGeobauFiles') {
 task importData(type: Ili2pgReplace, dependsOn: 'uploadDxfGeobauFiles') {
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     models = 'DM01AVSO24LV95'
+    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dbschema = 'agi_dm01avso24'
     dataFile = fileTree(dir: pathToUnzipFolder, include: '*.itf')
     dataset = dataFile

--- a/agi_av_import_export/build.gradle
+++ b/agi_av_import_export/build.gradle
@@ -60,20 +60,20 @@ if (gretlEnvironment == "test") {
     bucketNameGeobau += "-dev"
 }
 
-task downloadFiles(type: FtpDownload) { 
+task downloadFiles(type: FtpDownload) {
     server = ftpServerInfogrips
     user = ftpUserInfogrips
     password = ftpPwdInfogrips
     systemType = "WINDOWS"
     fileType = "BINARY"
     localDir = pathToTempFolder
-    remoteDir = "\\dm01avso24lv95\\itf" 
-    remoteFile = "*.zip" 
+    remoteDir = "\\dm01avso24lv95\\itf"
+    remoteFile = "*.zip"
 
     doLast {
         println "Files downloaded: " + pathToTempFolder
-    }       
-} 
+    }
+}
 
 task uploadFiles(type: S3Upload, dependsOn: 'downloadFiles') {
     accessKey = awsAccessKeyAgi
@@ -85,7 +85,7 @@ task uploadFiles(type: S3Upload, dependsOn: 'downloadFiles') {
 
 task unzipFiles(dependsOn: 'uploadFiles') {
     doLast {
-        fileTree(pathToTempFolder).files.each { 
+        fileTree(pathToTempFolder).files.each {
             String fileName = it
             copy {
                 from zipTree(fileName)
@@ -146,7 +146,7 @@ task importData(type: Ili2pgReplace, dependsOn: 'uploadDxfGeobauFiles') {
     dbschema = 'agi_dm01avso24'
     dataFile = fileTree(dir: pathToUnzipFolder, include: '*.itf')
     dataset = dataFile
-    datasetSubstring = 0..4     
+    datasetSubstring = 0..4
 
     disableValidation = true
 
@@ -164,5 +164,5 @@ task deleteFtpFiles(type: FtpDelete, dependsOn: 'importData') {
     password = ftpPwdInfogrips
     systemType = "WINDOWS"
     remoteDir = "\\dm01avso24lv95\\itf"
-    remoteFile = fileTree(pathToTempFolder) { include '*.zip' } 
+    remoteFile = fileTree(pathToTempFolder) { include '*.zip' }
 }

--- a/agi_check_ili_export/build.gradle
+++ b/agi_check_ili_export/build.gradle
@@ -57,7 +57,7 @@ if (gretlEnvironment == "test") {
     bucket = "ch.so.agi.geodata-int"
 } else if (gretlEnvironment == "production") {
     bucket = "ch.so.agi.geodata"
-} 
+}
 
 datasets.each { dataset ->
     def modelNames = dataset.models
@@ -101,9 +101,9 @@ datasets.each { dataset ->
         secretKey = awsSecretAccessKeyAgi
         sourceDir = file(Paths.get(pathToTempFolder, datasetId + "_xtf.zip"))
         bucketName = bucket
-        endPoint = "https://s3.eu-central-1.amazonaws.com" 
+        endPoint = "https://s3.eu-central-1.amazonaws.com"
         region = "eu-central-1"
-        acl = "private" 
+        acl = "private"
         metaData = ["lastEditingDate":todaysDate]
     }
 }
@@ -122,7 +122,7 @@ task zipLogFiles(type: Zip) {
     include "*_validation.xtf"
     archiveName  "datenvalidierung_"+todaysDate+".zip"
     destinationDir(file(pathToTempFolder))
-}   
+}
 zipLogFiles.mustRunAfter exportAllData
 
 task copyLogZipFile(type: Copy, dependsOn: "zipLogFiles") {
@@ -131,7 +131,7 @@ task copyLogZipFile(type: Copy, dependsOn: "zipLogFiles") {
     include "datenvalidierung_"+todaysDate+".zip"
     rename { String fileName ->
         fileName.replace("datenvalidierung_"+todaysDate+".zip", "datenvalidierung_latest.zip")
-    } 
+    }
 }
 
 task uploadLogZipFileDate(type: S3Upload, dependsOn: "copyLogZipFile") {

--- a/agi_check_ili_export/build.gradle
+++ b/agi_check_ili_export/build.gradle
@@ -70,6 +70,7 @@ datasets.each { dataset ->
         database = dbdatabase
         dbschema = schema
         models = modelNames
+        if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
         disableValidation = true
         logFile = file(Paths.get(pathToTempFolder, datasetId + "_" + todaysDate  + "_export.log"))
         //dataFile = file(Paths.get(pathToTempFolder, datasetId + "_" + todaysDate + ".xtf"))
@@ -80,6 +81,7 @@ datasets.each { dataset ->
     task "validateData_$datasetId"(type: IliValidator, dependsOn: "exportDataset_$datasetId") {
         //dataFiles = [Paths.get(pathToTempFolder, datasetId + "_" + todaysDate + ".xtf")]
         dataFiles = [Paths.get(pathToTempFolder, datasetId + ".xtf")]
+        if (findProperty('ilivalidatorModeldir')) modeldir = ilivalidatorModeldir
         logFile = file(Paths.get(pathToTempFolder, datasetId + "_validation.log"))
         xtflogFile = file(Paths.get(pathToTempFolder, datasetId + "_validation.xtf"))
         failOnError = false

--- a/agi_mopublic_pub_export/build.gradle
+++ b/agi_mopublic_pub_export/build.gradle
@@ -50,12 +50,12 @@ datasets.each { dataset ->
         disableValidation = true
 
         finalizedBy "emptyTables_$dataset"
-    } 
+    }
 
     task "emptyTables_$dataset"(type: SqlExecutor) {
         database = [dbUriPub, dbUserPub, dbPwdPub]
         sqlFiles = ['empty_tables.sql']
-    }      
+    }
 
     task "validateDataset_$dataset"(type: IliValidator, dependsOn: "exportDataset_$dataset") {
         dataFiles = [Paths.get(pathToTempFolder, dataset.toString() + ".xtf")]
@@ -92,12 +92,12 @@ datasets.each { dataset ->
         include "$dataset*_validation.log"
         archiveName dataset.toString() + "_gpkg.zip"
         destinationDir(file(pathToTempFolder))
-    }   
+    }
 
     task "gpkg2Shp_$dataset"(type: Gpkg2Shp, dependsOn: "zipDatasetGpkg_$dataset") {
         dataFile = file(Paths.get(pathToTempFolder, dataset.toString() + ".gpkg")) 
         outputDir = file(pathToTempFolder)
-    }  
+    }
 
     task "zipDatasetShp_$dataset"(type: Zip, dependsOn: "gpkg2Shp_$dataset") {
         from pathToTempFolder
@@ -110,7 +110,7 @@ datasets.each { dataset ->
         destinationDir(file(pathToTempFolder))
 
         finalizedBy "removeShpFiles_$dataset"
-    }     
+    }
 
     task "removeShpFiles_$dataset"(type: Delete) {
         delete fileTree(pathToTempFolder) {
@@ -120,7 +120,7 @@ datasets.each { dataset ->
             include '**/*.prj'
             include '**/*.fix'
         }
-    }     
+    }
 
     task "uploadXtf_$dataset"(type: S3Upload, dependsOn: "zipDatasetShp_$dataset") {
         accessKey = awsAccessKeyAgi
@@ -130,7 +130,7 @@ datasets.each { dataset ->
         region = "eu-central-1"
         bucketName = s3Bucket
         acl = "public-read"
-    }     
+    }
 
     task "uploadGpkg_$dataset"(type: S3Upload, dependsOn: "uploadXtf_$dataset") {
         accessKey = awsAccessKeyAgi
@@ -140,7 +140,7 @@ datasets.each { dataset ->
         region = "eu-central-1"
         bucketName = s3Bucket
         acl = "public-read"
-    }  
+    }
 
     task "uploadShp_$dataset"(type: S3Upload, dependsOn: "uploadGpkg_$dataset") {
         accessKey = awsAccessKeyAgi
@@ -152,7 +152,7 @@ datasets.each { dataset ->
         acl = "public-read"
 
         finalizedBy "removeFiles_$dataset"
-    }  
+    }
 
     task "removeFiles_$dataset"(type: Delete) {
         delete fileTree(pathToTempFolder) {
@@ -171,4 +171,3 @@ task exportAllDatasets() {
         tasks.findAll { task -> task.name.startsWith('uploadShp_') }
     }
 }
-

--- a/agi_mopublic_pub_export/build.gradle
+++ b/agi_mopublic_pub_export/build.gradle
@@ -45,6 +45,7 @@ datasets.each { dataset ->
         database = [dbUriPub, dbUserPub, dbPwdPub]
         dbschema = "agi_mopublic_pub_export"
         models = "SO_AGI_MOpublic_20201009"
+        if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
         logFile = file(Paths.get(pathToTempFolder, dataset.toString() + "_" + todaysDate  + "_export.log"))
         dataFile = file(Paths.get(pathToTempFolder, dataset.toString() + ".xtf"))
         disableValidation = true
@@ -59,6 +60,7 @@ datasets.each { dataset ->
 
     task "validateDataset_$dataset"(type: IliValidator, dependsOn: "exportDataset_$dataset") {
         dataFiles = [Paths.get(pathToTempFolder, dataset.toString() + ".xtf")]
+        if (findProperty('ilivalidatorModeldir')) modeldir = ilivalidatorModeldir
         logFile = file(Paths.get(pathToTempFolder, dataset.toString() + "_" + todaysDate  + "_validation.log"))
         failOnError = false
         //if (new File("config/"+datasetId + ".toml").isFile()) configFile = "config/"+datasetId + ".toml"
@@ -75,6 +77,7 @@ datasets.each { dataset ->
 
     task "importDatasetGpkg_$dataset"(type: Ili2gpkgImport, dependsOn: "zipDatasetXtf_$dataset") {
         models = "SO_AGI_MOpublic_20201009"
+        if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
         dataFile = file(Paths.get(pathToTempFolder, dataset.toString() + ".xtf"))
         dbfile = file(Paths.get(pathToTempFolder, dataset.toString() + ".gpkg"))
         disableValidation = true


### PR DESCRIPTION
Requires that the `ili2dbModeldir` and the `ilivalidatorModeldir` properties are set. See https://github.com/sogis/gretl/pull/67 for an example.

However, these properties are not mandatory. If they are not set the ili2db and ilivalidator defaults are used.