### PR TITLE
[agi_av_import_export] modeldir setzen

### DIFF
--- a/agi_av_import_export/build.gradle
+++ b/agi_av_import_export/build.gradle
@@ -106,7 +106,7 @@ task unzipFiles(dependsOn: 'uploadFiles') {
 task createFederalFiles(type: Av2ch, dependsOn: 'unzipFiles') {
     inputFile = fileTree(pathToUnzipFolder) { include '*.itf' }
     outputDirectory = file(pathToFederalFolder)
-    if (findProperty('ilivalidatorModeldir')) modeldir = ilivalidatorModeldir
+    modeldir = "https://geo.so.ch/models/"
     zip = true
 
     doLast {

--- a/agi_av_import_export/build.gradle
+++ b/agi_av_import_export/build.gradle
@@ -106,6 +106,7 @@ task unzipFiles(dependsOn: 'uploadFiles') {
 task createFederalFiles(type: Av2ch, dependsOn: 'unzipFiles') {
     inputFile = fileTree(pathToUnzipFolder) { include '*.itf' }
     outputDirectory = file(pathToFederalFolder)
+    if (findProperty('ilivalidatorModeldir')) modeldir = ilivalidatorModeldir
     zip = true
 
     doLast {


### PR DESCRIPTION
In diesem besonderen Fall (Task-Typ _Av2ch_) setzen wir `modeldir` fix auf einen URL-String. Denn mir scheint, dass dieser Task-Typ den Ausdruck `%ITF_DIR;https://geo.so.ch/models/;%JAR_DIR/ilimodels` nicht versteht. Im Log wird nämlich gemeldet:

```
Folder /tmp/workspace/agi_av_import_export/agi_av_import_export/%ITF_DIR doesn't exist; ignored
[...]
Folder /tmp/workspace/agi_av_import_export/agi_av_import_export/%JAR_DIR/ilimodels doesn't exist; ignored
```

Aber dieser Task-Typ berücksichtigt ebenfalls die _ParentSites_, weshalb der Eintrag `https://geo.so.ch/models/` ausreicht. Log-Auszug:

```
lookup model <DM01AVCH24LV95D> 1.0 in repository <%ITF_DIR/>
Folder /tmp/workspace/agi_av_import_export/agi_av_import_export/%ITF_DIR doesn't exist; ignored
lookup model <DM01AVCH24LV95D> 1.0 in repository <https://geo.so.ch/models/>
lookup model <DM01AVCH24LV95D> 1.0 in repository <%JAR_DIR/ilimodels/>
Folder /tmp/workspace/agi_av_import_export/agi_av_import_export/%JAR_DIR/ilimodels doesn't exist; ignored
lookup model <DM01AVCH24LV95D> 1.0 in repository <http://models.geo.kgk-cgc.ch/>
lookup model <DM01AVCH24LV95D> 1.0 in repository <http://models.geo.admin.ch/>
```

Und im letzten Repo wird dann das Modell gefunden.