### PR TITLE
Set modeldir

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,8 +117,13 @@ git checkout -b branchname
   * `solrIndexupdaterBaseUrl` (die interne Basis-URL zum Indexupdater für Solr)
   * `gretlShare`
   * `gretlEnvironment` (der Wert dieser Variable ist je nach Umgebung `test`, `integration` oder `production`)
-
-Die Anleitung, wie man solche Ressourcen (z.B. DB-Verbindungen) in Jenkins definiert oder bestehende Ressourcen bearbeitet, ist unter https://github.com/sogis/gretl/tree/master/openshift#create-or-update-resources-to-be-used-by-gretl. Die Anleitung, wie man neue Credentials anlegt oder bestehende bearbeitet, ist unter https://github.com/sogis/gretl/tree/master/openshift#create-or-update-secrets-to-be-used-by-gretl.
+  Die Anleitung, wie man solche Ressourcen (z.B. DB-Verbindungen) in Jenkins definiert oder bestehende Ressourcen bearbeitet, ist unter https://github.com/sogis/gretl/tree/master/openshift#create-or-update-resources-to-be-used-by-gretl. Die Anleitung, wie man neue Credentials anlegt oder bestehende bearbeitet, ist unter https://github.com/sogis/gretl/tree/master/openshift#create-or-update-secrets-to-be-used-by-gretl.
+* Bei _Ili2pg_-Tasks und _IliValidator_-Tasks die folgende Option setzen,
+  damit in den Betriebs-Umgebungen für den Download der benötigten Modelle
+  die Anzahl abzufragender INTERLIS-Repositories reduziert wird:
+  Bei _Ili2pg_-Tasks: `if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir`
+  Bei _IliValidator_-Tasks: `if (findProperty('ilivalidatorModeldir')) modeldir = ilivalidatorModeldir`
+  (Beispiele siehe https://github.com/sogis/gretljobs/commit/de8cc2f550d05442f558f077b85528bc2542c452)
 
 ### Files
 

--- a/README.md
+++ b/README.md
@@ -117,13 +117,17 @@ git checkout -b branchname
   * `solrIndexupdaterBaseUrl` (die interne Basis-URL zum Indexupdater für Solr)
   * `gretlShare`
   * `gretlEnvironment` (der Wert dieser Variable ist je nach Umgebung `test`, `integration` oder `production`)
-  Die Anleitung, wie man solche Ressourcen (z.B. DB-Verbindungen) in Jenkins definiert oder bestehende Ressourcen bearbeitet, ist unter https://github.com/sogis/gretl/tree/master/openshift#create-or-update-resources-to-be-used-by-gretl. Die Anleitung, wie man neue Credentials anlegt oder bestehende bearbeitet, ist unter https://github.com/sogis/gretl/tree/master/openshift#create-or-update-secrets-to-be-used-by-gretl.
 * Bei _Ili2pg_-Tasks und _IliValidator_-Tasks die folgende Option setzen,
   damit in den Betriebs-Umgebungen für den Download der benötigten Modelle
   die Anzahl abzufragender INTERLIS-Repositories reduziert wird:
+
   Bei _Ili2pg_-Tasks: `if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir`
+
   Bei _IliValidator_-Tasks: `if (findProperty('ilivalidatorModeldir')) modeldir = ilivalidatorModeldir`
+
   (Beispiele siehe https://github.com/sogis/gretljobs/commit/de8cc2f550d05442f558f077b85528bc2542c452)
+
+ Die Anleitung, wie man solche Ressourcen (z.B. DB-Verbindungen) in Jenkins definiert oder bestehende Ressourcen bearbeitet, ist unter https://github.com/sogis/gretl/tree/master/openshift#create-or-update-resources-to-be-used-by-gretl. Die Anleitung, wie man neue Credentials anlegt oder bestehende bearbeitet, ist unter https://github.com/sogis/gretl/tree/master/openshift#create-or-update-secrets-to-be-used-by-gretl.
 
 ### Files
 

--- a/afu_abbaustellen_pub/build.gradle
+++ b/afu_abbaustellen_pub/build.gradle
@@ -30,10 +30,12 @@ task exportGisXtf(type: Ili2pgExport, dependsOn: deleteAppData){
     disableValidation = true
     dataFile = gisXtfPath
     models = 'SO_AFU_ABBAUSTELLEN_20210630'
+    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
 }
 
 task validateJoined(type: IliValidator, dependsOn: exportGisXtf){
     dataFiles = [gisXtfPath, appXtfPath]
+    if (findProperty('ilivalidatorModeldir')) modeldir = ilivalidatorModeldir
     allObjectsAccessible = true
 }
 
@@ -42,6 +44,7 @@ task importAppData(type: Ili2pgImport, dependsOn: validateJoined){
     dbschema = schemaNameEdit
     disableValidation = true
     dataFile = appXtfPath
+    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
 }
 
 task writeToPub(type: Db2Db, dependsOn: importAppData){ 

--- a/afu_gefahrenkartierung_pub_export_ai/build.gradle
+++ b/afu_gefahrenkartierung_pub_export_ai/build.gradle
@@ -75,6 +75,7 @@ task exportGefkartMgdm(type: Ili2pgExport, dependsOn: 'mapGefkart2Mgdm') {
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     dbschema = "afu_gefahrenkartierung_mgdm"
     models = "Hazard_Mapping_LV95_V1_2"
+    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dataFile = exportFile
 }
 

--- a/afu_gewaesserschutz_pub/build.gradle
+++ b/afu_gewaesserschutz_pub/build.gradle
@@ -51,6 +51,7 @@ task exportAfuGewaesserschutz(type: Ili2pgExport, dependsOn: transferZonen) {
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     dbschema = 'afu_gewaesserschutz' 
     models = 'PlanerischerGewaesserschutz_LV95_V1_1'
+    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dataFile = exportFile
     disableValidation = true
   

--- a/afu_nabodat_import/build.gradle
+++ b/afu_nabodat_import/build.gradle
@@ -27,6 +27,7 @@ task importNabodat(type: Ili2pgReplace, dependsOn: unpackFiles){
      database = [dbUriEdit, dbUserEdit, dbPwdEdit]
      dbschema = 'afu_bodendaten_nabodat_v1'
      models = 'NABODAT_ErgebnisseBodenbelastung_Punktdaten_V1_1'
+     if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
      dataFile = 'upload/data.xtf'
      dataset = 'punktdaten'
      importTid = 'true'

--- a/agi_ch_gemeinden/build.gradle
+++ b/agi_ch_gemeinden/build.gradle
@@ -47,6 +47,7 @@ task dbImport(type: Ili2pgImport, dependsOn: 'unzipSwissBoundaries3D'){
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     dbschema = "agi_swissboundaries3d"
     models = "swissBOUNDARIES3D_ili2_LV95_V1_3"
+    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     disableValidation = false
     dataFile = file(xtfFilePath)
     deleteData = true

--- a/agi_check_ili_export/build.gradle
+++ b/agi_check_ili_export/build.gradle
@@ -171,6 +171,7 @@ task uploadLogZipFileLatest(type: S3Upload, dependsOn: "uploadLogZipFileDate") {
 
 //     task "importDatasetGpkg_$datasetId"(type: Ili2gpkgImport, dependsOn: "zipDatasetXtf_$datasetId") {
 //         models = modelNames
+//         if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
 //         dataFile = file(Paths.get(pathToTempFolder, datasetId + "_" + todaysDate + ".xtf"))
 //         dbfile = file(Paths.get(pathToTempFolder, datasetId + "_" + todaysDate + ".gpkg"))
 //         disableValidation = true

--- a/agi_dm01avso24/build.gradle
+++ b/agi_dm01avso24/build.gradle
@@ -51,6 +51,7 @@ cadastralSurveyingDataSets.each { cadastralSurveyingDataSet ->
         database = [dbUriEdit, dbUserEdit, dbPwdEdit]
         //database = ["jdbc:postgresql://localhost:54321/edit", "admin", "admin"]
         models = 'DM01AVSO24LV95'
+        if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
         dbschema = 'agi_dm01avso24_strokearcs'
         dataFile = file(Paths.get(pathToTempFolder.toString(), dataSet + "00.itf"))
         //topics = "DM01AVCH24LV95D.Liegenschaften;DM01AVCH24LV95D.Gemeindegrenzen;DM01AVCH24LV95D.Gebaeudeadressen"

--- a/agi_plz_ortschaften_pub/build.gradle
+++ b/agi_plz_ortschaften_pub/build.gradle
@@ -46,6 +46,7 @@ task dbImport(type: Ili2pgImport, dependsOn: 'unzipData'){
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     dbschema = "agi_plz_ortschaften"
     models = "PLZOCH1LV95D"
+    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     disableValidation = false
     dataFile = file(xtfFilePath)
     deleteData = true

--- a/agi_swisstopo_gebaeudeadressen/build.gradle
+++ b/agi_swisstopo_gebaeudeadressen/build.gradle
@@ -43,6 +43,7 @@ task dbImport(type: Ili2pgImport, dependsOn: 'unzipData') {
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     dbschema = "agi_swisstopo_gebaeudeadressen"
     models = "OfficialIndexOfAddresses_V2"
+    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     disableValidation = true
     dataFile = file(xtfFilePath)
     deleteData = true

--- a/alw_fruchtfolgeflaechen_export_ai/build.gradle
+++ b/alw_fruchtfolgeflaechen_export_ai/build.gradle
@@ -57,6 +57,7 @@ task exportFFFMgdm(type: Ili2pgExport, dependsOn: 'mapFFF2Mgdm') {
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     dbschema = "alw_fruchtfolgeflaechen_mgdm_v1"
     models = "Fruchtfolgeflaechen_LV95_V1"
+    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dataFile = exportFile
 }
 

--- a/alw_fruchtfolgeflaechen_pub/build.gradle
+++ b/alw_fruchtfolgeflaechen_pub/build.gradle
@@ -75,6 +75,7 @@ task exportFFF(type: Ili2pgExport, dependsOn: 'fff_to_pub_db') {
     database = [dbUriPub, dbUserPub, dbPwdPub]
     dbschema = "alw_fruchtfolgeflaechen_pub_v1"
     models = "SO_ALW_Fruchtfolgeflaechen_Publikation_20220110"
+    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dataFile = exportFile
 }
 
@@ -127,6 +128,7 @@ Wandelt den aktuellen Export zu einem Geopackage um und lädt ihn hoch
 */
 task importDataToGeopackage(type: Ili2gpkgImport, dependsOn: 'exportFFF') {
     models = "SO_ALW_Fruchtfolgeflaechen_Publikation_20220110"
+    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dataFile = file(exportFile);
     dbfile = file(exportFileGeopackage)  
     disableValidation = true //Da schon der Export validiert wurde, muss der Import nicht auch noch mal validiert werden!

--- a/alw_landwirtschaft_tierhaltung_import_bodenbedeckung/build.gradle
+++ b/alw_landwirtschaft_tierhaltung_import_bodenbedeckung/build.gradle
@@ -40,6 +40,7 @@ task importGELAN(type: Ili2pgReplace, dependsOn: downloadData) {
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     dbschema = "alw_landwirtschaft_tierhaltung_v1"
     models = 'SO_ALW_Landwirtschaft_Tierhaltung_20210426'
+    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dataFile = Paths.get(pathToTempFolder, 'Export_ais_ln.xtf')
     dataset = 'bodenbedeckung'
 }

--- a/alw_landwirtschaft_tierhaltung_import_massnahmen/build.gradle
+++ b/alw_landwirtschaft_tierhaltung_import_massnahmen/build.gradle
@@ -40,6 +40,7 @@ task importGELAN(type: Ili2pgReplace, dependsOn: downloadData) {
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     dbschema = "alw_landwirtschaft_tierhaltung_v1"
     models = 'SO_ALW_Landwirtschaft_Tierhaltung_20210426'
+    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dataFile = Paths.get(pathToTempFolder, 'Export_ais_pp-mg.xtf')
     dataset = 'massnahmen'
 }

--- a/alw_landwirtschaft_tierhaltung_pub/build.gradle
+++ b/alw_landwirtschaft_tierhaltung_pub/build.gradle
@@ -41,6 +41,7 @@ task importGELAN(type: Ili2pgReplace, dependsOn: downloadData) {
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     dbschema = "alw_landwirtschaft_tierhaltung_v1"
     models = 'SO_ALW_Landwirtschaft_Tierhaltung_20210426'
+    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dataFile = Paths.get(pathToTempFolder, 'Export_ais_agrardaten.xtf')
     dataset = 'agrardaten'
 }

--- a/alw_strukturverbesserungen_suissemelio/build.gradle
+++ b/alw_strukturverbesserungen_suissemelio/build.gradle
@@ -76,4 +76,3 @@ task uploadXtfFile (dependsOn: validateSVGIS_Suissemelio){
     }
     finalizedBy deleteXtfFile
 }
-

--- a/alw_strukturverbesserungen_suissemelio/build.gradle
+++ b/alw_strukturverbesserungen_suissemelio/build.gradle
@@ -45,6 +45,7 @@ task transfer_SVGIS_Suissemelio(type: Db2Db){
 task exportSVGIS_Suissemelio(type: Ili2pgExport, dependsOn: 'transfer_SVGIS_Suissemelio') {
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     models = 'Strukturverbesserungen_LV95_V2'
+    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dbschema = 'alw_strukturverbesserungen_suissemelio'
     dataFile = file(SVGIS_SuissemelioXtfFileName)
     disableValidation = true
@@ -52,6 +53,7 @@ task exportSVGIS_Suissemelio(type: Ili2pgExport, dependsOn: 'transfer_SVGIS_Suis
 
 task validateSVGIS_Suissemelio(type: IliValidator, dependsOn: 'exportSVGIS_Suissemelio') {
     dataFiles = [file(SVGIS_SuissemelioXtfFileName)]
+    if (findProperty('ilivalidatorModeldir')) modeldir = ilivalidatorModeldir
     logFile = "ilivalidator_SVGIS_Suissemelio.log"
     allObjectsAccessible = true
     failOnError = true

--- a/alw_zonengrenzen_import/build.gradle
+++ b/alw_zonengrenzen_import/build.gradle
@@ -34,6 +34,7 @@ task importKataloge(type: Ili2pgReplace, dependsOn: 'downloadKataloge'){
      database = [dbUriEdit, dbUserEdit, dbPwdEdit]
      dbschema = 'alw_zonengrenzen'
      models = 'Landwirtschaftliche_Zonengrenzen_LV95_V1_2'
+     if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
      dataFile = file(Paths.get(pathToTempFolder.toString(), 'landwirtschaftliche_zonengrenzen_kataloge_20140701.xml'))
      dataset = 'landwirtschaftliche_zonengrenzen_kataloge_20140701.xml-2938'
 }
@@ -57,6 +58,7 @@ task importData(type: Ili2pgReplace, dependsOn: 'unzipData'){
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     dbschema = 'alw_zonengrenzen'
     models = 'Landwirtschaftliche_Zonengrenzen_LV95_V1_2'
+    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dataFile = file(Paths.get(pathToUnzipFolder.toString(), 'NachF_LWZ_INTERLIS2.xtf'))
     dataset = 'NachF_LWZ_INTERLIS2.xtf'
     strokeArcs = true

--- a/arp_mjpnl_initialisierung/build.gradle
+++ b/arp_mjpnl_initialisierung/build.gradle
@@ -36,6 +36,7 @@ task importMJPNL(type: Ili2pgReplace, dependsOn: 'copyXtfFile') {
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     dbschema = "arp_mjpnl_v1"
     models = "SO_ARP_MJPNL_20201026"
+    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     topics = "SO_ARP_MJPNL_20201026.MJPNL"
     dataFile = "upload/mjpnl_init.xtf"
     dataset = "MJPNL"
@@ -62,6 +63,7 @@ task importGELAN(type: Ili2pgReplace, dependsOn: downloadData) {
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     dbschema = "arp_mjpnl_v1"
     models = 'SO_ALW_Landwirtschaft_Tierhaltung_20210426'
+    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     topics = 'SO_ALW_Landwirtschaft_Tierhaltung_20210426.Betriebsdaten_Strukturdaten'
     dataFile = Paths.get(pathToTempFolder, 'Export_ais_agrardaten.xtf')
     dataset = 'GELAN'

--- a/arp_npl_export_ai/build.gradle
+++ b/arp_npl_export_ai/build.gradle
@@ -41,6 +41,7 @@ task deleteMgdmLandUsesPlansData(type: SqlExecutor) {
 task importMgdmHauptnutzung(type: Ili2pgImport, dependsOn: 'deleteMgdmLandUsesPlansData') {
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     models = iliModelMgdmHauptnutzung
+    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dbschema = dbSchemaMgdmLandUsePlans
     dataFile = file("Hauptnutzung_CH_V1_1.xml")
     disableValidation = true
@@ -54,6 +55,7 @@ task transferLandUsePlansData(type: SqlExecutor, dependsOn: 'importMgdmHauptnutz
 task exportMgdmLandUsePlans(type: Ili2pgExport, dependsOn: 'transferLandUsePlansData') {
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     models = iliModelMgdmLandUsePlans
+    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dbschema = dbSchemaMgdmLandUsePlans
     dataFile = file(mgdmLandUsePlansXtfFileName)
     disableValidation = true
@@ -61,6 +63,7 @@ task exportMgdmLandUsePlans(type: Ili2pgExport, dependsOn: 'transferLandUsePlans
 
 task validateMgdmLandUsePlans(type: IliValidator, dependsOn: 'exportMgdmLandUsePlans') {
     dataFiles = [file("Hauptnutzung_CH_V1_1.xml"), file(mgdmLandUsePlansXtfFileName)]
+    if (findProperty('ilivalidatorModeldir')) modeldir = ilivalidatorModeldir
     logFile = "ilivalidator_landuseplans.log"
     allObjectsAccessible = true
     configFile = "config.toml"
@@ -103,6 +106,7 @@ task transferNoiseSensitivityLevels(type: SqlExecutor) {
 task exportMgdmNoiseSensitivityLevels(type: Ili2pgExport, dependsOn: 'transferNoiseSensitivityLevels') {
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     models = iliModelMgdmNoiseSensitivityLevels
+    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dbschema = dbSchemaMgdmSensitivityLevels
     dataFile = file(mgdmSensitivityLevelsXtfFileName)
     disableValidation = true
@@ -110,6 +114,7 @@ task exportMgdmNoiseSensitivityLevels(type: Ili2pgExport, dependsOn: 'transferNo
 
 task validateMgdmNoiseSensitivityLevels(type: IliValidator, dependsOn: 'exportMgdmNoiseSensitivityLevels') {
     dataFiles = [file(mgdmSensitivityLevelsXtfFileName)]
+    if (findProperty('ilivalidatorModeldir')) modeldir = ilivalidatorModeldir
     logFile = "ilivalidator_noisesensitivitylevels.log"
     configFile = "config.toml"
     failOnError = true
@@ -146,6 +151,7 @@ task transferWaldabstandslinien(type: SqlExecutor) {
 task exportMgdmWaldabstandslinien(type: Ili2pgExport, dependsOn: 'transferWaldabstandslinien') {
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     models = iliModelMgdmWaldabstand
+    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dbschema = dbSchemaWaldabstand
     dataFile = file(mgdmWaldabstandXtfFileName)
     disableValidation = true
@@ -153,6 +159,7 @@ task exportMgdmWaldabstandslinien(type: Ili2pgExport, dependsOn: 'transferWaldab
 
 task validateMgdmWaldabstandslinien(type: IliValidator, dependsOn: 'exportMgdmWaldabstandslinien') {
     dataFiles = [file(mgdmWaldabstandXtfFileName)]
+    if (findProperty('ilivalidatorModeldir')) modeldir = ilivalidatorModeldir
     logFile = "ilivalidator_waldabstandslinien.log"
     configFile = "config.toml"
     failOnError = true

--- a/arp_npl_import/build.gradle
+++ b/arp_npl_import/build.gradle
@@ -46,6 +46,7 @@ task replaceDataset (type: Ili2pgReplace, dependsOn: 'checkBsfNummer') {
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     dbschema = "arp_npl"
     models = "SO_Nutzungsplanung_20171118"
+    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     disableValidation = true
     dataset = ili2pgDataset
     dataFile = "upload/${ili2pgDataset}.xtf"

--- a/arp_nutzungsplanung_delete_dataset/build.gradle
+++ b/arp_nutzungsplanung_delete_dataset/build.gradle
@@ -12,6 +12,7 @@ task exportData_Dataset_BFSNr(type: Ili2pgExport) {
     description = "Exportiert die zu löschenden Daten mit dem angegebenden Datasetname (BFS-Nr.)aus dem Schema arp_nutzungsplanung_v1 in ein INTERLIS-Datei. Dient zur Sicherung"
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     models = 'SO_ARP_Nutzungsplanung_Nachfuehrung_20201005'
+    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dbschema = 'arp_nutzungsplanung_v1'
     dataset = bfsnr
     dataFile = "$rootDir/" + bfsnr + ".xtf"
@@ -22,6 +23,7 @@ task delete_Dataset_BFSNr(type: Ili2pgDelete, dependsOn: 'exportData_Dataset_BFS
     description = "Löscht Daten mit dem angegebenen Datasetname (BFS-Nr.) aus dem Schema arp_nutzungsplanung_v1"
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     models = 'SO_ARP_Nutzungsplanung_Nachfuehrung_20201005'
+    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dbschema = 'arp_nutzungsplanung_v1'
     dataset = bfsnr
 }

--- a/arp_nutzungsplanung_digizone_pub/build.gradle
+++ b/arp_nutzungsplanung_digizone_pub/build.gradle
@@ -15,6 +15,7 @@ task exportDataEdit (type: Ili2pgExport) {
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     dbschema = 'arp_nutzungsplanung_digizone_v1'
     models = 'SO_ARP_Nutzungsplanung_Publikation_20201005'
+    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dataFile= file("digizone.xtf")
     disableValidation = true
 }
@@ -22,6 +23,7 @@ task exportDataEdit (type: Ili2pgExport) {
 task validateDataEdit(type: IliValidator, dependsOn: 'exportDataEdit') {
     description = "Validiert die exportierten INTERLIS-Datei gegen das Modell."
     dataFiles = file("digizone.xtf")
+    if (findProperty('ilivalidatorModeldir')) modeldir = ilivalidatorModeldir
     failOnError = true
 }
 
@@ -30,6 +32,7 @@ task importXTF_pub(type: Ili2pgReplace, dependsOn: 'validateDataEdit') {
     database = [dbUriPub, dbUserPub, dbPwdPub]
     dbschema = 'arp_nutzungsplanung_pub_v1'
     models = 'SO_ARP_Nutzungsplanung_Publikation_20201005'
+    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dataset = 'digizone'
     dataFile = file("digizone.xtf")
     disableValidation = true

--- a/arp_nutzungsplanung_import/build.gradle
+++ b/arp_nutzungsplanung_import/build.gradle
@@ -20,6 +20,7 @@ task importXtfFile(type: Ili2pgReplace, dependsOn: 'copyXtfFile') {
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     dbschema = 'arp_nutzungsplanung_import_v1'
     models = 'SO_Nutzungsplanung_20171118'
+    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     deleteData= true
     dataset = ili2pgDataset
     dataFile = "upload/${ili2pgDataset}.xtf"
@@ -40,6 +41,7 @@ task deleteData_import(type: Ili2pgDelete) {
     description = "Löscht/leert Daten mit dem angegebenen Datasetname (BFS-Nr.) aus dem Schema arp_nutzungsplanung_import_v1"
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     models = 'SO_ARP_Nutzungsplanung_Nachfuehrung_20201005'
+    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dbschema = 'arp_nutzungsplanung_import_v1'
     dataset = ili2pgDataset
 }
@@ -56,6 +58,7 @@ task exportData_Dataset_BFSNr(type: Ili2pgExport) {
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     dbschema = 'arp_nutzungsplanung_transfer_v1'
     models = 'SO_ARP_Nutzungsplanung_Nachfuehrung_20201005'
+    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dataset = ili2pgDataset
     dataFile= file(ili2pgDataset + ".xtf")
     disableValidation = true
@@ -64,6 +67,7 @@ task exportData_Dataset_BFSNr(type: Ili2pgExport) {
 task validateData_Dataset_BFSNr(type: IliValidator, dependsOn: 'exportData_Dataset_BFSNr') {
     description = "Validiert die exportierten INTERLIS-Datei gegen das Modell."
     dataFiles = file(ili2pgDataset + ".xtf")
+    if (findProperty('ilivalidatorModeldir')) modeldir = ilivalidatorModeldir
     allObjectsAccessible = true
     failOnError = false
 }
@@ -77,6 +81,7 @@ task importData_Dataset_BFSNr(type: Ili2pgImport) {
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     dbschema = 'arp_nutzungsplanung_v1'
     models = 'SO_ARP_Nutzungsplanung_Nachfuehrung_20201005'
+    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dataset = ili2pgDataset
     dataFile = file(ili2pgDataset + ".xtf")
     disableValidation = true
@@ -88,6 +93,7 @@ task exportData_Dataset_Kanton(type: Ili2pgExport) {
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     dbschema = 'arp_nutzungsplanung_transfer_v1'
     models = 'SO_ARP_Nutzungsplanung_Nachfuehrung_20201005'
+    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dataset = 'Kanton'
     dataFile = file(ili2pgDataset + "_Kanton.xtf")
     disableValidation = true
@@ -96,6 +102,7 @@ task exportData_Dataset_Kanton(type: Ili2pgExport) {
 task validateData_Dataset_Kanton(type: IliValidator, dependsOn: 'exportData_Dataset_Kanton') {
     description = "Validiert die exportierten INTERLIS-Datei gegen das Modell."
     dataFiles = file(ili2pgDataset + "_Kanton.xtf")
+    if (findProperty('ilivalidatorModeldir')) modeldir = ilivalidatorModeldir
     allObjectsAccessible = true
     failOnError = false
 }
@@ -109,6 +116,7 @@ task importData_Dataset_Kanton(type: Ili2pgImport) {
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     dbschema = 'arp_nutzungsplanung_kanton_v1'
     models = 'SO_ARP_Nutzungsplanung_Nachfuehrung_20201005'
+    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dataFile = file(ili2pgDataset + "_Kanton.xtf")
     disableValidation = true
     finalizedBy deleteXtfFile_Kanton

--- a/arp_nutzungsplanung_import_ersterfassung/build.gradle
+++ b/arp_nutzungsplanung_import_ersterfassung/build.gradle
@@ -20,6 +20,7 @@ task importXtfFile(type: Ili2pgReplace, dependsOn: 'copyXtfFile') {
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     dbschema = 'arp_nutzungsplanung_import_v1'
     models = 'SO_Nutzungsplanung_20171118'
+    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     deleteData= true
     dataset = ili2pgDataset
     dataFile = "upload/${ili2pgDataset}.xtf"
@@ -46,6 +47,7 @@ task deleteData_import(type: Ili2pgDelete, dependsOn: 'transferData') {
     description = "Löscht/leert Daten mit dem angegebenen Datasetname (BFS-Nr.) aus dem Schema arp_nutzungsplanung_import_v1"
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     models = 'SO_ARP_Nutzungsplanung_Nachfuehrung_20201005'
+    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dbschema = 'arp_nutzungsplanung_import_v1'
     dataset = ili2pgDataset
 }
@@ -61,6 +63,7 @@ task exportDataEdit (type: Ili2pgExport, dependsOn: 'deleteData_transfer_pub') {
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     dbschema = 'arp_nutzungsplanung_transfer_v1'
     models = 'SO_ARP_Nutzungsplanung_Nachfuehrung_20201005'
+    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dataset = ili2pgDataset
     dataFile= file(ili2pgDataset + "for_stage.xtf")
     disableValidation = true
@@ -69,6 +72,7 @@ task exportDataEdit (type: Ili2pgExport, dependsOn: 'deleteData_transfer_pub') {
 task validateDataEdit(type: IliValidator, dependsOn: 'exportDataEdit') {
     description = "Validiert die exportierten INTERLIS-Datei gegen das Modell."
     dataFiles = file(ili2pgDataset + "for_stage.xtf")
+    if (findProperty('ilivalidatorModeldir')) modeldir = ilivalidatorModeldir
     allObjectsAccessible = true
     failOnError = true
 }
@@ -85,6 +89,7 @@ task exportData (type: Ili2pgExport, dependsOn: 'transferData_pub') {
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     dbschema = 'arp_nutzungsplanung_transfer_pub_v1'
     models = 'SO_ARP_Nutzungsplanung_Publikation_20201005'
+    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dataFile= file(ili2pgDataset + "_pub.xtf")
     disableValidation = true
 }
@@ -92,6 +97,7 @@ task exportData (type: Ili2pgExport, dependsOn: 'transferData_pub') {
 task validateData(type: IliValidator, dependsOn: 'exportData') {
     description = "Validiert die exportierten INTERLIS-Datei gegen das Modell."
     dataFiles = file(ili2pgDataset + "_pub.xtf")
+    if (findProperty('ilivalidatorModeldir')) modeldir = ilivalidatorModeldir
     failOnError = true
 }
 
@@ -100,6 +106,7 @@ task importXTF_stage(type: Ili2pgReplace, dependsOn: 'validateData') {
     database = [dbUriPub, dbUserPub, dbPwdPub]
     dbschema = 'arp_nutzungsplanung_staging_v1'
     models = 'SO_ARP_Nutzungsplanung_Publikation_20201005'
+    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dataset = ili2pgDataset
     dataFile = file(ili2pgDataset + "_pub.xtf")
     disableValidation = true

--- a/arp_nutzungsplanung_kanton_pub/build.gradle
+++ b/arp_nutzungsplanung_kanton_pub/build.gradle
@@ -20,6 +20,7 @@ task exportDataEdit (type: Ili2pgExport, dependsOn: 'deleteData_transfer_pub') {
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     dbschema = 'arp_nutzungsplanung_kanton_v1'
     models = 'SO_ARP_Nutzungsplanung_Nachfuehrung_20201005'
+    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dataFile= file("kanton.xtf")
     disableValidation = true
 }
@@ -27,6 +28,7 @@ task exportDataEdit (type: Ili2pgExport, dependsOn: 'deleteData_transfer_pub') {
 task validateDataEdit(type: IliValidator, dependsOn: 'exportDataEdit') {
     description = "Validiert die exportierten INTERLIS-Datei gegen das Modell."
     dataFiles = file("kanton.xtf")
+    if (findProperty('ilivalidatorModeldir')) modeldir = ilivalidatorModeldir
     configFile = 'SO_ARP_Nutzungsplanung_Nachfuehrung_20201005.ini'
     allObjectsAccessible = true
     failOnError = true
@@ -43,6 +45,7 @@ task exportData (type: Ili2pgExport, dependsOn: 'transferData') {
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     dbschema = 'arp_nutzungsplanung_transfer_pub_v1'
     models = 'SO_ARP_Nutzungsplanung_Publikation_20201005'
+    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dataFile= file("kanton_pub.xtf")
     disableValidation = true
 }
@@ -50,6 +53,7 @@ task exportData (type: Ili2pgExport, dependsOn: 'transferData') {
 task validateData(type: IliValidator, dependsOn: 'exportData') {
     description = "Validiert die exportierten INTERLIS-Datei gegen das Modell."
     dataFiles = file("kanton_pub.xtf")
+    if (findProperty('ilivalidatorModeldir')) modeldir = ilivalidatorModeldir
     failOnError = true
 }
 
@@ -58,6 +62,7 @@ task importXTF_stage(type: Ili2pgReplace, dependsOn: 'validateData') {
     database = [dbUriPub, dbUserPub, dbPwdPub]
     dbschema = 'arp_nutzungsplanung_staging_v1'
     models = 'SO_ARP_Nutzungsplanung_Publikation_20201005'
+    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dataset = 'Kanton'
     dataFile = file("kanton_pub.xtf")
     disableValidation = true
@@ -67,6 +72,7 @@ task delete_Dataset_stage(type: Ili2pgDelete) {
     description = "Löscht Daten mit Dataset= Kanton aus dem Schema arp_nutzungsplanung_staging"
     database = [dbUriPub, dbUserPub, dbPwdPub]
     models = 'SO_ARP_Nutzungsplanung_Publikation_20201005'
+    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dbschema = 'arp_nutzungsplanung_staging_v1'
     dataset = 'Kanton'
 }
@@ -76,6 +82,7 @@ task importXTF_pub(type: Ili2pgReplace) {
     database = [dbUriPub, dbUserPub, dbPwdPub]
     dbschema = 'arp_nutzungsplanung_pub_v1'
     models = 'SO_ARP_Nutzungsplanung_Publikation_20201005'
+    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dataset = 'Kanton'
     dataFile = file("kanton_pub.xtf")
     disableValidation = true

--- a/arp_nutzungsplanung_pub/build.gradle
+++ b/arp_nutzungsplanung_pub/build.gradle
@@ -20,6 +20,7 @@ task exportDataEdit (type: Ili2pgExport, dependsOn: 'deleteData_transfer_pub') {
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     dbschema = 'arp_nutzungsplanung_v1'
     models = 'SO_ARP_Nutzungsplanung_Nachfuehrung_20201005'
+    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dataset = bfsnr
     dataFile= file(bfsnr + ".xtf")
     disableValidation = true
@@ -28,6 +29,7 @@ task exportDataEdit (type: Ili2pgExport, dependsOn: 'deleteData_transfer_pub') {
 task validateDataEdit(type: IliValidator, dependsOn: 'exportDataEdit') {
     description = "Validiert die exportierten INTERLIS-Datei gegen das Modell."
     dataFiles = file(bfsnr + ".xtf")
+    if (findProperty('ilivalidatorModeldir')) modeldir = ilivalidatorModeldir
     configFile = 'SO_ARP_Nutzungsplanung_Nachfuehrung_20201005.ini'
     allObjectsAccessible = true
     failOnError = true
@@ -45,6 +47,7 @@ task exportData (type: Ili2pgExport, dependsOn: 'transferData') {
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     dbschema = 'arp_nutzungsplanung_transfer_pub_v1'
     models = 'SO_ARP_Nutzungsplanung_Publikation_20201005'
+    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dataFile= file(bfsnr + "_pub.xtf")
     disableValidation = true
 }
@@ -52,6 +55,7 @@ task exportData (type: Ili2pgExport, dependsOn: 'transferData') {
 task validateData(type: IliValidator, dependsOn: 'exportData') {
     description = "Validiert die exportierten INTERLIS-Datei gegen das Modell."
     dataFiles = file(bfsnr + "_pub.xtf")
+    if (findProperty('ilivalidatorModeldir')) modeldir = ilivalidatorModeldir
     failOnError = true
 }
 
@@ -60,6 +64,7 @@ task importXTF_stage(type: Ili2pgReplace, dependsOn: 'validateData') {
     database = [dbUriPub, dbUserPub, dbPwdPub]
     dbschema = 'arp_nutzungsplanung_staging_v1'
     models = 'SO_ARP_Nutzungsplanung_Publikation_20201005'
+    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dataset = bfsnr
     dataFile = file(bfsnr + "_pub.xtf")
     disableValidation = true
@@ -69,6 +74,7 @@ task delete_Dataset_stage(type: Ili2pgDelete) {
     description = "Löscht Daten mit dem angegebenen Datasetname (BFS-Nr.) aus dem Schema arp_nutzungsplanung_staging"
     database = [dbUriPub, dbUserPub, dbPwdPub]
     models = 'SO_ARP_Nutzungsplanung_Publikation_20201005'
+    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dbschema = 'arp_nutzungsplanung_staging_v1'
     dataset = bfsnr
 }
@@ -78,6 +84,7 @@ task importXTF_pub(type: Ili2pgReplace) {
     database = [dbUriPub, dbUserPub, dbPwdPub]
     dbschema = 'arp_nutzungsplanung_pub_v1'
     models = 'SO_ARP_Nutzungsplanung_Publikation_20201005'
+    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dataset = bfsnr
     dataFile = file(bfsnr + "_pub.xtf")
     disableValidation = true

--- a/arp_wildruhezonen_export_ai/build.gradle
+++ b/arp_wildruhezonen_export_ai/build.gradle
@@ -20,6 +20,7 @@ Package and upload to the KKGEO AI
 task exportMgdmWildruhezonen(type: Ili2pgExport) {
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     models = "Wildruhezonen_LV95_V2_1"
+    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dbschema = "arp_wildruhezonen_mgdm_v1"
     dataFile = file(xtfFileName)
     disableValidation = true
@@ -27,6 +28,7 @@ task exportMgdmWildruhezonen(type: Ili2pgExport) {
 
 task validateMgdmWildruhezonen(type: IliValidator, dependsOn: 'exportMgdmWildruhezonen') {
     dataFiles = [file(xtfFileName)]
+    if (findProperty('ilivalidatorModeldir')) modeldir = ilivalidatorModeldir
     logFile = "ilivalidator.log"
     failOnError = true
 }

--- a/avt_groblaermkataster_pub/build.gradle
+++ b/avt_groblaermkataster_pub/build.gradle
@@ -16,6 +16,7 @@ task replaceDataset (type: Ili2pgImport, dependsOn: 'copyCsvFile') {
     database = [dbUriPub, dbUserPub, dbPwdPub]
     dbschema = "avt_groblaermkataster_pub"
     models = "SO_AVT_Groblaermkataster_20190709"
+    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     disableValidation = true
     deleteData = true
     dataFile = "upload/uploadFile.xtf"  // name is injected by jenkins

--- a/avt_kunstbauten_pub/build.gradle
+++ b/avt_kunstbauten_pub/build.gradle
@@ -14,10 +14,12 @@ task exportXtf(type: Ili2pgExport){
     disableValidation = true
     dataFile = xtfPath
     models = "SO_AVT_Kunstbauten_Publikation_20220207"
+    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
 }
 
 task validate(type: IliValidator, dependsOn: exportXtf){
     dataFiles = [xtfPath]
+    if (findProperty('ilivalidatorModeldir')) modeldir = ilivalidatorModeldir
 }
 
 task writeToPub(type: Db2Db, dependsOn: validate){ 

--- a/avt_oev_gueteklassen_import/build.gradle
+++ b/avt_oev_gueteklassen_import/build.gradle
@@ -19,6 +19,7 @@ task import_to_stage(type: Ili2pgImport, dependsOn: rename){
      database = [dbUriEdit, dbUserEdit, dbPwdEdit]
      dbschema = 'avt_oev_gueteklassen_staging_v1'
      models = 'SO_AVT_Oev_Gueteklassen_20220120'
+     if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
      dataFile = 'upload/uploadFile.xtf'
      deleteData = true
 }
@@ -28,6 +29,7 @@ task import_to_pub(type: Ili2pgImport){
      database = [dbUriPub, dbUserPub, dbPwdPub]
      dbschema = 'avt_oev_gueteklassen_pub_v1'
      models = 'SO_AVT_Oev_Gueteklassen_20220120'
+     if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
      dataFile = 'upload/uploadFile.xtf'
      deleteData = true
 }

--- a/avt_strassenlaerm/build.gradle
+++ b/avt_strassenlaerm/build.gradle
@@ -31,6 +31,7 @@ task replaceDataset (type: Ili2pgReplace, dependsOn: downloadData) {
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     dbschema = "avt_strassenlaerm"
     models = "SO_AVT_Strassenlaerm_20190806"
+    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     disableValidation = true
     importTid = true
     dataset = "data"

--- a/awa_stromversorgungssicherheit_netzgebiete_pub/build.gradle
+++ b/awa_stromversorgungssicherheit_netzgebiete_pub/build.gradle
@@ -25,6 +25,7 @@ task transferNetzgebiete(type: Db2Db){
 task exportMgdmNetzgebiete(type: Ili2pgExport, dependsOn: 'transferNetzgebiete') {
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     models = "SupplySecurity_RuledAreas_V1_2"
+    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dbschema = "awa_stromversorgungssicherheit"
     dataFile = file(mgdmNetzgebieteXtfFileName)
     disableValidation = true
@@ -32,6 +33,7 @@ task exportMgdmNetzgebiete(type: Ili2pgExport, dependsOn: 'transferNetzgebiete')
 
 task validateMgdmNetzgebiete(type: IliValidator, dependsOn: 'exportMgdmNetzgebiete') {
     dataFiles = [file(mgdmNetzgebieteXtfFileName)]
+    if (findProperty('ilivalidatorModeldir')) modeldir = ilivalidatorModeldir
     logFile = "ilivalidator.log"
     failOnError = true
 }

--- a/awjf_statische_waldgrenzen_export_ai/build.gradle
+++ b/awjf_statische_waldgrenzen_export_ai/build.gradle
@@ -21,6 +21,7 @@ task transferWaldgrenzen(type: SqlExecutor) {
 task exportMgdmWaldgrenzen(type: Ili2pgExport, dependsOn: 'transferWaldgrenzen') {
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     models = iliModelMgdmWaldgrenzen
+    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dbschema = dbSchemaMgdmWaldgrenzen
     dataFile = file(mgdmWaldgrenzenXtfFileName)
     disableValidation = true
@@ -28,6 +29,7 @@ task exportMgdmWaldgrenzen(type: Ili2pgExport, dependsOn: 'transferWaldgrenzen')
 
 task validateMgdmWaldgrenzen(type: IliValidator, dependsOn: 'exportMgdmWaldgrenzen') {
     dataFiles = [file(mgdmWaldgrenzenXtfFileName)]
+    if (findProperty('ilivalidatorModeldir')) modeldir = ilivalidatorModeldir
     logFile = "ilivalidator_waldgrenzen.log"
     //configFile = "config.toml"
     failOnError = false


### PR DESCRIPTION
Im Job _alw_fruchtfolgeflächen_ habe ich nichts geändert, weil dort bereits teilweise `modeldir` gesetzt ist (Verweis auf Modelle, die im Job-Verzeichnis liegen).