### PR TITLE
Rename default branch to main

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,7 @@ pipeline {
                 retry(2)
             }
             steps {
-                git url: "${env.GIT_REPO_URL}", branch: "${params.BRANCH ?: 'master'}", changelog: false
+                git url: "${env.GIT_REPO_URL}", branch: "${params.BRANCH ?: 'main'}", changelog: false
                 container('gretl') {
                     dir(env.JOB_BASE_NAME) {
                         sh 'gretl'

--- a/README.md
+++ b/README.md
@@ -34,16 +34,16 @@ und so prüfen, ob die Änderungen wie gewünscht funktionieren.
 Allenfalls noch erforderliche Anpassungen
 kann man im gleichen Branch vornehmen und sie wieder pushen, usw.
 
-Bei einem **neuen Job**, der also noch nicht im _master_-Branch,
+Bei einem **neuen Job**, der also noch nicht im _main_-Branch,
 sondern erst in einem anderen Branch vorliegt, ist das Vorgehen ähnlich;
-man muss aber zuerst gemäss folgender Anleitung auch im _master_-Branch
+man muss aber zuerst gemäss folgender Anleitung auch im _main_-Branch
 den entsprechenden Job-Ordner und eine leere Datei _build.gradle_ anlegen,
 damit der Job bereits in GRETL-Jenkins aufgelistet wird:
 
 * Den Job wie gehabt lokal in einem Branch entwickeln und den Branch pushen
-* Lokal in den _master_-Branch wechseln und den aktuellen Stand pullen:
+* Lokal in den _main_-Branch wechseln und den aktuellen Stand pullen:
   ```
-  git checkout master && git pull
+  git checkout main && git pull
   ```
 * Auch in diesem Branch einen Ordner mit demselben Namen wie der neue Job anlegen:
   ```
@@ -59,7 +59,7 @@ damit der Job bereits in GRETL-Jenkins aufgelistet wird:
   ```
 * Diesen "Job-Initialisierungs-Commit" pushen:
   ```
-  git push origin master
+  git push origin main
   ```
 * In GRETL-Jenkins z.B. der Testumgebung
   den Job _gretl-job-generator_ einmal laufenlassen
@@ -76,7 +76,7 @@ in welchem man den neuen Job entwickelt hat.
 git checkout -b branchname
 ```
 
-* Änderungen müssen immer per Pull Request in den master-Branch eingepflegt werden
+* Änderungen müssen immer per Pull Request in den main-Branch eingepflegt werden
 
 ### build.gradle
 

--- a/afu_abbaustellen_pub/Jenkinsfile
+++ b/afu_abbaustellen_pub/Jenkinsfile
@@ -6,7 +6,7 @@ pipeline {
     stages {
         stage('Run GRETL-Job') {
             steps {
-                git url: "${env.GIT_REPO_URL}", branch: "${params.BRANCH ?: 'master'}", changelog: false
+                git url: "${env.GIT_REPO_URL}", branch: "${params.BRANCH ?: 'main'}", changelog: false
                 container('gretl') {
                     dir(env.JOB_BASE_NAME) {
                         sh "gretl -PafuAbbaustellenAppXtfUrl=${params.afuAbbaustellenAppXtfUrl}"

--- a/afu_nabodat_import/Jenkinsfile
+++ b/afu_nabodat_import/Jenkinsfile
@@ -24,7 +24,7 @@ pipeline {
     stages {
         stage('Run GRETL-Job') {
             steps {
-                git url: "${env.GIT_REPO_URL}", branch: "${params.BRANCH ?: 'master'}", changelog: false
+                git url: "${env.GIT_REPO_URL}", branch: "${params.BRANCH ?: 'main'}", changelog: false
                 container('gretl') {
                     dir(env.JOB_BASE_NAME) {
                         unstash name: 'uploadDir'

--- a/afu_oekomorphologie_csvimport/Jenkinsfile
+++ b/afu_oekomorphologie_csvimport/Jenkinsfile
@@ -24,7 +24,7 @@ pipeline {
     stages {
         stage('Run GRETL-Job') {
             steps {
-                git url: "${env.GIT_REPO_URL}", branch: "${params.BRANCH ?: 'master'}", changelog: false
+                git url: "${env.GIT_REPO_URL}", branch: "${params.BRANCH ?: 'main'}", changelog: false
                 container('gretl') {
                     dir(env.JOB_BASE_NAME) {
                         unstash name: 'uploadDir'

--- a/agi_check_ili_export/Jenkinsfile
+++ b/agi_check_ili_export/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
                 retry(2)
             }
             steps {
-                git url: "${env.GIT_REPO_URL}", branch: "${params.BRANCH ?: 'master'}", changelog: false
+                git url: "${env.GIT_REPO_URL}", branch: "${params.BRANCH ?: 'main'}", changelog: false
                 container('gretl') {
                     dir(env.JOB_BASE_NAME) {
                         sh 'gretl'

--- a/alw_fruchtfolgeflaechen/Jenkinsfile
+++ b/alw_fruchtfolgeflaechen/Jenkinsfile
@@ -59,7 +59,7 @@ pipeline {
                 ORG_GRADLE_PROJECT_dbPwdProcessing = 'pass'
             }
             steps {
-                git url: "${env.GIT_REPO_URL}", branch: "${params.BRANCH ?: 'master'}", changelog: false
+                git url: "${env.GIT_REPO_URL}", branch: "${params.BRANCH ?: 'main'}", changelog: false
                 container('gretl') {
                     dir(env.JOB_BASE_NAME) {
                         sh 'gretl prepare_db importAll'

--- a/arp_mjpnl_initialisierung/Jenkinsfile
+++ b/arp_mjpnl_initialisierung/Jenkinsfile
@@ -24,7 +24,7 @@ pipeline {
     stages {
         stage('Run GRETL-Job') {
             steps {
-                git url: "${env.GIT_REPO_URL}", branch: "${params.BRANCH ?: 'master'}", changelog: false
+                git url: "${env.GIT_REPO_URL}", branch: "${params.BRANCH ?: 'main'}", changelog: false
                 container('gretl') {
                     dir(env.JOB_BASE_NAME) {
                         unstash name: 'uploadDir'

--- a/arp_npl_import/Jenkinsfile
+++ b/arp_npl_import/Jenkinsfile
@@ -30,7 +30,7 @@ pipeline {
     stages {
         stage('Run GRETL-Job') {
             steps {
-                git url: "${env.GIT_REPO_URL}", branch: "${params.BRANCH ?: 'master'}", changelog: false
+                git url: "${env.GIT_REPO_URL}", branch: "${params.BRANCH ?: 'main'}", changelog: false
                 container('gretl') {
                     dir(env.JOB_BASE_NAME) {
                         unstash name: 'uploadDir'

--- a/arp_nutzungsplanung_delete_dataset/Jenkinsfile
+++ b/arp_nutzungsplanung_delete_dataset/Jenkinsfile
@@ -6,7 +6,7 @@ pipeline {
     stages {
         stage('Run GRETL-Job') {
             steps {
-                git url: "${env.GIT_REPO_URL}", branch: "${params.BRANCH ?: 'master'}", changelog: false
+                git url: "${env.GIT_REPO_URL}", branch: "${params.BRANCH ?: 'main'}", changelog: false
                 container('gretl') {
                     dir(env.JOB_BASE_NAME) {
                         sh "gretl -Pbfsnr=${params.bfsnr}"

--- a/arp_nutzungsplanung_import/Jenkinsfile
+++ b/arp_nutzungsplanung_import/Jenkinsfile
@@ -30,7 +30,7 @@ pipeline {
     stages {
         stage('Run GRETL-Job') {
             steps {
-                git url: "${env.GIT_REPO_URL}", branch: "${params.BRANCH ?: 'master'}", changelog: false
+                git url: "${env.GIT_REPO_URL}", branch: "${params.BRANCH ?: 'main'}", changelog: false
                 container('gretl') {
                     dir(env.JOB_BASE_NAME) {
                         unstash name: 'uploadDir'

--- a/arp_nutzungsplanung_import_ersterfassung/Jenkinsfile
+++ b/arp_nutzungsplanung_import_ersterfassung/Jenkinsfile
@@ -30,7 +30,7 @@ pipeline {
     stages {
         stage('Run GRETL-Job') {
             steps {
-                git url: "${env.GIT_REPO_URL}", branch: "${params.BRANCH ?: 'master'}", changelog: false
+                git url: "${env.GIT_REPO_URL}", branch: "${params.BRANCH ?: 'main'}", changelog: false
                 container('gretl') {
                     dir(env.JOB_BASE_NAME) {
                         unstash name: 'uploadDir'

--- a/arp_nutzungsplanung_kanton_pub/Jenkinsfile
+++ b/arp_nutzungsplanung_kanton_pub/Jenkinsfile
@@ -9,7 +9,7 @@ pipeline {
             agent { label 'gretl' }
             steps {
                 script { currentBuild.description = "${params.buildDescription}" }
-                git url: "${env.GIT_REPO_URL}", branch: "${params.BRANCH ?: 'master'}", changelog: false
+                git url: "${env.GIT_REPO_URL}", branch: "${params.BRANCH ?: 'main'}", changelog: false
                 container('gretl') {
                     dir(env.JOB_BASE_NAME) {
                         sh "gretl importXTF_stage"

--- a/arp_nutzungsplanung_pub/Jenkinsfile
+++ b/arp_nutzungsplanung_pub/Jenkinsfile
@@ -9,7 +9,7 @@ pipeline {
             agent { label 'gretl' }
             steps {
                 script { currentBuild.description = "${params.buildDescription}" }
-                git url: "${env.GIT_REPO_URL}", branch: "${params.BRANCH ?: 'master'}", changelog: false
+                git url: "${env.GIT_REPO_URL}", branch: "${params.BRANCH ?: 'main'}", changelog: false
                 container('gretl') {
                     dir(env.JOB_BASE_NAME) {
                         sh "gretl -Pbfsnr=${params.bfsnr} importXTF_stage"

--- a/arp_nutzungsplanung_pub_easy_validation/Jenkinsfile
+++ b/arp_nutzungsplanung_pub_easy_validation/Jenkinsfile
@@ -9,7 +9,7 @@ pipeline {
             agent { label 'gretl' }
             steps {
                 script { currentBuild.description = "${params.buildDescription}" }
-                git url: "${env.GIT_REPO_URL}", branch: "${params.BRANCH ?: 'master'}", changelog: false
+                git url: "${env.GIT_REPO_URL}", branch: "${params.BRANCH ?: 'main'}", changelog: false
                 container('gretl') {
                     dir(env.JOB_BASE_NAME) {
                         sh "gretl -Pbfsnr=${params.bfsnr} importXTF_stage"

--- a/avt_ausnahmetransportrouten_export_ai/Jenkinsfile
+++ b/avt_ausnahmetransportrouten_export_ai/Jenkinsfile
@@ -24,7 +24,7 @@ pipeline {
     stages {
         stage('Run GRETL-Job') {
             steps {
-                git url: "${env.GIT_REPO_URL}", branch: "${params.BRANCH ?: 'master'}", changelog: false
+                git url: "${env.GIT_REPO_URL}", branch: "${params.BRANCH ?: 'main'}", changelog: false
                 container('gretl') {
                     dir(env.JOB_BASE_NAME) {
                         unstash name: 'uploadDir'

--- a/avt_groblaermkataster_pub/Jenkinsfile
+++ b/avt_groblaermkataster_pub/Jenkinsfile
@@ -24,7 +24,7 @@ pipeline {
     stages {
         stage('Run GRETL-Job') {
             steps {
-                git url: "${env.GIT_REPO_URL}", branch: "${params.BRANCH ?: 'master'}", changelog: false
+                git url: "${env.GIT_REPO_URL}", branch: "${params.BRANCH ?: 'main'}", changelog: false
                 container('gretl') {
                     dir(env.JOB_BASE_NAME) {
                         unstash name: 'uploadDir'

--- a/avt_kantonsstrassen_pub/Jenkinsfile
+++ b/avt_kantonsstrassen_pub/Jenkinsfile
@@ -24,7 +24,7 @@ pipeline {
     stages {
         stage('Run GRETL-Job') {
             steps {
-                git url: "${env.GIT_REPO_URL}", branch: "${params.BRANCH ?: 'master'}", changelog: false
+                git url: "${env.GIT_REPO_URL}", branch: "${params.BRANCH ?: 'main'}", changelog: false
                 container('gretl') {
                     dir(env.JOB_BASE_NAME) {
                         unstash name: 'uploadDir'

--- a/avt_oev_gueteklassen_import/Jenkinsfile
+++ b/avt_oev_gueteklassen_import/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
     stages {
         stage('Run GRETL-Job') {
             steps {
-                git url: "${env.GIT_REPO_URL}", branch: "${params.BRANCH ?: 'master'}", changelog: false
+                git url: "${env.GIT_REPO_URL}", branch: "${params.BRANCH ?: 'main'}", changelog: false
                 container('gretl') {
                     dir(env.JOB_BASE_NAME) {
                         unstash name: 'uploadDir'

--- a/awjf_biotopbaeume_import/Jenkinsfile
+++ b/awjf_biotopbaeume_import/Jenkinsfile
@@ -24,7 +24,7 @@ pipeline {
     stages {
         stage('Run GRETL-Job') {
             steps {
-                git url: "${env.GIT_REPO_URL}", branch: "${params.BRANCH ?: 'master'}", changelog: false
+                git url: "${env.GIT_REPO_URL}", branch: "${params.BRANCH ?: 'main'}", changelog: false
                 container('gretl') {
                     dir(env.JOB_BASE_NAME) {
                         unstash name: 'uploadDir'

--- a/awjf_gesuchsteller/Jenkinsfile
+++ b/awjf_gesuchsteller/Jenkinsfile
@@ -24,7 +24,7 @@ pipeline {
     stages {
         stage('Run GRETL-Job') {
             steps {
-                git url: "${env.GIT_REPO_URL}", branch: "${params.BRANCH ?: 'master'}", changelog: false
+                git url: "${env.GIT_REPO_URL}", branch: "${params.BRANCH ?: 'main'}", changelog: false
                 container('gretl') {
                     dir(env.JOB_BASE_NAME) {
                         unstash name: 'uploadDir'

--- a/gretl_job_generator.groovy
+++ b/gretl_job_generator.groovy
@@ -56,7 +56,7 @@ for (jobFile in jobFiles) {
   pipelineJob(jobName) {
     if (!productionEnv) { // we don't want the BRANCH parameter in production environment
       parameters {
-        stringParam('BRANCH', 'master', 'Name of branch to check out')
+        stringParam('BRANCH', 'main', 'Name of branch to check out')
       }
     }
     if (properties.getProperty('parameters.fileParam') != 'none') {


### PR DESCRIPTION
Reasons:
* _main_ is now the default for new repos on GitHub
* https://github.com/sogis/schema-jobs and https://github.com/sogis-oereb/oereb-gretljobs already use _main_ for their default branch; with this change, all GRETL job repos use the same name for their default branch

The developers will need to follow the instructions under https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch#updating-a-local-clone-after-a-branch-name-changes in order to update their local clone of the repo. 