### PR TITLE
Set compose project name

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,7 +349,9 @@ welches Image man starten möchte.
 Mit `--docker-network NETWORK` (optional) kann angegeben werden,
 dass der GRETL-Container an ein bestimmtes Docker-Netzwerk
 angebunden werden soll.
-(Die Namen der verfügbaren Docker-Netzwerke
+(Das Docker-Netzwerk, das mit `docker compose up` erstellt wird,
+heisst in der Regel `gretljobs_default`;
+die Namen der vorhandenen Docker-Netzwerke
 können mit dem Befehl `docker network ls` ermittelt werden.)
 
 Mit `--job-directory $PWD/jobname` wird

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,5 @@
-version: '3'
+version: '3.8'
+name: gretljobs
 services:
   edit-db:
     build: .


### PR DESCRIPTION
Dies erfordert eine aktuelle Compose-Version.

Unter Linux:
* Prüfen, ob das Paket-Repository von Docker eingebunden ist: `cat /etc/apt/sources.list.d/docker.list`
* Falls es nicht eingebunden ist: Gemäss der Anleitung unter https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository einbinden, danach ausführen: `sudo apt-get update`
* Alte Versionen deinstallieren:
```
sudo apt remove docker-compose
sudo rm $(which docker-compose)
```
* Neue Version installieren:
  ```
  sudo apt-get install docker-compose-plugin
  ```