### PR TITLE
Möglichkeit, den Job mit GRETL 2.2 auszuführen

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,9 +202,12 @@ Allerdings können auch diejenigen Benutzer oder Gruppen, welche durch globale B
 
 Mit `nodeLabel` kann bestimmt werden,
 auf welchem Node der Job ausgeführt werden soll.
-Erlaubt ist hier einzig der Wert `gretl-bigtmp`;
-so wird der Job auf einem Jenkins Agent
-mit einem grösseren `/tmp`-Verzeichnis ausgeführt.
+Erlaubt ist hier der Wert `gretl-bigtmp`
+damit der Job auf einem Jenkins Agent
+mit einem grösseren `/tmp`-Verzeichnis ausgeführt wird.
+Und der Wert `gretl-2.2`,
+damit der Job auf einem Jenkins Agent
+mit GRETL Version 2.2 ausgeführt wird.
 Lässt man diese Property weg,
 wird der Job auf einem normalen Jenkins Agent
 (mit dem Label `gretl`) ausgeführt.

--- a/agi_check_ili_export/job.properties
+++ b/agi_check_ili_export/job.properties
@@ -1,2 +1,3 @@
 logRotator.numToKeep=30
 triggers.cron=H H(1-3) * * *
+nodeLabel=gretl-2.2


### PR DESCRIPTION
Frühestens dann mergen, wenn GRETL 2.2 in einer ausgereiften Version vorhanden ist.

Evtl. brauchen wir dies allerdings gar nicht. Aber es ist hier als Vorbereitung, falls nach der Umstellung auf GRETL 2.2 doch noch eine weitere GRETL-Version verfügbar sein sollte. Und es soll im Hinblick auf weitere Situationen, wo zwei GRETL-Versionen parallel betrieben werden müssen, hier im Repo bleiben.

Muss dann unter Umständen auch noch bei den ÖREB-GRETL-Jobs und den Schema-Jobs umgesetzt werden.