### PR TITLE
No need to set modeldir for ili2pg tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,11 +117,11 @@ git checkout -b branchname
   * `solrIndexupdaterBaseUrl` (die interne Basis-URL zum Indexupdater für Solr)
   * `gretlShare`
   * `gretlEnvironment` (der Wert dieser Variable ist je nach Umgebung `test`, `integration` oder `production`)
-* Bei _Ili2pg_-Tasks und _IliValidator_-Tasks die folgende Option setzen,
+* Bei _Ili2gpkg_-Tasks und _IliValidator_-Tasks die folgende Option setzen,
   damit in den Betriebs-Umgebungen für den Download der benötigten Modelle
   die Anzahl abzufragender INTERLIS-Repositories reduziert wird:
 
-  Bei _Ili2pg_-Tasks: `if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir`
+  Bei _Ili2gpkg_-Tasks: `if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir`
 
   Bei _IliValidator_-Tasks: `if (findProperty('ilivalidatorModeldir')) modeldir = ilivalidatorModeldir`
 

--- a/afu_abbaustellen_pub/build.gradle
+++ b/afu_abbaustellen_pub/build.gradle
@@ -30,7 +30,6 @@ task exportGisXtf(type: Ili2pgExport, dependsOn: deleteAppData){
     disableValidation = true
     dataFile = gisXtfPath
     models = 'SO_AFU_ABBAUSTELLEN_20210630'
-    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
 }
 
 task validateJoined(type: IliValidator, dependsOn: exportGisXtf){
@@ -44,7 +43,6 @@ task importAppData(type: Ili2pgImport, dependsOn: validateJoined){
     dbschema = schemaNameEdit
     disableValidation = true
     dataFile = appXtfPath
-    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
 }
 
 task writeToPub(type: Db2Db, dependsOn: importAppData){ 

--- a/afu_gefahrenkartierung_pub_export_ai/build.gradle
+++ b/afu_gefahrenkartierung_pub_export_ai/build.gradle
@@ -75,7 +75,6 @@ task exportGefkartMgdm(type: Ili2pgExport, dependsOn: 'mapGefkart2Mgdm') {
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     dbschema = "afu_gefahrenkartierung_mgdm"
     models = "Hazard_Mapping_LV95_V1_2"
-    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dataFile = exportFile
 }
 

--- a/afu_gewaesserschutz_bereiche_pub/build.gradle
+++ b/afu_gewaesserschutz_bereiche_pub/build.gradle
@@ -13,7 +13,6 @@ task exportDataEdit (type: Ili2pgExport) {
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     dbschema = 'afu_gewaesserschutz_bereiche_v1'
     models = 'PlanerischerGewaesserschutz_LV95_V1_1'
-    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dataFile= file(FileName)
     disableValidation = true
 }
@@ -39,7 +38,6 @@ task exportData (type: Ili2pgExport, dependsOn: 'transferGewaesserschutz') {
     database = [dbUriPub, dbUserPub, dbPwdPub]
     dbschema = 'afu_gewaesserschutz_pub_v1'
     models = 'SO_AfU_Gewaesserschutz_Publikation_20220817'
-    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dataFile= file(FileNamePub)
     disableValidation = true
 }

--- a/afu_gewaesserschutz_pub/build.gradle
+++ b/afu_gewaesserschutz_pub/build.gradle
@@ -51,7 +51,6 @@ task exportAfuGewaesserschutz(type: Ili2pgExport, dependsOn: transferZonen) {
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     dbschema = 'afu_gewaesserschutz' 
     models = 'PlanerischerGewaesserschutz_LV95_V1_1'
-    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dataFile = exportFile
     disableValidation = true
   

--- a/afu_gewaesserschutz_zone_areal_pub/build.gradle
+++ b/afu_gewaesserschutz_zone_areal_pub/build.gradle
@@ -13,7 +13,6 @@ task exportDataEdit (type: Ili2pgExport) {
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     dbschema = 'afu_gewaesserschutz'
     models = 'PlanerischerGewaesserschutz_LV95_V1_1'
-    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dataFile= file(FileName)
     disableValidation = true
 }
@@ -41,7 +40,6 @@ task exportData (type: Ili2pgExport, dependsOn: 'transferGewaesserschutz') {
     database = [dbUriPub, dbUserPub, dbPwdPub]
     dbschema = 'afu_gewaesserschutz_staging_v1'
     models = 'SO_AfU_Gewaesserschutz_Publikation_20220817'
-    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dataFile= file(FileNamePub)
     disableValidation = true
 }
@@ -64,7 +62,6 @@ task importXTF_pub(type: Ili2pgImport) {
     database = [dbUriPub, dbUserPub, dbPwdPub]
     dbschema = 'afu_gewaesserschutz_pub_v1'
     models = 'SO_AfU_Gewaesserschutz_Publikation_20220817'
-    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dataFile = file(FileNamePub)
     deleteData = true
     disableValidation = true

--- a/afu_gewaesserschutz_zonen_areale_pub/build.gradle
+++ b/afu_gewaesserschutz_zonen_areale_pub/build.gradle
@@ -13,7 +13,6 @@ task exportDataEdit (type: Ili2pgExport) {
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     dbschema = 'afu_gewaesserschutz_zonen_areale_v1'
     models = 'PlanerischerGewaesserschutz_LV95_V1_1'
-    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dataFile= file(FileName)
     disableValidation = true
 }
@@ -39,7 +38,6 @@ task exportData (type: Ili2pgExport, dependsOn: 'transferGewaesserschutz') {
     database = [dbUriPub, dbUserPub, dbPwdPub]
     dbschema = 'afu_gewaesserschutz_staging_v1'
     models = 'SO_AfU_Gewaesserschutz_Publikation_20220817'
-    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dataFile= file(FileNamePub)
     disableValidation = true
 }
@@ -62,7 +60,6 @@ task importXTF_pub(type: Ili2pgImport) {
     database = [dbUriPub, dbUserPub, dbPwdPub]
     dbschema = 'afu_gewaesserschutz_pub_v1'
     models = 'SO_AfU_Gewaesserschutz_Publikation_20220817'
-    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dataFile = file(FileNamePub)
     deleteData = true
     disableValidation = true

--- a/afu_nabodat_import/build.gradle
+++ b/afu_nabodat_import/build.gradle
@@ -27,7 +27,6 @@ task importNabodat(type: Ili2pgReplace, dependsOn: unpackFiles){
      database = [dbUriEdit, dbUserEdit, dbPwdEdit]
      dbschema = 'afu_bodendaten_nabodat_v1'
      models = 'NABODAT_ErgebnisseBodenbelastung_Punktdaten_V1_1'
-     if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
      dataFile = 'upload/data.xtf'
      dataset = 'punktdaten'
      importTid = 'true'

--- a/agi_ch_gemeinden/build.gradle
+++ b/agi_ch_gemeinden/build.gradle
@@ -47,7 +47,6 @@ task dbImport(type: Ili2pgImport, dependsOn: 'unzipSwissBoundaries3D'){
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     dbschema = "agi_swissboundaries3d"
     models = "swissBOUNDARIES3D_ili2_LV95_V1_3"
-    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     disableValidation = false
     dataFile = file(xtfFilePath)
     deleteData = true

--- a/agi_dm01avso24/build.gradle
+++ b/agi_dm01avso24/build.gradle
@@ -51,7 +51,6 @@ cadastralSurveyingDataSets.each { cadastralSurveyingDataSet ->
         database = [dbUriEdit, dbUserEdit, dbPwdEdit]
         //database = ["jdbc:postgresql://localhost:54321/edit", "admin", "admin"]
         models = 'DM01AVSO24LV95'
-        if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
         dbschema = 'agi_dm01avso24_strokearcs'
         dataFile = file(Paths.get(pathToTempFolder.toString(), dataSet + "00.itf"))
         //topics = "DM01AVCH24LV95D.Liegenschaften;DM01AVCH24LV95D.Gemeindegrenzen;DM01AVCH24LV95D.Gebaeudeadressen"

--- a/agi_plz_ortschaften_pub/build.gradle
+++ b/agi_plz_ortschaften_pub/build.gradle
@@ -46,7 +46,6 @@ task dbImport(type: Ili2pgImport, dependsOn: 'unzipData'){
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     dbschema = "agi_plz_ortschaften"
     models = "PLZOCH1LV95D"
-    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     disableValidation = false
     dataFile = file(xtfFilePath)
     deleteData = true

--- a/agi_swisstopo_gebaeudeadressen/build.gradle
+++ b/agi_swisstopo_gebaeudeadressen/build.gradle
@@ -43,7 +43,6 @@ task dbImport(type: Ili2pgImport, dependsOn: 'unzipData') {
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     dbschema = "agi_swisstopo_gebaeudeadressen"
     models = "OfficialIndexOfAddresses_V2"
-    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     disableValidation = true
     dataFile = file(xtfFilePath)
     deleteData = true

--- a/alw_fruchtfolgeflaechen_export_ai/build.gradle
+++ b/alw_fruchtfolgeflaechen_export_ai/build.gradle
@@ -57,7 +57,6 @@ task exportFFFMgdm(type: Ili2pgExport, dependsOn: 'mapFFF2Mgdm') {
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     dbschema = "alw_fruchtfolgeflaechen_mgdm_v1"
     models = "Fruchtfolgeflaechen_LV95_V1"
-    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dataFile = exportFile
 }
 

--- a/alw_fruchtfolgeflaechen_pub/build.gradle
+++ b/alw_fruchtfolgeflaechen_pub/build.gradle
@@ -75,7 +75,6 @@ task exportFFF(type: Ili2pgExport, dependsOn: 'fff_to_pub_db') {
     database = [dbUriPub, dbUserPub, dbPwdPub]
     dbschema = "alw_fruchtfolgeflaechen_pub_v1"
     models = "SO_ALW_Fruchtfolgeflaechen_Publikation_20220110"
-    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dataFile = exportFile
 }
 

--- a/alw_landwirtschaft_tierhaltung_import_bodenbedeckung/build.gradle
+++ b/alw_landwirtschaft_tierhaltung_import_bodenbedeckung/build.gradle
@@ -40,7 +40,6 @@ task importGELAN(type: Ili2pgReplace, dependsOn: downloadData) {
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     dbschema = "alw_landwirtschaft_tierhaltung_v1"
     models = 'SO_ALW_Landwirtschaft_Tierhaltung_20210426'
-    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dataFile = Paths.get(pathToTempFolder, 'Export_ais_ln.xtf')
     dataset = 'bodenbedeckung'
 }

--- a/alw_landwirtschaft_tierhaltung_import_massnahmen/build.gradle
+++ b/alw_landwirtschaft_tierhaltung_import_massnahmen/build.gradle
@@ -40,7 +40,6 @@ task importGELAN(type: Ili2pgReplace, dependsOn: downloadData) {
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     dbschema = "alw_landwirtschaft_tierhaltung_v1"
     models = 'SO_ALW_Landwirtschaft_Tierhaltung_20210426'
-    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dataFile = Paths.get(pathToTempFolder, 'Export_ais_pp-mg.xtf')
     dataset = 'massnahmen'
 }

--- a/alw_landwirtschaft_tierhaltung_pub/build.gradle
+++ b/alw_landwirtschaft_tierhaltung_pub/build.gradle
@@ -41,7 +41,6 @@ task importGELAN(type: Ili2pgReplace, dependsOn: downloadData) {
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     dbschema = "alw_landwirtschaft_tierhaltung_v1"
     models = 'SO_ALW_Landwirtschaft_Tierhaltung_20210426'
-    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dataFile = Paths.get(pathToTempFolder, 'Export_ais_agrardaten.xtf')
     dataset = 'agrardaten'
 }

--- a/alw_strukturverbesserungen_suissemelio/build.gradle
+++ b/alw_strukturverbesserungen_suissemelio/build.gradle
@@ -45,7 +45,6 @@ task transfer_SVGIS_Suissemelio(type: Db2Db){
 task exportSVGIS_Suissemelio(type: Ili2pgExport, dependsOn: 'transfer_SVGIS_Suissemelio') {
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     models = 'Strukturverbesserungen_LV95_V2'
-    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dbschema = 'alw_strukturverbesserungen_suissemelio'
     dataFile = file(SVGIS_SuissemelioXtfFileName)
     disableValidation = true

--- a/alw_zonengrenzen_import/build.gradle
+++ b/alw_zonengrenzen_import/build.gradle
@@ -34,7 +34,6 @@ task importKataloge(type: Ili2pgReplace, dependsOn: 'downloadKataloge'){
      database = [dbUriEdit, dbUserEdit, dbPwdEdit]
      dbschema = 'alw_zonengrenzen'
      models = 'Landwirtschaftliche_Zonengrenzen_LV95_V1_2'
-     if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
      dataFile = file(Paths.get(pathToTempFolder.toString(), 'landwirtschaftliche_zonengrenzen_kataloge_20140701.xml'))
      dataset = 'landwirtschaftliche_zonengrenzen_kataloge_20140701.xml-2938'
 }
@@ -58,7 +57,6 @@ task importData(type: Ili2pgReplace, dependsOn: 'unzipData'){
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     dbschema = 'alw_zonengrenzen'
     models = 'Landwirtschaftliche_Zonengrenzen_LV95_V1_2'
-    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dataFile = file(Paths.get(pathToUnzipFolder.toString(), 'NachF_LWZ_INTERLIS2.xtf'))
     dataset = 'NachF_LWZ_INTERLIS2.xtf'
     strokeArcs = true

--- a/arp_mjpnl_initialisierung/build.gradle
+++ b/arp_mjpnl_initialisierung/build.gradle
@@ -36,7 +36,6 @@ task importMJPNL(type: Ili2pgReplace, dependsOn: 'copyXtfFile') {
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     dbschema = "arp_mjpnl_v1"
     models = "SO_ARP_MJPNL_20201026"
-    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     topics = "SO_ARP_MJPNL_20201026.MJPNL"
     dataFile = "upload/mjpnl_init.xtf"
     dataset = "MJPNL Basisdaten"
@@ -63,7 +62,6 @@ task importGELAN(type: Ili2pgReplace, dependsOn: downloadData) {
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     dbschema = "arp_mjpnl_v1"
     models = 'SO_ALW_Landwirtschaft_Tierhaltung_20210426'
-    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     topics = 'SO_ALW_Landwirtschaft_Tierhaltung_20210426.Betriebsdaten_Strukturdaten'
     dataFile = Paths.get(pathToTempFolder, 'Export_ais_agrardaten.xtf')
     dataset = 'GELAN'

--- a/arp_naturreservate_pub/build.gradle
+++ b/arp_naturreservate_pub/build.gradle
@@ -13,7 +13,6 @@ task exportDataEdit (type: Ili2pgExport) {
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     dbschema = 'arp_naturreservate'
     models = 'SO_ARP_Naturreservate_20200609'
-    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dataFile= file(FileName)
     disableValidation = true
 }
@@ -43,7 +42,6 @@ task exportData (type: Ili2pgExport, dependsOn: 'transferArpNaturreservate') {
     database = [dbUriPub, dbUserPub, dbPwdPub]
     dbschema = 'arp_naturreservate_staging_v1'
     models = 'SO_ARP_Naturreservate_Publikation_20200609'
-    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dataFile= file(FileNamePub)
     disableValidation = true
 }
@@ -70,7 +68,6 @@ task importXTF_pub(type: Ili2pgImport) {
     database = [dbUriPub, dbUserPub, dbPwdPub]
     dbschema = 'arp_naturreservate_pub'
     models = 'SO_ARP_Naturreservate_Publikation_20200609'
-    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dataFile = file(FileNamePub)
     deleteData = true
     disableValidation = true

--- a/arp_npl_export_ai/build.gradle
+++ b/arp_npl_export_ai/build.gradle
@@ -41,7 +41,6 @@ task deleteMgdmLandUsesPlansData(type: SqlExecutor) {
 task importMgdmHauptnutzung(type: Ili2pgImport, dependsOn: 'deleteMgdmLandUsesPlansData') {
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     models = iliModelMgdmHauptnutzung
-    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dbschema = dbSchemaMgdmLandUsePlans
     dataFile = file("Hauptnutzung_CH_V1_1.xml")
     disableValidation = true
@@ -55,7 +54,6 @@ task transferLandUsePlansData(type: SqlExecutor, dependsOn: 'importMgdmHauptnutz
 task exportMgdmLandUsePlans(type: Ili2pgExport, dependsOn: 'transferLandUsePlansData') {
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     models = iliModelMgdmLandUsePlans
-    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dbschema = dbSchemaMgdmLandUsePlans
     dataFile = file(mgdmLandUsePlansXtfFileName)
     disableValidation = true
@@ -106,7 +104,6 @@ task transferNoiseSensitivityLevels(type: SqlExecutor) {
 task exportMgdmNoiseSensitivityLevels(type: Ili2pgExport, dependsOn: 'transferNoiseSensitivityLevels') {
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     models = iliModelMgdmNoiseSensitivityLevels
-    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dbschema = dbSchemaMgdmSensitivityLevels
     dataFile = file(mgdmSensitivityLevelsXtfFileName)
     disableValidation = true
@@ -151,7 +148,6 @@ task transferWaldabstandslinien(type: SqlExecutor) {
 task exportMgdmWaldabstandslinien(type: Ili2pgExport, dependsOn: 'transferWaldabstandslinien') {
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     models = iliModelMgdmWaldabstand
-    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dbschema = dbSchemaWaldabstand
     dataFile = file(mgdmWaldabstandXtfFileName)
     disableValidation = true

--- a/arp_npl_import/build.gradle
+++ b/arp_npl_import/build.gradle
@@ -46,7 +46,6 @@ task replaceDataset (type: Ili2pgReplace, dependsOn: 'checkBsfNummer') {
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     dbschema = "arp_npl"
     models = "SO_Nutzungsplanung_20171118"
-    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     disableValidation = true
     dataset = ili2pgDataset
     dataFile = "upload/${ili2pgDataset}.xtf"

--- a/arp_nutzungsplanung_delete_dataset/build.gradle
+++ b/arp_nutzungsplanung_delete_dataset/build.gradle
@@ -12,7 +12,6 @@ task exportData_Dataset_BFSNr(type: Ili2pgExport) {
     description = "Exportiert die zu löschenden Daten mit dem angegebenden Datasetname (BFS-Nr.)aus dem Schema arp_nutzungsplanung_v1 in ein INTERLIS-Datei. Dient zur Sicherung"
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     models = 'SO_ARP_Nutzungsplanung_Nachfuehrung_20201005'
-    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dbschema = 'arp_nutzungsplanung_v1'
     dataset = bfsnr
     dataFile = "$rootDir/" + bfsnr + ".xtf"
@@ -23,7 +22,6 @@ task delete_Dataset_BFSNr(type: Ili2pgDelete, dependsOn: 'exportData_Dataset_BFS
     description = "Löscht Daten mit dem angegebenen Datasetname (BFS-Nr.) aus dem Schema arp_nutzungsplanung_v1"
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     models = 'SO_ARP_Nutzungsplanung_Nachfuehrung_20201005'
-    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dbschema = 'arp_nutzungsplanung_v1'
     dataset = bfsnr
 }

--- a/arp_nutzungsplanung_digizone_pub/build.gradle
+++ b/arp_nutzungsplanung_digizone_pub/build.gradle
@@ -15,7 +15,6 @@ task exportDataEdit (type: Ili2pgExport) {
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     dbschema = 'arp_nutzungsplanung_digizone_v1'
     models = 'SO_ARP_Nutzungsplanung_Publikation_20201005'
-    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dataFile= file("digizone.xtf")
     disableValidation = true
 }
@@ -32,7 +31,6 @@ task importXTF_pub(type: Ili2pgReplace, dependsOn: 'validateDataEdit') {
     database = [dbUriPub, dbUserPub, dbPwdPub]
     dbschema = 'arp_nutzungsplanung_pub_v1'
     models = 'SO_ARP_Nutzungsplanung_Publikation_20201005'
-    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dataset = 'digizone'
     dataFile = file("digizone.xtf")
     disableValidation = true

--- a/arp_nutzungsplanung_import/build.gradle
+++ b/arp_nutzungsplanung_import/build.gradle
@@ -20,7 +20,6 @@ task importXtfFile(type: Ili2pgReplace, dependsOn: 'copyXtfFile') {
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     dbschema = 'arp_nutzungsplanung_import_v1'
     models = 'SO_Nutzungsplanung_20171118'
-    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     deleteData= true
     dataset = ili2pgDataset
     dataFile = "upload/${ili2pgDataset}.xtf"
@@ -41,7 +40,6 @@ task deleteData_import(type: Ili2pgDelete) {
     description = "Löscht/leert Daten mit dem angegebenen Datasetname (BFS-Nr.) aus dem Schema arp_nutzungsplanung_import_v1"
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     models = 'SO_ARP_Nutzungsplanung_Nachfuehrung_20201005'
-    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dbschema = 'arp_nutzungsplanung_import_v1'
     dataset = ili2pgDataset
 }
@@ -58,7 +56,6 @@ task exportData_Dataset_BFSNr(type: Ili2pgExport) {
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     dbschema = 'arp_nutzungsplanung_transfer_v1'
     models = 'SO_ARP_Nutzungsplanung_Nachfuehrung_20201005'
-    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dataset = ili2pgDataset
     dataFile= file(ili2pgDataset + ".xtf")
     disableValidation = true
@@ -81,7 +78,6 @@ task importData_Dataset_BFSNr(type: Ili2pgImport) {
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     dbschema = 'arp_nutzungsplanung_v1'
     models = 'SO_ARP_Nutzungsplanung_Nachfuehrung_20201005'
-    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dataset = ili2pgDataset
     dataFile = file(ili2pgDataset + ".xtf")
     disableValidation = true
@@ -93,7 +89,6 @@ task exportData_Dataset_Kanton(type: Ili2pgExport) {
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     dbschema = 'arp_nutzungsplanung_transfer_v1'
     models = 'SO_ARP_Nutzungsplanung_Nachfuehrung_20201005'
-    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dataset = 'Kanton'
     dataFile = file(ili2pgDataset + "_Kanton.xtf")
     disableValidation = true
@@ -116,7 +111,6 @@ task importData_Dataset_Kanton(type: Ili2pgImport) {
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     dbschema = 'arp_nutzungsplanung_kanton_v1'
     models = 'SO_ARP_Nutzungsplanung_Nachfuehrung_20201005'
-    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dataFile = file(ili2pgDataset + "_Kanton.xtf")
     disableValidation = true
     finalizedBy deleteXtfFile_Kanton

--- a/arp_nutzungsplanung_import_ersterfassung/build.gradle
+++ b/arp_nutzungsplanung_import_ersterfassung/build.gradle
@@ -20,7 +20,6 @@ task importXtfFile(type: Ili2pgReplace, dependsOn: 'copyXtfFile') {
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     dbschema = 'arp_nutzungsplanung_import_v1'
     models = 'SO_Nutzungsplanung_20171118'
-    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     deleteData= true
     dataset = ili2pgDataset
     dataFile = "upload/${ili2pgDataset}.xtf"
@@ -47,7 +46,6 @@ task deleteData_import(type: Ili2pgDelete, dependsOn: 'transferData') {
     description = "Löscht/leert Daten mit dem angegebenen Datasetname (BFS-Nr.) aus dem Schema arp_nutzungsplanung_import_v1"
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     models = 'SO_ARP_Nutzungsplanung_Nachfuehrung_20201005'
-    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dbschema = 'arp_nutzungsplanung_import_v1'
     dataset = ili2pgDataset
 }
@@ -63,7 +61,6 @@ task exportDataEdit (type: Ili2pgExport, dependsOn: 'deleteData_transfer_pub') {
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     dbschema = 'arp_nutzungsplanung_transfer_v1'
     models = 'SO_ARP_Nutzungsplanung_Nachfuehrung_20201005'
-    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dataset = ili2pgDataset
     dataFile= file(ili2pgDataset + "for_stage.xtf")
     disableValidation = true
@@ -89,7 +86,6 @@ task exportData (type: Ili2pgExport, dependsOn: 'transferData_pub') {
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     dbschema = 'arp_nutzungsplanung_transfer_pub_v1'
     models = 'SO_ARP_Nutzungsplanung_Publikation_20201005'
-    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dataFile= file(ili2pgDataset + "_pub.xtf")
     disableValidation = true
 }
@@ -106,7 +102,6 @@ task importXTF_stage(type: Ili2pgReplace, dependsOn: 'validateData') {
     database = [dbUriPub, dbUserPub, dbPwdPub]
     dbschema = 'arp_nutzungsplanung_staging_v1'
     models = 'SO_ARP_Nutzungsplanung_Publikation_20201005'
-    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dataset = ili2pgDataset
     dataFile = file(ili2pgDataset + "_pub.xtf")
     disableValidation = true

--- a/arp_nutzungsplanung_kanton_pub/build.gradle
+++ b/arp_nutzungsplanung_kanton_pub/build.gradle
@@ -20,7 +20,6 @@ task exportDataEdit (type: Ili2pgExport, dependsOn: 'deleteData_transfer_pub') {
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     dbschema = 'arp_nutzungsplanung_kanton_v1'
     models = 'SO_ARP_Nutzungsplanung_Nachfuehrung_20201005'
-    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dataFile= file("kanton.xtf")
     disableValidation = true
 }
@@ -45,7 +44,6 @@ task exportData (type: Ili2pgExport, dependsOn: 'transferData') {
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     dbschema = 'arp_nutzungsplanung_transfer_pub_v1'
     models = 'SO_ARP_Nutzungsplanung_Publikation_20201005'
-    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dataFile= file("kanton_pub.xtf")
     disableValidation = true
 }
@@ -62,7 +60,6 @@ task importXTF_stage(type: Ili2pgReplace, dependsOn: 'validateData') {
     database = [dbUriPub, dbUserPub, dbPwdPub]
     dbschema = 'arp_nutzungsplanung_staging_v1'
     models = 'SO_ARP_Nutzungsplanung_Publikation_20201005'
-    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dataset = 'Kanton'
     dataFile = file("kanton_pub.xtf")
     disableValidation = true
@@ -72,7 +69,6 @@ task delete_Dataset_stage(type: Ili2pgDelete) {
     description = "Löscht Daten mit Dataset= Kanton aus dem Schema arp_nutzungsplanung_staging"
     database = [dbUriPub, dbUserPub, dbPwdPub]
     models = 'SO_ARP_Nutzungsplanung_Publikation_20201005'
-    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dbschema = 'arp_nutzungsplanung_staging_v1'
     dataset = 'Kanton'
 }
@@ -82,7 +78,6 @@ task importXTF_pub(type: Ili2pgReplace) {
     database = [dbUriPub, dbUserPub, dbPwdPub]
     dbschema = 'arp_nutzungsplanung_pub_v1'
     models = 'SO_ARP_Nutzungsplanung_Publikation_20201005'
-    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dataset = 'Kanton'
     dataFile = file("kanton_pub.xtf")
     disableValidation = true

--- a/arp_nutzungsplanung_nf_export/build.gradle
+++ b/arp_nutzungsplanung_nf_export/build.gradle
@@ -43,7 +43,6 @@ dataSets.each { dataSetId ->
         database = [dbUriEdit, dbUserEdit, dbPwdEdit]
         dbschema = "arp_nutzungsplanung_v1"
         models = "SO_ARP_Nutzungsplanung_Nachfuehrung_20201005"
-        if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
         disableValidation = true
         logFile = file(Paths.get(pathToTempFolder, filenameSuffix+dataSet + "_" + todaysDate  + "_export.log"))
         dataFile = file(Paths.get(pathToTempFolder, filenameSuffix+dataSet + ".xtf"))

--- a/arp_nutzungsplanung_pub/build.gradle
+++ b/arp_nutzungsplanung_pub/build.gradle
@@ -20,7 +20,6 @@ task exportDataEdit (type: Ili2pgExport, dependsOn: 'deleteData_transfer_pub') {
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     dbschema = 'arp_nutzungsplanung_v1'
     models = 'SO_ARP_Nutzungsplanung_Nachfuehrung_20201005'
-    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dataset = bfsnr
     dataFile= file(bfsnr + ".xtf")
     disableValidation = true
@@ -47,7 +46,6 @@ task exportData (type: Ili2pgExport, dependsOn: 'transferData') {
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     dbschema = 'arp_nutzungsplanung_transfer_pub_v1'
     models = 'SO_ARP_Nutzungsplanung_Publikation_20201005'
-    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dataFile= file(bfsnr + "_pub.xtf")
     disableValidation = true
 }
@@ -64,7 +62,6 @@ task importXTF_stage(type: Ili2pgReplace, dependsOn: 'validateData') {
     database = [dbUriPub, dbUserPub, dbPwdPub]
     dbschema = 'arp_nutzungsplanung_staging_v1'
     models = 'SO_ARP_Nutzungsplanung_Publikation_20201005'
-    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dataset = bfsnr
     dataFile = file(bfsnr + "_pub.xtf")
     disableValidation = true
@@ -74,7 +71,6 @@ task delete_Dataset_stage(type: Ili2pgDelete) {
     description = "Löscht Daten mit dem angegebenen Datasetname (BFS-Nr.) aus dem Schema arp_nutzungsplanung_staging"
     database = [dbUriPub, dbUserPub, dbPwdPub]
     models = 'SO_ARP_Nutzungsplanung_Publikation_20201005'
-    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dbschema = 'arp_nutzungsplanung_staging_v1'
     dataset = bfsnr
 }
@@ -84,7 +80,6 @@ task importXTF_pub(type: Ili2pgReplace) {
     database = [dbUriPub, dbUserPub, dbPwdPub]
     dbschema = 'arp_nutzungsplanung_pub_v1'
     models = 'SO_ARP_Nutzungsplanung_Publikation_20201005'
-    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dataset = bfsnr
     dataFile = file(bfsnr + "_pub.xtf")
     disableValidation = true

--- a/arp_wildruhezonen_export_ai/build.gradle
+++ b/arp_wildruhezonen_export_ai/build.gradle
@@ -20,7 +20,6 @@ Package and upload to the KKGEO AI
 task exportMgdmWildruhezonen(type: Ili2pgExport) {
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     models = "Wildruhezonen_LV95_V2_1"
-    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dbschema = "arp_wildruhezonen_mgdm_v1"
     dataFile = file(xtfFileName)
     disableValidation = true

--- a/avt_groblaermkataster_pub/build.gradle
+++ b/avt_groblaermkataster_pub/build.gradle
@@ -16,7 +16,6 @@ task replaceDataset (type: Ili2pgImport, dependsOn: 'copyCsvFile') {
     database = [dbUriPub, dbUserPub, dbPwdPub]
     dbschema = "avt_groblaermkataster_pub"
     models = "SO_AVT_Groblaermkataster_20190709"
-    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     disableValidation = true
     deleteData = true
     dataFile = "upload/uploadFile.xtf"  // name is injected by jenkins

--- a/avt_kunstbauten_pub/build.gradle
+++ b/avt_kunstbauten_pub/build.gradle
@@ -14,7 +14,6 @@ task exportXtf(type: Ili2pgExport){
     disableValidation = true
     dataFile = xtfPath
     models = "SO_AVT_Kunstbauten_Publikation_20220207"
-    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
 }
 
 task validate(type: IliValidator, dependsOn: exportXtf){

--- a/avt_oev_gueteklassen_import/build.gradle
+++ b/avt_oev_gueteklassen_import/build.gradle
@@ -19,7 +19,6 @@ task import_to_stage(type: Ili2pgImport, dependsOn: rename){
      database = [dbUriEdit, dbUserEdit, dbPwdEdit]
      dbschema = 'avt_oev_gueteklassen_staging_v1'
      models = 'SO_AVT_Oev_Gueteklassen_20220120'
-     if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
      dataFile = 'upload/uploadFile.xtf'
      deleteData = true
 }
@@ -29,7 +28,6 @@ task import_to_pub(type: Ili2pgImport){
      database = [dbUriPub, dbUserPub, dbPwdPub]
      dbschema = 'avt_oev_gueteklassen_pub_v1'
      models = 'SO_AVT_Oev_Gueteklassen_20220120'
-     if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
      dataFile = 'upload/uploadFile.xtf'
      deleteData = true
 }

--- a/avt_strassenlaerm/build.gradle
+++ b/avt_strassenlaerm/build.gradle
@@ -31,7 +31,6 @@ task replaceDataset (type: Ili2pgReplace, dependsOn: downloadData) {
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     dbschema = "avt_strassenlaerm"
     models = "SO_AVT_Strassenlaerm_20190806"
-    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     disableValidation = true
     importTid = true
     dataset = "data"

--- a/awa_stromversorgungssicherheit_netzgebiete_pub/build.gradle
+++ b/awa_stromversorgungssicherheit_netzgebiete_pub/build.gradle
@@ -25,7 +25,6 @@ task transferNetzgebiete(type: Db2Db){
 task exportMgdmNetzgebiete(type: Ili2pgExport, dependsOn: 'transferNetzgebiete') {
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     models = "SupplySecurity_RuledAreas_V1_2"
-    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dbschema = "awa_stromversorgungssicherheit"
     dataFile = file(mgdmNetzgebieteXtfFileName)
     disableValidation = true

--- a/awjf_statische_waldgrenze_pub/build.gradle
+++ b/awjf_statische_waldgrenze_pub/build.gradle
@@ -13,7 +13,6 @@ task exportDataEdit (type: Ili2pgExport) {
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     dbschema = 'awjf_statische_waldgrenze'
     models = 'SO_AWJF_Statische_Waldgrenzen_20191119'
-    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dataFile= file(FileName)
     disableValidation = true
 }
@@ -38,7 +37,6 @@ task exportData (type: Ili2pgExport, dependsOn: 'transferStatischeWaldgrenzen') 
     database = [dbUriPub, dbUserPub, dbPwdPub]
     dbschema = 'awjf_statische_waldgrenze_staging_v1'
     models = 'SO_AWJF_Statische_Waldgrenzen_Publikation_20191119'
-    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dataFile= file(FileNamePub)
     disableValidation = true
 }
@@ -62,7 +60,6 @@ task importXTF_pub(type: Ili2pgImport) {
     database = [dbUriPub, dbUserPub, dbPwdPub]
     dbschema = 'awjf_statische_waldgrenze_pub_v1'
     models = 'SO_AWJF_Statische_Waldgrenzen_Publikation_20191119'
-    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dataFile = file(FileNamePub)
     deleteData = true
     disableValidation = true

--- a/awjf_statische_waldgrenzen_export_ai/build.gradle
+++ b/awjf_statische_waldgrenzen_export_ai/build.gradle
@@ -21,7 +21,6 @@ task transferWaldgrenzen(type: SqlExecutor) {
 task exportMgdmWaldgrenzen(type: Ili2pgExport, dependsOn: 'transferWaldgrenzen') {
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     models = iliModelMgdmWaldgrenzen
-    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dbschema = dbSchemaMgdmWaldgrenzen
     dataFile = file(mgdmWaldgrenzenXtfFileName)
     disableValidation = true


### PR DESCRIPTION
Es ist gar nicht nötig, bei _ili2pg_-Tasks das _modeldir_ zu setzen. Denn der Standard für diese Tasks lautet
`%ILI_FROM_DB;%XTF_DIR;http://models.interlis.ch/;%JAR_DIR`.
Das Modell wird also immer zuerst in der DB gesucht, und bei uns ist es auch immer bereits in der DB, weil wir die Schemen vorab mit _ili2pg_ angelegt haben.

Wir brauchen also (fast) nur noch die Variable _ilivalidatorModeldir_, und sie muss nur bei den _IliValidator_-Tasks gesetzt werden.

Was noch dazukommt:
* Der Ili2gpkgImport-Task würde im Prinzip das ili2dbModeldir noch benötigen. Wahrscheinlich kann man ihm aber ebenfalls das _ilivalidatorModeldir_ übergeben, ohne dass es Probleme gibt, weil _ili2db_ unbekannte Platzhalter stillschweigend ignoriert.
* Der Av2ch-Task benötigt ebenfalls ein modeldir; er versteht aber z.B. `%XTF_DIR` oder `%ITF_DIR` ohnehin nicht, und weil er bisher nur einmal vorkommt, kann man ihm das modeldir hartcodiert auf https://geo.so.ch/models/ setzen.

Die Variable soll übrigens neu lauten:
```
ilivalidatorModeldir=%ITF_DIR;https://geo.so.ch/models/;%JAR_DIR/ilimodels
```
https://sogis.openproject.com/projects/task/work_packages/1396