### PR TITLE
Don't set modeldir

### DIFF
--- a/agi_av_import_export/build.gradle
+++ b/agi_av_import_export/build.gradle
@@ -144,7 +144,6 @@ task uploadDxfGeobauFiles(type: S3Upload, dependsOn: 'createDxfGeobauFiles') {
 task importData(type: Ili2pgReplace, dependsOn: 'uploadDxfGeobauFiles') {
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     models = 'DM01AVSO24LV95'
-    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
     dbschema = 'agi_dm01avso24'
     dataFile = fileTree(dir: pathToUnzipFolder, include: '*.itf')
     dataset = dataFile

--- a/agi_check_ili_export/build.gradle
+++ b/agi_check_ili_export/build.gradle
@@ -70,7 +70,6 @@ datasets.each { dataset ->
         database = dbdatabase
         dbschema = schema
         models = modelNames
-        if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
         disableValidation = true
         logFile = file(Paths.get(pathToTempFolder, datasetId + "_" + todaysDate  + "_export.log"))
         //dataFile = file(Paths.get(pathToTempFolder, datasetId + "_" + todaysDate + ".xtf"))

--- a/agi_mopublic_pub_export/build.gradle
+++ b/agi_mopublic_pub_export/build.gradle
@@ -45,7 +45,6 @@ datasets.each { dataset ->
         database = [dbUriPub, dbUserPub, dbPwdPub]
         dbschema = "agi_mopublic_pub_export"
         models = "SO_AGI_MOpublic_20201009"
-        if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
         logFile = file(Paths.get(pathToTempFolder, dataset.toString() + "_" + todaysDate  + "_export.log"))
         dataFile = file(Paths.get(pathToTempFolder, dataset.toString() + ".xtf"))
         disableValidation = true


### PR DESCRIPTION
Because in these cases the models are found in the DB anyways. (The ili2db default starts with `%ILI_FROM_DB`.)