### PR TITLE
Use ilivalidatorModeldir instead of ili2dbModeldir in Ili2gpkg tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,13 +117,10 @@ git checkout -b branchname
   * `solrIndexupdaterBaseUrl` (die interne Basis-URL zum Indexupdater für Solr)
   * `gretlShare`
   * `gretlEnvironment` (der Wert dieser Variable ist je nach Umgebung `test`, `integration` oder `production`)
-* Bei _Ili2gpkg_-Tasks und _IliValidator_-Tasks die folgende Option setzen,
+* Bei _IliValidator_-Tasks und _Ili2gpkg_-Tasks die folgende Option setzen,
   damit in den Betriebs-Umgebungen für den Download der benötigten Modelle
   die Anzahl abzufragender INTERLIS-Repositories reduziert wird:
-
-  Bei _Ili2gpkg_-Tasks: `if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir`
-
-  Bei _IliValidator_-Tasks: `if (findProperty('ilivalidatorModeldir')) modeldir = ilivalidatorModeldir`
+  `if (findProperty('ilivalidatorModeldir')) modeldir = ilivalidatorModeldir`
 
   (Beispiele siehe https://github.com/sogis/gretljobs/commit/de8cc2f550d05442f558f077b85528bc2542c452)
 

--- a/README.md
+++ b/README.md
@@ -117,10 +117,17 @@ git checkout -b branchname
   * `solrIndexupdaterBaseUrl` (die interne Basis-URL zum Indexupdater für Solr)
   * `gretlShare`
   * `gretlEnvironment` (der Wert dieser Variable ist je nach Umgebung `test`, `integration` oder `production`)
-* Bei _IliValidator_-Tasks und _Ili2gpkg_-Tasks die folgende Option setzen,
+* Bei _IliValidator_-Tasks und _Ili2gpkgImport_-Tasks die folgende Option setzen,
   damit in den Betriebs-Umgebungen für den Download der benötigten Modelle
   die Anzahl abzufragender INTERLIS-Repositories reduziert wird:
+
   `if (findProperty('ilivalidatorModeldir')) modeldir = ilivalidatorModeldir`
+
+  (Falls das Modell durch einen vorgängigen Schema-Import (`--schemaimport`)
+  allerdings bereits in der GeoPackage-Datei enthalten sein sollte,
+  muss die `modeldir`-Option nicht gesetzt werden,
+  weil _ili2gpkgImport_ dann das Modell im GeoPackage findet
+  und also nicht online danach suchen muss.)
 
   (Beispiele siehe https://github.com/sogis/gretljobs/commit/de8cc2f550d05442f558f077b85528bc2542c452)
 

--- a/agi_check_ili_export/build.gradle
+++ b/agi_check_ili_export/build.gradle
@@ -121,7 +121,7 @@ datasets.each { dataset ->
             !datasetId.contains(editIdentifier) && isPublic
         }
         models = (exportModel != null) ? exportModel : modelNames
-        if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
+        if (findProperty('ilivalidatorModeldir')) modeldir = ilivalidatorModeldir
         dataFile = file(Paths.get(pathToTempFolder, datasetId + ".xtf"))
         dbfile = file(Paths.get(pathToTempFolder, datasetId + ".gpkg"))
         disableValidation = true
@@ -316,7 +316,7 @@ task uploadLogZipFileLatest(type: S3Upload, dependsOn: "uploadLogZipFileDate") {
 
 //     task "importDatasetGpkg_$datasetId"(type: Ili2gpkgImport, dependsOn: "zipDatasetXtf_$datasetId") {
 //         models = modelNames
-//         if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
+//         if (findProperty('ilivalidatorModeldir')) modeldir = ilivalidatorModeldir
 //         dataFile = file(Paths.get(pathToTempFolder, datasetId + "_" + todaysDate + ".xtf"))
 //         dbfile = file(Paths.get(pathToTempFolder, datasetId + "_" + todaysDate + ".gpkg"))
 //         disableValidation = true

--- a/agi_mopublic_pub_export/build.gradle
+++ b/agi_mopublic_pub_export/build.gradle
@@ -76,7 +76,7 @@ datasets.each { dataset ->
 
     task "importDatasetGpkg_$dataset"(type: Ili2gpkgImport, dependsOn: "zipDatasetXtf_$dataset") {
         models = "SO_AGI_MOpublic_20201009"
-        if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
+        if (findProperty('ilivalidatorModeldir')) modeldir = ilivalidatorModeldir
         dataFile = file(Paths.get(pathToTempFolder, dataset.toString() + ".xtf"))
         dbfile = file(Paths.get(pathToTempFolder, dataset.toString() + ".gpkg"))
         disableValidation = true

--- a/alw_fruchtfolgeflaechen_pub/build.gradle
+++ b/alw_fruchtfolgeflaechen_pub/build.gradle
@@ -127,7 +127,7 @@ Wandelt den aktuellen Export zu einem Geopackage um und lädt ihn hoch
 */
 task importDataToGeopackage(type: Ili2gpkgImport, dependsOn: 'exportFFF') {
     models = "SO_ALW_Fruchtfolgeflaechen_Publikation_20220110"
-    if (findProperty('ili2dbModeldir')) modeldir = ili2dbModeldir
+    if (findProperty('ilivalidatorModeldir')) modeldir = ilivalidatorModeldir
     dataFile = file(exportFile);
     dbfile = file(exportFileGeopackage)  
     disableValidation = true //Da schon der Export validiert wurde, muss der Import nicht auch noch mal validiert werden!


### PR DESCRIPTION
_ili2gpkg_ (_ili2db_) ignoriert ihm unbekannte Platzhalter wie z.B. `%ITF_DIR`, das von `ilivalidator` benutzt wird. Deshalb können wir für _ili2gpkg_-Tasks ebenfalls das `ilivalidatorModeldir` verwenden und brauchen also keine separate Variable für _ili2db_-Tasks.

Genauer gesagt ist bei _ili2gpkgImport_ so:
Falls das Modell nicht vorgängig in die DB importiert worden ist (mit `--schemaimport`), kann man einfach `modeldir = ilivalidatorModeldir` verwenden. Dies ist bei uns wohl der häufigste Fall. Falls das Modell bereits importiert worden ist, also bereits im GeoPackage vorhanden ist, soll man die `modeldir`-Option nicht setzen, damit das Modell direkt in der GeoPackage-Datei gefunden wird und somit auch sicher die richtige Version verwendet wird.