### PR TITLE
Feature: Grant permission to multiple roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,8 @@ parameters.stringParams=bfsnr;0000;BFS-Nr. der Gemeinde welche publiziert werden
 Mit `triggers.upstream` kann eingestellt werden, dass der Job immer dann ausgeführt werden soll, wenn ein bestimmter anderer Job erfolgreich ausgeführt worden ist. Es können hier auch mehrere Jobs angegeben werden, jeweils durch Komma und Leerschlag voneinander getrennt (z.B. `other_job_name_1, other_job_name_2`).
 
 Mit `authorization.permissions` kann angegeben werden, welcher Benutzer oder welche Benutzergruppe den Job manuell starten darf.
+Mehrere Benutzer oder Gruppen
+können mit Komma getrennt aneinandergereiht werden.
 Folgende GRETL-spezifischen Benutzergruppen stehen im Moment zur Verfügung:
 
 * gretl-users-barpa

--- a/arp_agglomerationsprogramme_pub/job.properties
+++ b/arp_agglomerationsprogramme_pub/job.properties
@@ -1,1 +1,1 @@
-authorization.permissions=gretl-users-barpa
+authorization.permissions=gretl-users-barpa,gretl-users-bvtaa

--- a/gretl_job_generator.groovy
+++ b/gretl_job_generator.groovy
@@ -78,8 +78,11 @@ for (jobFile in jobFiles) {
       }
     }
     if (jobProperties.getProperty('authorization.permissions') != 'nobody') {
-      authorization {
-        permissions(jobProperties.getProperty('authorization.permissions'), ['hudson.model.Item.Build', 'hudson.model.Item.Read'])
+      def roles = jobProperties.getProperty('authorization.permissions').split(',')
+      for ( r in roles ) {
+        authorization {
+          permissions(r.trim(), ['hudson.model.Item.Build', 'hudson.model.Item.Read'])
+        }
       }
     }
     if (jobProperties.getProperty('logRotator.numToKeep') != 'unlimited') {


### PR DESCRIPTION
Bei der Erteilung von Berechtigungen auf einem Job können neu mehrere Benutzer oder Gruppen mit Komma getrennt aneinandergereiht werden. Z.B.

`authorization.permissions=gretl-users-barpa,gretl-users-bvtaa`