### PR TITLE
[arp_nutzungsplanung_planregister_pub_alles] neuer Job

### DIFF
--- a/arp_nutzungsplanung_planregister_pub_alles/build.gradle
+++ b/arp_nutzungsplanung_planregister_pub_alles/build.gradle
@@ -1,0 +1,76 @@
+// Datenumbau alle Nutzungsplanungsdaten für Planregsiter und sendet dieses an Typo3
+
+import ch.so.agi.gretl.tasks.*
+import ch.so.agi.gretl.api.TransferSet
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.io.File
+
+apply plugin: 'ch.so.agi.gretl'
+
+//Für Planregister
+def iliModelPlanregister = "SO_Nutzungsplanung_Planregister_Publikation_20221115"
+def dbSchemaPlanregister = "arp_nutzungsplanung_planregister_pub_v1"
+def PlanregisterXtfFileName = "ch.so.arp.planregister.xml" //Muss xml heissen wegen Planregister
+def PlanregisterZipFileName = "ch.so.arp.planregister.gz"
+
+
+//defaultTasks ''
+
+task transfer_planregister_alles(type: Db2Db) {
+    sourceDb = [dbUriEdit, dbUserEdit, dbPwdEdit]
+    targetDb = [dbUriPub, dbUserPub, dbPwdPub]
+    transferSets = [
+            new TransferSet('insert_dataset.sql', 'arp_nutzungsplanung_planregister_pub_v1.t_ili2db_dataset', true),
+            new TransferSet('insert_basket.sql', 'arp_nutzungsplanung_planregister_pub_v1.t_ili2db_basket', true),
+            new TransferSet('insert_arp_nutzungsplanung_planregister_pub_grundwasserschutz.sql', 'arp_nutzungsplanung_planregister_pub_v1.planregister_dokument', true),
+            new TransferSet('insert_arp_nutzungsplanung_planregister_pub_kantonal.sql', 'arp_nutzungsplanung_planregister_pub_v1.planregister_dokument', true),
+            new TransferSet('insert_arp_nutzungsplanung_planregister_pub_kommunal.sql', 'arp_nutzungsplanung_planregister_pub_v1.planregister_dokument', true),
+            new TransferSet('insert_arp_nutzungsplanung_planregister_pub_naturreservate.sql', 'arp_nutzungsplanung_planregister_pub_v1.planregister_dokument', true),
+            new TransferSet('insert_arp_nutzungsplanung_planregister_pub_waldgrenze.sql', 'arp_nutzungsplanung_planregister_pub_v1.planregister_dokument', true)
+    ];
+}
+
+task deleteData_doppelte_dokumente (type: SqlExecutor, dependsOn:transfer_planregister_alles) {
+    description = "Löscht die doppelten Dokumente aus dem Schema arp_nutzungsplanung_planregister_pub" 
+    database = [dbUriPub, dbUserPub, dbPwdPub]
+    sqlFiles = ["delete_arp_nutzungsplanung_planregister_pub_doppelte_dokumente.sql"]
+}
+
+task export_planregister_pub(type: Ili2pgExport, dependsOn: 'deleteData_doppelte_dokumente') {
+    database = [dbUriPub, dbUserPub, dbPwdPub]
+    models = iliModelPlanregister
+    dbschema = dbSchemaPlanregister
+    dataFile = file(PlanregisterXtfFileName)
+    disableValidation = true
+    // Kein Dataset, weil alle Daten enthalten sein sollen. 
+}
+
+task zipPlanregister(type: Tar, dependsOn: 'export_planregister_pub') {
+    archiveName = PlanregisterZipFileName
+    from pathToTempFolder
+    from "."
+    include PlanregisterXtfFileName
+    destinationDir(file(pathToTempFolder))
+    extension 'gz'
+    compression = Compression.GZIP
+}
+
+task uploadPlanregister(dependsOn: 'zipPlanregister') {
+
+    def digiplanLogin = digiplanUser + ":" + digiplanPwd
+    def zipFilePath = Paths.get(pathToTempFolder.toString(), PlanregisterZipFileName)
+    //def serverUrl = "https://so.ch/typo3/api/digiplan"
+    def serverUrl = "https://testweb.so.ch/ typo3/api/digiplan"
+
+    doLast {
+        def response = ["curl", "-v", "-u", digiplanLogin, "--data-binary", "@" + zipFilePath, "-H", "Content-Type: application/xml", "-H", "Content-Encoding: gzip", "-X", "POST", serverUrl
+                        ].execute().text
+
+        println(response)
+        if (response.contains("false") || response == null || response.trim().isEmpty()) {
+            throw new GradleException()
+        }
+    }
+}
+

--- a/arp_nutzungsplanung_planregister_pub_alles/delete_arp_nutzungsplanung_planregister_pub_doppelte_dokumente.sql
+++ b/arp_nutzungsplanung_planregister_pub_alles/delete_arp_nutzungsplanung_planregister_pub_doppelte_dokumente.sql
@@ -1,0 +1,20 @@
+-- In der Nutzungsplanung müssen komunale Dokumente in mehreren Gemeidnen erfasst werden, 
+-- wenn die Nutzungsplanung über die Gemeindegrenze geht. Das kann zu doppelten Dokumenten 
+-- führen die wir im Planregsiter nicht wollen. Deshalb diese Query, welche die Doppelten Einträge löscht.
+
+DELETE
+FROM
+arp_nutzungsplanung_planregister_pub_v1.planregister_dokument
+WHERE
+    t_id IN
+(
+SELECT 
+    b.t_id AS t_id_delete
+FROM
+    arp_nutzungsplanung_planregister_pub_v1.planregister_dokument a,
+    arp_nutzungsplanung_planregister_pub_v1.planregister_dokument b
+WHERE
+    a.dokument_url = b.dokument_url
+    AND
+    a.t_id < b.t_id
+)

--- a/arp_nutzungsplanung_planregister_pub_alles/dummy.txt
+++ b/arp_nutzungsplanung_planregister_pub_alles/dummy.txt
@@ -1,0 +1,1 @@
+Hallo Andrea

--- a/arp_nutzungsplanung_planregister_pub_alles/insert_arp_nutzungsplanung_planregister_pub_grundwasserschutz.sql
+++ b/arp_nutzungsplanung_planregister_pub_alles/insert_arp_nutzungsplanung_planregister_pub_grundwasserschutz.sql
@@ -1,0 +1,79 @@
+WITH dokument_schutzzonenplan_gws AS(
+    SELECT
+        dokument.t_id as dok_t_id,
+        dokument.titel AS planungsinstrument,
+        dokument.offiziellertitel AS bezeichnung,
+        'Gemeinde' AS planungsbehoerde,
+        gemeinde.gemeindename AS gemeinde,
+        dokument.publiziertab AS rechtskraft_ab,
+        CASE dokument.rechtsstatus
+            WHEN 'inKraft'
+                THEN 'in Kraft'
+            WHEN 'laufendeAenderung'
+                THEN 'Änderung mit Vorwirkungt'
+        END AS rechtsstatus,
+        dokument.textimweb AS dokument_url,
+        --Encoding von 'https://geo.so.ch/map?t=nutzungsplanung&hp=ch.so.agi.gemeindegrenzen&hf=[["gemeindename","=","' || gemeinde.gemeindename || '"]]'
+        'https://geo.so.ch/map?t=nutzungsplanung&hp=ch.so.agi.gemeindegrenzen&hf=%5B%5B%22bfs_gemeindenummer%22,%22=%22,%22' || dokument.gemeinde || '%22%5D%5D' AS karte_url,
+        'Amt für Umwelt' AS zustaendige_amt,
+        False AS aktuelle_ortsplanung,
+        dokument.offiziellenr AS offiziellenr
+    FROM
+        afu_gewaesserschutz_zonen_areale_v1.gwszonen_dokument AS dokument
+            LEFT JOIN
+                agi_hoheitsgrenzen_pub.hoheitsgrenzen_gemeindegrenze AS gemeinde ON dokument.gemeinde=gemeinde.bfs_gemeindenummer
+    WHERE 
+        dokument.titel ='Schutzzonenplan' 
+    ),
+    
+dokument_rrb AS(
+    SELECT
+        dokument.t_id as dok_t_id,
+        dokument.t_id AS t_id_rrb,
+        dokument.publiziertab AS rrb_datum,
+        dokument.offiziellenr AS rrb_nr,
+        dokument.textimweb AS rrb_url
+    FROM
+        afu_gewaesserschutz_zonen_areale_v1.gwszonen_dokument AS dokument
+    WHERE 
+        dokument.titel ='Regierungsratsbeschluss' 
+
+   ),
+
+dokument_sbv AS(
+    SELECT
+        dokument.t_id as dok_t_id,
+        dokument.textimweb AS sonderbauvorschrift_url
+    FROM
+        afu_gewaesserschutz_zonen_areale_v1.gwszonen_dokument AS dokument
+    WHERE 
+        dokument.titel ='Schutzzonenreglement'
+ 
+   )
+
+INSERT INTO arp_nutzungsplanung_planregister_v1.planregister_dokument
+
+SELECT
+    nextval('arp_nutzungsplanung_planregister_v1.t_ili2db_seq'::regclass) AS t_id,
+    'gewaesserschutz' AS t_datasetname,
+    schutzzonenplan.planungsinstrument,
+    schutzzonenplan.bezeichnung,
+    schutzzonenplan.planungsbehoerde,
+    schutzzonenplan.gemeinde,
+    schutzzonenplan.rechtskraft_ab,
+    schutzzonenplan.rechtsstatus,
+    schutzzonenplan.dokument_url,
+    rrb.rrb_datum,
+    rrb.rrb_nr,
+    rrb.rrb_url,
+    sbv.sonderbauvorschrift_url,
+    schutzzonenplan.karte_url,
+    schutzzonenplan.zustaendige_amt,
+    schutzzonenplan.aktuelle_ortsplanung,
+    schutzzonenplan.offiziellenr
+FROM
+    dokument_schutzzonenplan_gws AS schutzzonenplan
+    LEFT JOIN
+    dokument_rrb AS rrb ON replace(SPLIT_PART(schutzzonenplan.dokument_url,'/',6),'-P.pdf','-E')=replace(SPLIT_PART(rrb.rrb_url,'/',6),'.pdf','')
+    LEFT JOIN
+    dokument_sbv AS sbv ON replace(SPLIT_PART(schutzzonenplan.dokument_url,'/',6),'-P.pdf','-S')=replace(SPLIT_PART(sbv.sonderbauvorschrift_url,'/',6),'.pdf','')

--- a/arp_nutzungsplanung_planregister_pub_alles/insert_arp_nutzungsplanung_planregister_pub_kantonal.sql
+++ b/arp_nutzungsplanung_planregister_pub_alles/insert_arp_nutzungsplanung_planregister_pub_kantonal.sql
@@ -1,0 +1,108 @@
+WITH dokument_plan_kantonal AS(
+    SELECT
+        dokument.t_id AS plan_t_id,
+        CASE dokument.rechtsvorschrift
+            WHEN TRUE
+                THEN dokument.titel
+            ELSE 'Grundlage'
+        END AS planungsinstrument,
+        dokument.offiziellertitel AS bezeichnung,
+        'Kanton' AS planungsbehoerde,
+        gemeinde.gemeindename AS gemeinde,
+        dokument.publiziertab AS rechtskraft_ab,
+        CASE dokument.rechtsstatus
+            WHEN 'inKraft'
+                THEN 'in Kraft'
+            WHEN 'AenderungMitVorwirkung'
+                THEN 'Änderung mit Vorwirkungt'
+            WHEN 'AenderungOhneVorwirkung'
+                THEN 'Änderung ohne Vorwirkungt'
+            ELSE 'aufgehoben'
+        END AS rechtsstatus,
+        CASE 
+            WHEN dokument.textimweb IS NULL
+                THEN 'https://planregister-data.so.ch/public/kanton/Dokument-nicht-digital-verfuegbar.pdf'
+            ELSE dokument.textimweb 
+        END AS dokument_url,
+        --Encoding von 'https://geo.so.ch/map?t=nutzungsplanung&hp=ch.so.agi.gemeindegrenzen&hf=[["gemeindename","=","' || gemeinde.gemeindename || '"]]'
+        'https://geo.so.ch/map?t=nutzungsplanung&hp=ch.so.agi.gemeindegrenzen&hf=%5B%5B%22bfs_gemeindenummer%22,%22=%22,%22' || dokument.gemeinde || '%22%5D%5D' AS karte_url,
+        dokument.zustaendige_amt,
+        dokument.aktuelle_ortsplanung,
+        dokument.offiziellenr
+     FROM
+        arp_nutzungsplanung_kanton_v1.rechtsvorschrften_dokument AS dokument
+        LEFT JOIN 
+            agi_hoheitsgrenzen_pub.hoheitsgrenzen_gemeindegrenze AS gemeinde ON dokument.gemeinde=gemeinde.bfs_gemeindenummer
+    WHERE 
+        dokument.titel != 'Regierungsratsbeschluss' 
+        AND
+        dokument.titel != 'Sonderbauvorschriften'
+        AND
+        dokument.titel != 'Eisenbahngesetz' --will man nicht im Planregister auf Typo3 haben
+        AND
+        dokument.titel != 'Auszug kantonale Bauverordnung' --will man nicht im Planregister auf Typo3 haben
+        AND
+        dokument.titel != 'Nationalstrassenverordnung' --will man nicht im Planregister auf Typo3 haben
+        AND
+        dokument.titel != 'Richtplan' --will man nicht im Planregister auf Typo3 haben
+        AND
+        dokument.titel != 'Schutzverordnung' --will man nicht im Planregister auf Typo3 haben
+        AND 
+        dokument.rechtsstatus != 'AenderungMitVorwirkung' --Stand 21.04.2023 momentan nur die in Kraft und aufgehobenen publizieren
+        AND 
+        dokument.rechtsstatus != 'AenderungOhneVorwirkung' --Stand 21.04.2023 momentan nur die in Kraft und aufgehobenen publizieren
+    ),
+    
+    dokument_rrb_kantonal AS(
+    SELECT
+        zuordnung_rrb.dokument_planregister AS t_id_plan_rrb,
+        zuordnung_rrb.entscheide_sbv AS t_id_rrb,
+        dokument_rrb.publiziertab AS rrb_datum,
+        dokument_rrb.offiziellenr AS rrb_nr,
+        dokument_rrb.textimweb  AS rrb_url
+    FROM
+        arp_nutzungsplanung_kanton_v1.rechtsvorschrften_dokument_entscheid_sbv AS zuordnung_rrb
+        LEFT JOIN 
+            arp_nutzungsplanung_kanton_v1.rechtsvorschrften_dokument AS dokument_rrb ON dokument_rrb.t_id=zuordnung_rrb.entscheide_sbv
+    WHERE 
+        dokument_rrb.titel = 'Regierungsratsbeschluss'
+    ),
+    
+    dokument_sbv_kantonal AS(
+SELECT
+        zuordnung_sbv.dokument_planregister AS t_id_plan_rrb,
+        zuordnung_sbv.entscheide_sbv AS t_id_sbv,
+        dokument_sbv.textimweb  AS sonderbauvorschrift_url
+    FROM
+        arp_nutzungsplanung_kanton_v1.rechtsvorschrften_dokument_entscheid_sbv AS zuordnung_sbv
+        LEFT JOIN 
+            arp_nutzungsplanung_kanton_v1.rechtsvorschrften_dokument AS dokument_sbv ON dokument_sbv.t_id=zuordnung_sbv.entscheide_sbv
+    WHERE 
+        dokument_sbv.titel = 'Sonderbauvorschriften'
+    )
+
+SELECT 
+-- DISTINCT ON (plan.plan_t_id)
+    nextval('arp_nutzungsplanung_planregister_v1.t_ili2db_seq'::regclass) AS t_id,
+    'nutzungsplanung_kantonal' AS t_datasetname,
+    plan.planungsinstrument,
+    plan.bezeichnung,
+    plan.planungsbehoerde,
+    plan.gemeinde,
+    plan.rechtskraft_ab,
+    plan.rechtsstatus,
+    plan.dokument_url,
+    rrb.rrb_datum,
+    rrb.rrb_nr,
+    rrb.rrb_url,
+    sbv.sonderbauvorschrift_url,
+    plan.karte_url,
+    plan.zustaendige_amt,
+    plan.aktuelle_ortsplanung,
+    plan.offiziellenr
+FROM 
+    dokument_plan_kantonal AS plan
+    LEFT JOIN
+        dokument_rrb_kantonal AS rrb ON plan.plan_t_id = rrb.t_id_plan_rrb
+     LEFT JOIN
+        dokument_sbv_kantonal AS sbv ON plan.plan_t_id = sbv.t_id_plan_rrb

--- a/arp_nutzungsplanung_planregister_pub_alles/insert_arp_nutzungsplanung_planregister_pub_kommunal.sql
+++ b/arp_nutzungsplanung_planregister_pub_alles/insert_arp_nutzungsplanung_planregister_pub_kommunal.sql
@@ -1,0 +1,112 @@
+WITH dokument_plan_kommunal AS(
+    SELECT
+        dokument.t_id AS plan_t_id,
+        CASE dokument.rechtsvorschrift
+            WHEN TRUE
+                THEN dokument.titel
+            ELSE 'Grundlage'
+        END AS planungsinstrument,
+        dokument.offiziellertitel AS bezeichnung,
+        'Gemeinde' AS planungsbehoerde,
+        gemeinde.gemeindename AS gemeinde,
+        dokument.gemeinde AS bfsnr,
+        dokument.publiziertab AS rechtskraft_ab,
+        CASE dokument.rechtsstatus
+            WHEN 'inKraft'
+                THEN 'in Kraft'
+            WHEN 'AenderungMitVorwirkung'
+                THEN 'Änderung mit Vorwirkungt'
+            WHEN 'AenderungOhneVorwirkung'
+                THEN 'Änderung ohne Vorwirkungt'
+            ELSE 'aufgehoben'
+        END AS rechtsstatus,
+        CASE 
+            WHEN dokument.textimweb IS NULL
+                THEN 'https://planregister-data.so.ch/public/kanton/Dokument-nicht-digital-verfuegbar.pdf'
+            ELSE dokument.textimweb 
+        END AS dokument_url,
+        --Encoding von 'https://geo.so.ch/map?t=nutzungsplanung&hp=ch.so.agi.gemeindegrenzen&hf=[["gemeindename","=","' || gemeinde.gemeindename || '"]]'
+        'https://geo.so.ch/map?t=nutzungsplanung&hp=ch.so.agi.gemeindegrenzen&hf=%5B%5B%22bfs_gemeindenummer%22,%22=%22,%22' || dokument.gemeinde || '%22%5D%5D' AS karte_url,
+        dokument.zustaendige_amt,
+        dokument.aktuelle_ortsplanung,
+        dokument.offiziellenr
+     FROM
+        arp_nutzungsplanung_v1.rechtsvorschrften_dokument AS dokument
+        LEFT JOIN 
+            agi_hoheitsgrenzen_pub.hoheitsgrenzen_gemeindegrenze AS gemeinde ON dokument.gemeinde=gemeinde.bfs_gemeindenummer
+    WHERE 
+        dokument.titel != 'Regierungsratsbeschluss' 
+        AND 
+        dokument.titel != 'Sonderbauvorschriften'
+        AND
+        dokument.titel != 'Eisenbahngesetz' --will man nicht im Planregister auf Typo3 haben
+        AND
+        dokument.titel != 'Auszug kantonale Bauverordnung' --will man nicht im Planregister auf Typo3 haben
+        AND
+        dokument.titel != 'Nationalstrassenverordnung' --will man nicht im Planregister auf Typo3 haben
+        AND
+        dokument.titel != 'Richtplantext' --will man nicht im Planregister auf Typo3 haben
+        AND
+        dokument.titel != 'Richtplan' --will man nicht im Planregister auf Typo3 haben
+        AND
+        dokument.titel != 'Schutzverordnung' --will man nicht im Planregister auf Typo3 haben
+        AND
+        dokument.rechtsstatus != 'AenderungMitVorwirkung' --Stand 21.04.2023 momentan nur die in Kraft und aufgehobenen publizieren
+        AND
+        dokument.rechtsstatus != 'AenderungOhneVorwirkung' --Stand 21.04.2023 momentan nur die in Kraft aufgehobenen publizieren
+    ),
+    
+    dokument_rrb_kommunal AS(
+    SELECT
+        zuordnung_rrb.dokument_planregister AS t_id_plan_rrb,
+        zuordnung_rrb.entscheide_sbv AS t_id_rrb,
+        dokument_rrb.publiziertab AS rrb_datum,
+        dokument_rrb.offiziellenr AS rrb_nr,
+        dokument_rrb.textimweb  AS rrb_url
+    FROM
+        arp_nutzungsplanung_v1.rechtsvorschrften_dokument_entscheid_sbv AS zuordnung_rrb
+        LEFT JOIN 
+            arp_nutzungsplanung_v1.rechtsvorschrften_dokument AS dokument_rrb ON dokument_rrb.t_id=zuordnung_rrb.entscheide_sbv
+    WHERE 
+        dokument_rrb.titel = 'Regierungsratsbeschluss'
+    ),
+    
+    dokument_sbv_kommunal AS(
+SELECT
+        zuordnung_sbv.dokument_planregister AS t_id_plan_rrb,
+        zuordnung_sbv.entscheide_sbv AS t_id_sbv,
+        dokument_sbv.textimweb  AS sonderbauvorschrift_url
+    FROM
+        arp_nutzungsplanung_v1.rechtsvorschrften_dokument_entscheid_sbv AS zuordnung_sbv
+        LEFT JOIN 
+            arp_nutzungsplanung_v1.rechtsvorschrften_dokument AS dokument_sbv ON dokument_sbv.t_id=zuordnung_sbv.entscheide_sbv
+    WHERE 
+        dokument_sbv.titel = 'Sonderbauvorschriften'
+
+    )
+
+SELECT 
+    DISTINCT ON (plan.plan_t_id)
+    nextval('arp_nutzungsplanung_planregister_v1.t_ili2db_seq'::regclass) AS t_id,
+    'nutzungsplanung_kommunal' || '_' || plan.bfsnr AS t_datasetname,
+    plan.planungsinstrument,
+    plan.bezeichnung,
+    plan.planungsbehoerde,
+    plan.gemeinde,
+    plan.rechtskraft_ab,
+    plan.rechtsstatus,
+    plan.dokument_url,
+    rrb.rrb_datum,
+    rrb.rrb_nr,
+    rrb.rrb_url,
+    sbv.sonderbauvorschrift_url,
+    plan.karte_url,
+    plan.zustaendige_amt,
+    plan.aktuelle_ortsplanung,
+    plan.offiziellenr
+FROM 
+    dokument_plan_kommunal AS plan
+    LEFT JOIN
+        dokument_rrb_kommunal AS rrb ON plan.plan_t_id = rrb.t_id_plan_rrb
+     LEFT JOIN
+        dokument_sbv_kommunal AS sbv ON plan.plan_t_id = sbv.t_id_plan_rrb

--- a/arp_nutzungsplanung_planregister_pub_alles/insert_arp_nutzungsplanung_planregister_pub_naturreservate.sql
+++ b/arp_nutzungsplanung_planregister_pub_alles/insert_arp_nutzungsplanung_planregister_pub_naturreservate.sql
@@ -1,0 +1,104 @@
+WITH dokument_plan_naturreservat AS(
+    SELECT
+        reservat.t_id AS reservat_t_id,
+        dokument.t_id,
+        CASE dokument.typ
+            WHEN 'RRB'
+                THEN 'Regierungsratsbeschluss'
+            ELSE dokument.typ
+        END AS planungsinstrument,
+        dokument.bezeichnung AS bezeichnung,
+        'Kanton' AS planungsbehoerde,
+ --     Gemeindenamen von der URL übernehmen https://planregister-data.so.ch/public/Erlinsbach/101-39-P.pdf
+       --SPLIT_PART(dokument.dateipfad,'/',5) AS gemeinde,
+       SPLIT_PART(SPLIT_PART(dokument.dateipfad,'/',7),'-',2) AS gemeinde, --solang die Ablage noch auf g: ist
+        dokument.publiziertab AS rechtskraft_ab,
+        CASE dokument.rechtsstatus
+            WHEN 'inKraft'
+                THEN 'in Kraft'
+            WHEN 'laufendeAenderung'
+                THEN 'Änderung mit Vorwirkungt'
+        END AS rechtsstatus,
+        dokument.dateipfad AS dokument_url,
+        --Encoding von 'https://geo.so.ch/map?t=nutzungsplanung&hp=ch.so.agi.gemeindegrenzen&hf=[["gemeindename","=","' || gemeinde.gemeindename || '"]]'
+        'https://geo.so.ch/map?t=nutzungsplanung&hp=ch.so.agi.gemeindegrenzen&hf=%5B%5B%22gemeindename%22,%22=%22,%22' || 'Solothurn' || '%22%5D%5D' AS karte_url,
+        'Amt für Raumplanung' AS zustaendige_amt,
+        False AS aktuelle_ortsplanung,
+        dokument.offiziellenr
+FROM
+    arp_naturreservate.reservate_reservat AS reservat 
+    LEFT JOIN
+     arp_naturreservate.reservate_reservat_dokument AS dokument_reservat ON reservat.t_id=dokument_reservat.reservat
+    left JOIN  
+    arp_naturreservate.reservate_dokument AS dokument ON dokument.t_id=dokument_reservat.dokument 
+WHERE 
+    reservat.einzelschutz IS false 
+        AND 
+            dokument.typ ='Gestaltungsplan' 
+        AND
+            rechtsvorschrift IS TRUE
+    ),
+    
+dokument_rrb AS(
+    SELECT
+        reservat.t_id AS t_id_reservat,
+        dokument.t_id AS t_id_rrb,
+        dokument.publiziertab AS rrb_datum,
+        dokument.offiziellenr AS rrb_nr,
+        dokument.dateipfad AS rrb_url
+FROM
+    arp_naturreservate.reservate_reservat AS reservat 
+    LEFT JOIN
+     arp_naturreservate.reservate_reservat_dokument AS dokument_reservat ON reservat.t_id=dokument_reservat.reservat
+    left JOIN  
+    arp_naturreservate.reservate_dokument AS dokument ON dokument.t_id=dokument_reservat.dokument 
+WHERE 
+    reservat.einzelschutz IS false 
+        AND 
+            dokument.typ ='RRB'
+    ),    
+
+dokument_sbv AS(
+    SELECT
+        reservat.t_id AS t_id_reservat,
+        dokument.t_id AS t_id_sbv,
+        dokument.dateipfad AS sonderbauvorschrift_url
+FROM
+    arp_naturreservate.reservate_reservat AS reservat 
+    LEFT JOIN
+     arp_naturreservate.reservate_reservat_dokument AS dokument_reservat ON reservat.t_id=dokument_reservat.reservat
+    left JOIN  
+    arp_naturreservate.reservate_dokument AS dokument ON dokument.t_id=dokument_reservat.dokument 
+WHERE 
+    reservat.einzelschutz IS false 
+        AND 
+            dokument.typ ='Sonderbauvorschriften'
+    )
+  
+INSERT INTO arp_nutzungsplanung_planregister_v1.planregister_dokument
+
+SELECT 
+    DISTINCT ON (naturreservat.t_id)
+    nextval('arp_nutzungsplanung_planregister_v1.t_ili2db_seq'::regclass) AS t_id,
+    'naturreservat' AS t_datasetname,
+    naturreservat.planungsinstrument,
+    naturreservat.bezeichnung,
+    naturreservat.planungsbehoerde,
+    naturreservat.gemeinde,
+    naturreservat.rechtskraft_ab,
+    naturreservat.rechtsstatus,
+    naturreservat.dokument_url,
+    rrb.rrb_datum,
+    rrb.rrb_nr,
+    NULL AS rrb_url, --rrb.rrb_url,   !!!! doppelet RRB müssen bereinigt werden
+    sbv.sonderbauvorschrift_url,
+    naturreservat.karte_url,
+    naturreservat.zustaendige_amt,
+    naturreservat.aktuelle_ortsplanung,
+    naturreservat.offiziellenr
+FROM 
+    dokument_plan_naturreservat AS naturreservat
+    LEFT JOIN
+        dokument_rrb AS rrb ON naturreservat.reservat_t_id = rrb.t_id_reservat
+     LEFT JOIN
+        dokument_sbv AS sbv ON naturreservat.reservat_t_id = sbv.t_id_reservat

--- a/arp_nutzungsplanung_planregister_pub_alles/insert_arp_nutzungsplanung_planregister_pub_waldgrenze.sql
+++ b/arp_nutzungsplanung_planregister_pub_alles/insert_arp_nutzungsplanung_planregister_pub_waldgrenze.sql
@@ -1,0 +1,81 @@
+WITH dokument_plan_waldgrenze AS(
+    SELECT
+        wald_typ.t_id AS wald_typ_t_id,
+        dokument.t_id,
+        CASE dokument.typ
+            WHEN 'RRB'
+                THEN 'Regierungsratsbeschluss'
+            ELSE dokument.typ
+        END AS planungsinstrument,
+        dokument.offiziellertitel AS bezeichnung,
+        'Kanton' AS planungsbehoerde,
+        gemeinde.gemeindename  AS gemeinde,
+        dokument.publiziert_ab AS rechtskraft_ab,
+        CASE dokument.rechtsstatus
+            WHEN 'inKraft'
+                THEN 'in Kraft'
+            WHEN 'laufendeAenderung'
+                THEN 'Änderung mit Vorwirkungt'
+        END AS rechtsstatus,
+        dokument.text_im_web AS dokument_url,
+        --Encoding von 'https://geo.so.ch/map?t=nutzungsplanung&hp=ch.so.agi.gemeindegrenzen&hf=[["gemeindename","=","' || gemeinde.gemeindename || '"]]'
+        'https://geo.so.ch/map?t=nutzungsplanung&hp=ch.so.agi.gemeindegrenzen&hf=%5B%5B%22bfs_gemeindenumme%22,%22=%22,%22' || dokument.gemeinde || '%22%5D%5D' AS karte_url,
+        'Amt für Wald, Jagd und Fischerei' AS zustaendige_amt,
+        False AS aktuelle_ortsplanung,
+        dokument.offiziellenr AS offiziellenr
+    FROM
+        awjf_statische_waldgrenze.geobasisdaten_typ AS wald_typ
+        LEFT JOIN
+        awjf_statische_waldgrenze.geobasisdaten_typ_dokument AS dokument_wald_typ ON wald_typ.t_id=dokument_wald_typ.festlegung
+            LEFT JOIN  
+                awjf_statische_waldgrenze.dokumente_dokument AS dokument ON dokument.t_id=dokument_wald_typ.dokumente 
+            LEFT JOIN
+                agi_hoheitsgrenzen_pub.hoheitsgrenzen_gemeindegrenze AS gemeinde ON dokument.gemeinde=gemeinde.bfs_gemeindenummer
+    WHERE 
+        dokument.typ ='Waldfeststellungsplan' 
+    ),
+    
+dokument_rrb AS(
+    SELECT
+        wald_typ.t_id AS t_id_wald,
+        dokument.t_id AS t_id_rrb,
+        dokument.publiziert_ab AS rrb_datum,
+        dokument.offiziellenr AS rrb_nr,
+        dokument.text_im_web AS rrb_url
+    FROM
+        awjf_statische_waldgrenze.geobasisdaten_typ AS wald_typ
+        LEFT JOIN
+        awjf_statische_waldgrenze.geobasisdaten_typ_dokument AS dokument_wald_typ ON wald_typ.t_id=dokument_wald_typ.festlegung
+        left JOIN  
+        awjf_statische_waldgrenze.dokumente_dokument AS dokument ON dokument.t_id=dokument_wald_typ.dokumente 
+    WHERE 
+        dokument.typ ='RRB'
+        AND
+        dokument.offiziellenr IS NOT NULL -- es gibt Pläne der Nutzungsplanung die erfasst sind unter dem Typ RRB, welche aber keine Nummer haben. RRB haben immer eine Nummer
+    )
+    
+  
+INSERT INTO arp_nutzungsplanung_planregister_v1.planregister_dokument
+
+SELECT 
+    nextval('arp_nutzungsplanung_planregister_v1.t_ili2db_seq'::regclass) AS t_id,
+    'statische_waldgrenze' AS t_datasetname,
+    waldfeststellungsplan.planungsinstrument,
+    waldfeststellungsplan.bezeichnung,
+    waldfeststellungsplan.planungsbehoerde,
+    waldfeststellungsplan.gemeinde,
+    waldfeststellungsplan.rechtskraft_ab,
+    waldfeststellungsplan.rechtsstatus,
+    waldfeststellungsplan.dokument_url,
+    rrb.rrb_datum,
+    rrb.rrb_nr,
+    rrb.rrb_url,
+    NULL AS sonderbauvorschrift_url, --Waldfeststellungsplan hat nie eine Sonderbauvorschrift
+    waldfeststellungsplan.karte_url,
+    waldfeststellungsplan.zustaendige_amt,
+    waldfeststellungsplan.aktuelle_ortsplanung,
+    waldfeststellungsplan.offiziellenr
+FROM 
+    dokument_plan_waldgrenze AS waldfeststellungsplan
+    LEFT JOIN
+    dokument_rrb AS rrb ON waldfeststellungsplan.wald_typ_t_id = rrb.t_id_wald

--- a/arp_nutzungsplanung_planregister_pub_alles/insert_basket.sql
+++ b/arp_nutzungsplanung_planregister_pub_alles/insert_basket.sql
@@ -1,0 +1,12 @@
+-- Basket anlegen
+
+SELECT
+    nextval('arp_nutzungsplanung_planregister_pub_v1.t_ili2db_seq'::regclass) AS t_id,
+    d.t_id AS dataset,
+    'SO_Nutzungsplanung_Planregister_Publikation_20221115.Planregister' AS topic,
+    NULL AS t_ili_tid,
+    d.datasetname AS attachmentkey,
+    NULL AS domains
+FROM
+        arp_nutzungsplanung_planregister_pub_v1.t_ili2db_dataset AS d
+;

--- a/arp_nutzungsplanung_planregister_pub_alles/insert_dataset.sql
+++ b/arp_nutzungsplanung_planregister_pub_alles/insert_dataset.sql
@@ -1,0 +1,31 @@
+-- Dataset anlegen
+WITH dataset AS (
+VALUES
+(nextval('arp_nutzungsplanung_planregister_pub_v1.t_ili2db_seq'::regclass),'gewaesserschutz'),
+(nextval('arp_nutzungsplanung_planregister_pub_v1.t_ili2db_seq'::regclass),'nutzungsplanung_kantonal'),
+(nextval('arp_nutzungsplanung_planregister_pub_v1.t_ili2db_seq'::regclass),'naturreservate'),
+(nextval('arp_nutzungsplanung_planregister_pub_v1.t_ili2db_seq'::regclass),'statische_waldgrenze')
+).
+
+dataset_kommunal AS (
+    SELECT
+        nextval('arp_nutzungsplanung_planregister_pub_v1.t_ili2db_seq'::regclass) AS t_id,
+        'nutzungsplanung_kommunal' || '_' || nutzungsplanung.datasetname AS datasetname
+    FROM
+        arp_nutzungsplanung_v1.t_ili2db_dataset AS nutzungsplanung
+)
+        
+SELECT
+    column1 AS t_id,
+    column2 AS datasetname
+FROM 
+    dataset
+    
+UNION
+
+SELECT
+    t_id,
+    datasetname
+FROM 
+    dataset_kommunal
+;

--- a/arp_nutzungsplanung_planregister_pub_alles/job.properties
+++ b/arp_nutzungsplanung_planregister_pub_alles/job.properties
@@ -1,0 +1,1 @@
+authorization.permissions=gretl-users-barpa


### PR DESCRIPTION
für die Lieferung an Typos3. Wird gebraucht damit das Schema auf der pub einmal befüllt wird. Danach werden Dataset aktualisiert mit den gretljob z.B. arp_nutzungsplanung_pub.