### PR TITLE
[arp_mjpnl_migration] Ermittle Baskets aus den t_ili2db_basket Tabelle 

### DIFF
--- a/arp_mjpnl_migration/build.gradle
+++ b/arp_mjpnl_migration/build.gradle
@@ -30,7 +30,14 @@ task "transfer_mjpnl"(type: Db2Db,dependsOn: "clean_mjpnl_before_import"){
     ];
 }
 
-task "postprocessing_remove_duplicate_coords"(type: SqlExecutor,dependsOn: "transfer_mjpnl") {
+task "postprocessing_fill_t_basket"(type: SqlExecutor,dependsOn: "transfer_mjpnl") {
+    description = "Füge den migrierten Daten korrekte Baskets zu"
+    database = [dbUriEdit, dbUserEdit, dbPwdEdit]
+    sqlParameters = [DB_Schema_MJPNL:DB_Schema_MJPNL]
+    sqlFiles = ['mjpnl_postprocessing_fill_t_basket.sql']
+}
+
+task "postprocessing_remove_duplicate_coords"(type: SqlExecutor,dependsOn: "postprocessing_fill_t_basket") {
     description = "Doppelte Koordinaten in Vereinbarungs-Geometrien entfernen"
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     sqlParameters = [DB_Schema_MJPNL:DB_Schema_MJPNL]

--- a/arp_mjpnl_migration/delete_mjpnl_before_import.sql
+++ b/arp_mjpnl_migration/delete_mjpnl_before_import.sql
@@ -4,3 +4,5 @@ DELETE FROM ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_leistung;
 DELETE FROM ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_vereinbarung;
 DELETE FROM ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_bewirtschafter;
 DELETE FROM ${DB_Schema_MJPNL}.mjpnl_vereinbarung WHERE mjpnl_version = 'MJPNL_2020';
+DELETE FROM ${DB_Schema_MJPNL}.t_ili2db_basket WHERE t_id = 9999999;
+DELETE FROM ${DB_Schema_MJPNL}.umweltziele_uzl_subregion WHERE t_id = 9999999;

--- a/arp_mjpnl_migration/mjpnl_dummy_entries.sql
+++ b/arp_mjpnl_migration/mjpnl_dummy_entries.sql
@@ -8,7 +8,7 @@ kontrollintervall, bemerkung, uzl_subregion, dateipfad_oder_url, erstellungsdatu
 operator_erstellung, aenderungsdatum, operator_aenderung)
 VALUES(
   9999999,
-  5,
+  (SELECT t_id FROM ${DB_Schema_MJPNL}.t_ili2db_basket WHERE topic = 'SO_ARP_MJPNL_20201026.MJPNL' LIMIT 1),
   uuid_generate_v4(),
   '01_DUMMY_00001',
   'Dummy',
@@ -41,9 +41,9 @@ VALUES(
 /* Dummy-Entry Abrechnung per Bewirtschafter */
 INSERT INTO ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_bewirtschafter
 (t_id, t_basket, t_ili_tid, gelan_pid_gelan, gelan_person, gelan_ortschaft, gelan_iban, betrag_total, status_abrechnung, datum_abrechnung, auszahlungsjahr, bemerkung, dateipfad_oder_url, erstellungsdatum, operator_erstellung, aenderungsdatum, operator_aenderung)
-VALUES(9999999, 5, uuid_generate_v4(), (SELECT pid_gelan FROM ${DB_Schema_MJPNL}.betrbsdttrktrdten_gelan_person LIMIT 1), 'Dummy-Name','Dummy-Ortschaft', 'CH16090100565713403', 99, 'initialisiert', '1990-01-01', 1900, 'Dummy-Entry', 'Dummy-Pfad', now()::date, 'bjsvwneu', NULL, NULL);
+VALUES(9999999, (SELECT t_id FROM ${DB_Schema_MJPNL}.t_ili2db_basket WHERE topic = 'SO_ARP_MJPNL_20201026.MJPNL' LIMIT 1), uuid_generate_v4(), (SELECT pid_gelan FROM ${DB_Schema_MJPNL}.betrbsdttrktrdten_gelan_person LIMIT 1), 'Dummy-Name','Dummy-Ortschaft', 'CH16090100565713403', 99, 'initialisiert', '1990-01-01', 1900, 'Dummy-Entry', 'Dummy-Pfad', now()::date, 'bjsvwneu', NULL, NULL);
 
 /* Dummy-Entry Abrechnung per Vereinbarung */
 INSERT INTO ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_vereinbarung
 (t_id, t_basket, t_ili_tid, vereinbarungs_nr, flurnamen, gemeinde, flaeche, gesamtbetrag, auszahlungsjahr, status_abrechnung, datum_abrechnung, bemerkung, abrechnungperbewirtschafter, vereinbarung)
-VALUES(9999999, 5, uuid_generate_v4(), '01_DUMMY_00001', 'Dummy-Flurnamen', 'Dummy-Gemeinde', 99, 99, 1900, 'initialisiert', '1990-01-01', 'Dummy Entry', 9999999, 9999999);
+VALUES(9999999, (SELECT t_id FROM ${DB_Schema_MJPNL}.t_ili2db_basket WHERE topic = 'SO_ARP_MJPNL_20201026.MJPNL' LIMIT 1), uuid_generate_v4(), '01_DUMMY_00001', 'Dummy-Flurnamen', 'Dummy-Gemeinde', 99, 99, 1900, 'initialisiert', '1990-01-01', 'Dummy Entry', 9999999, 9999999);

--- a/arp_mjpnl_migration/mjpnl_dummy_entries.sql
+++ b/arp_mjpnl_migration/mjpnl_dummy_entries.sql
@@ -47,3 +47,27 @@ VALUES(9999999, (SELECT t_id FROM ${DB_Schema_MJPNL}.t_ili2db_basket WHERE topic
 INSERT INTO ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_vereinbarung
 (t_id, t_basket, t_ili_tid, vereinbarungs_nr, flurnamen, gemeinde, flaeche, gesamtbetrag, auszahlungsjahr, status_abrechnung, datum_abrechnung, bemerkung, abrechnungperbewirtschafter, vereinbarung)
 VALUES(9999999, (SELECT t_id FROM ${DB_Schema_MJPNL}.t_ili2db_basket WHERE topic = 'SO_ARP_MJPNL_20201026.MJPNL' LIMIT 1), uuid_generate_v4(), '01_DUMMY_00001', 'Dummy-Flurnamen', 'Dummy-Gemeinde', 99, 99, 1900, 'initialisiert', '1990-01-01', 'Dummy Entry', 9999999, 9999999);
+
+/* Dummy-Entry in t_ili2db_basket um statische Baskets den Einträgen von mjpnl_leistung und mjpnl_vereinbarung zuzuweisen */
+INSERT
+  INTO ${DB_Schema_MJPNL}.t_ili2db_basket
+    (t_id, dataset, topic, t_ili_tid, attachmentkey)
+ SELECT
+    9999999 AS t_id,
+    t_id AS dataset,
+    'Dummy-Topic' AS topic,
+    uuid_generate_v4() AS t_ili_tid,
+    'Dummy' AS attachmentkey
+ FROM
+ ${DB_Schema_MJPNL}.t_ili2db_dataset
+ WHERE datasetname = 'MJPNL'
+;
+
+/* Dummy-Entry in umweltziele_uzl_subregion um statischer entry den Einträgen von mjpnl_leistung und mjpnl_vereinbarung zuzuweisen */
+INSERT
+  INTO ${DB_Schema_MJPNL}.umweltziele_uzl_subregion
+    (t_id, t_basket, srcode, srname,geometrie )
+ SELECT
+    9999999, u.t_basket, u.srcode, u.srname, u.geometrie
+ FROM ${DB_Schema_MJPNL}.umweltziele_uzl_subregion as u LIMIT 1
+;

--- a/arp_mjpnl_migration/mjpnl_dummy_entries.sql
+++ b/arp_mjpnl_migration/mjpnl_dummy_entries.sql
@@ -8,7 +8,7 @@ kontrollintervall, bemerkung, uzl_subregion, dateipfad_oder_url, erstellungsdatu
 operator_erstellung, aenderungsdatum, operator_aenderung)
 VALUES(
   9999999,
-  (SELECT t_id FROM ${DB_Schema_MJPNL}.t_ili2db_basket WHERE topic = 'SO_ARP_MJPNL_20201026.MJPNL' LIMIT 1),
+  (SELECT t_id FROM ${DB_Schema_MJPNL}.t_ili2db_basket WHERE t_ili_tid = 'SO_ARP_MJPNL_20201026.MJPNL' LIMIT 1),
   uuid_generate_v4(),
   '01_DUMMY_00001',
   'Dummy',
@@ -41,12 +41,12 @@ VALUES(
 /* Dummy-Entry Abrechnung per Bewirtschafter */
 INSERT INTO ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_bewirtschafter
 (t_id, t_basket, t_ili_tid, gelan_pid_gelan, gelan_person, gelan_ortschaft, gelan_iban, betrag_total, status_abrechnung, datum_abrechnung, auszahlungsjahr, bemerkung, dateipfad_oder_url, erstellungsdatum, operator_erstellung, aenderungsdatum, operator_aenderung)
-VALUES(9999999, (SELECT t_id FROM ${DB_Schema_MJPNL}.t_ili2db_basket WHERE topic = 'SO_ARP_MJPNL_20201026.MJPNL' LIMIT 1), uuid_generate_v4(), (SELECT pid_gelan FROM ${DB_Schema_MJPNL}.betrbsdttrktrdten_gelan_person LIMIT 1), 'Dummy-Name','Dummy-Ortschaft', 'CH16090100565713403', 99, 'initialisiert', '1990-01-01', 1900, 'Dummy-Entry', 'Dummy-Pfad', now()::date, 'bjsvwneu', NULL, NULL);
+VALUES(9999999, (SELECT t_id FROM ${DB_Schema_MJPNL}.t_ili2db_basket WHERE t_ili_tid = 'SO_ARP_MJPNL_20201026.MJPNL' LIMIT 1), uuid_generate_v4(), (SELECT pid_gelan FROM ${DB_Schema_MJPNL}.betrbsdttrktrdten_gelan_person LIMIT 1), 'Dummy-Name','Dummy-Ortschaft', 'CH16090100565713403', 99, 'initialisiert', '1990-01-01', 1900, 'Dummy-Entry', 'Dummy-Pfad', now()::date, 'bjsvwneu', NULL, NULL);
 
 /* Dummy-Entry Abrechnung per Vereinbarung */
 INSERT INTO ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_vereinbarung
 (t_id, t_basket, t_ili_tid, vereinbarungs_nr, flurnamen, gemeinde, flaeche, gesamtbetrag, auszahlungsjahr, status_abrechnung, datum_abrechnung, bemerkung, abrechnungperbewirtschafter, vereinbarung)
-VALUES(9999999, (SELECT t_id FROM ${DB_Schema_MJPNL}.t_ili2db_basket WHERE topic = 'SO_ARP_MJPNL_20201026.MJPNL' LIMIT 1), uuid_generate_v4(), '01_DUMMY_00001', 'Dummy-Flurnamen', 'Dummy-Gemeinde', 99, 99, 1900, 'initialisiert', '1990-01-01', 'Dummy Entry', 9999999, 9999999);
+VALUES(9999999, (SELECT t_id FROM ${DB_Schema_MJPNL}.t_ili2db_basket WHERE t_ili_tid = 'SO_ARP_MJPNL_20201026.MJPNL' LIMIT 1), uuid_generate_v4(), '01_DUMMY_00001', 'Dummy-Flurnamen', 'Dummy-Gemeinde', 99, 99, 1900, 'initialisiert', '1990-01-01', 'Dummy Entry', 9999999, 9999999);
 
 /* Dummy-Entry in t_ili2db_basket um statische Baskets den Einträgen von mjpnl_leistung und mjpnl_vereinbarung zuzuweisen */
 INSERT

--- a/arp_mjpnl_migration/mjpnl_leistung.sql
+++ b/arp_mjpnl_migration/mjpnl_leistung.sql
@@ -1,5 +1,5 @@
 SELECT
-    (SELECT t_id FROM ${DB_Schema_MJPNL}.t_ili2db_basket WHERE topic = 'SO_ARP_MJPNL_20201026.MJPNL' LIMIT 1) AS t_basket,
+    9999999 AS t_basket, --Dummy-Basket für reguläre MJPNL-Daten (ausserhalb von Basisdaten)
     lart.kurzbez AS leistung_beschrieb,
     CASE
         WHEN l.ansatz > 0 AND l.mass > 0 THEN 

--- a/arp_mjpnl_migration/mjpnl_leistung.sql
+++ b/arp_mjpnl_migration/mjpnl_leistung.sql
@@ -1,5 +1,5 @@
 SELECT
-    5 AS t_basket,
+    (SELECT t_id FROM ${DB_Schema_MJPNL}.t_ili2db_basket WHERE topic = 'SO_ARP_MJPNL_20201026.MJPNL' LIMIT 1) AS t_basket,
     lart.kurzbez AS leistung_beschrieb,
     CASE
         WHEN l.ansatz > 0 AND l.mass > 0 THEN 

--- a/arp_mjpnl_migration/mjpnl_postprocessing_abrechnung_per_bewirtschafter.sql
+++ b/arp_mjpnl_migration/mjpnl_postprocessing_abrechnung_per_bewirtschafter.sql
@@ -23,7 +23,7 @@ FROM
 )
 /* Dann Abrechnungsdaten per Bewirtschafter und Auszahlungsjahr und Status aggregieren */
 SELECT 
-   (SELECT t_id FROM ${DB_Schema_MJPNL}.t_ili2db_basket WHERE topic = 'SO_ARP_MJPNL_20201026.MJPNL' LIMIT 1) AS t_basket,   
+   (SELECT t_id FROM ${DB_Schema_MJPNL}.t_ili2db_basket WHERE t_ili_tid = 'SO_ARP_MJPNL_20201026.MJPNL' LIMIT 1) AS t_basket,   
    pers.pid_gelan,
    pers.name_vorname AS gelan_person,
    pers.ortschaft AS gelan_ortschaft,

--- a/arp_mjpnl_migration/mjpnl_postprocessing_abrechnung_per_bewirtschafter.sql
+++ b/arp_mjpnl_migration/mjpnl_postprocessing_abrechnung_per_bewirtschafter.sql
@@ -23,7 +23,7 @@ FROM
 )
 /* Dann Abrechnungsdaten per Bewirtschafter und Auszahlungsjahr und Status aggregieren */
 SELECT 
-   5 AS t_basket,   
+   (SELECT t_id FROM ${DB_Schema_MJPNL}.t_ili2db_basket WHERE topic = 'SO_ARP_MJPNL_20201026.MJPNL' LIMIT 1) AS t_basket,   
    pers.pid_gelan,
    pers.name_vorname AS gelan_person,
    pers.ortschaft AS gelan_ortschaft,

--- a/arp_mjpnl_migration/mjpnl_postprocessing_abrechnung_per_vereinbarung.sql
+++ b/arp_mjpnl_migration/mjpnl_postprocessing_abrechnung_per_vereinbarung.sql
@@ -4,7 +4,7 @@ INSERT INTO ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_vereinbarung
   (t_basket, vereinbarungs_nr, flurnamen, gemeinde, flaeche, gesamtbetrag,
    auszahlungsjahr, status_abrechnung, datum_abrechnung, abrechnungperbewirtschafter, vereinbarung)
 SELECT
-  5 AS t_basket,
+  (SELECT t_id FROM ${DB_Schema_MJPNL}.t_ili2db_basket WHERE topic = 'SO_ARP_MJPNL_20201026.MJPNL' LIMIT 1) AS t_basket,
   vbg.vereinbarungs_nr,
   array_to_string(vbg.flurname,', ') AS flurnamen,
   array_to_string(vbg.gemeinde,', ') AS gemeinde,

--- a/arp_mjpnl_migration/mjpnl_postprocessing_abrechnung_per_vereinbarung.sql
+++ b/arp_mjpnl_migration/mjpnl_postprocessing_abrechnung_per_vereinbarung.sql
@@ -4,7 +4,7 @@ INSERT INTO ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_vereinbarung
   (t_basket, vereinbarungs_nr, flurnamen, gemeinde, flaeche, gesamtbetrag,
    auszahlungsjahr, status_abrechnung, datum_abrechnung, abrechnungperbewirtschafter, vereinbarung)
 SELECT
-  (SELECT t_id FROM ${DB_Schema_MJPNL}.t_ili2db_basket WHERE topic = 'SO_ARP_MJPNL_20201026.MJPNL' LIMIT 1) AS t_basket,
+  (SELECT t_id FROM ${DB_Schema_MJPNL}.t_ili2db_basket WHERE t_ili_tid = 'SO_ARP_MJPNL_20201026.MJPNL' LIMIT 1) AS t_basket,
   vbg.vereinbarungs_nr,
   array_to_string(vbg.flurname,', ') AS flurnamen,
   array_to_string(vbg.gemeinde,', ') AS gemeinde,

--- a/arp_mjpnl_migration/mjpnl_postprocessing_fill_t_basket.sql
+++ b/arp_mjpnl_migration/mjpnl_postprocessing_fill_t_basket.sql
@@ -1,0 +1,9 @@
+-- Füge den migrierten Daten den korrekten Basket (der vom Topic MJPNL) zu 
+UPDATE ${DB_Schema_MJPNL}.mjpnl_vereinbarung
+SET t_basket = (SELECT t_id FROM ${DB_Schema_MJPNL}.t_ili2db_basket WHERE topic = 'SO_ARP_MJPNL_20201026.MJPNL' LIMIT 1);
+
+UPDATE ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_leistung
+SET t_basket = (SELECT t_id FROM ${DB_Schema_MJPNL}.t_ili2db_basket WHERE topic = 'SO_ARP_MJPNL_20201026.MJPNL' LIMIT 1);
+
+-- Lösche Dummy-Basket
+DELETE FROM ${DB_Schema_MJPNL}.t_ili2db_basket WHERE t_id = 9999999;

--- a/arp_mjpnl_migration/mjpnl_postprocessing_fill_t_basket.sql
+++ b/arp_mjpnl_migration/mjpnl_postprocessing_fill_t_basket.sql
@@ -1,9 +1,9 @@
 -- Füge den migrierten Daten den korrekten Basket (der vom Topic MJPNL) zu 
 UPDATE ${DB_Schema_MJPNL}.mjpnl_vereinbarung
-SET t_basket = (SELECT t_id FROM ${DB_Schema_MJPNL}.t_ili2db_basket WHERE topic = 'SO_ARP_MJPNL_20201026.MJPNL' LIMIT 1);
+SET t_basket = (SELECT t_id FROM ${DB_Schema_MJPNL}.t_ili2db_basket WHERE t_ili_tid = 'SO_ARP_MJPNL_20201026.MJPNL' LIMIT 1);
 
 UPDATE ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_leistung
-SET t_basket = (SELECT t_id FROM ${DB_Schema_MJPNL}.t_ili2db_basket WHERE topic = 'SO_ARP_MJPNL_20201026.MJPNL' LIMIT 1);
+SET t_basket = (SELECT t_id FROM ${DB_Schema_MJPNL}.t_ili2db_basket WHERE t_ili_tid = 'SO_ARP_MJPNL_20201026.MJPNL' LIMIT 1);
 
 -- Lösche Dummy-Basket
 DELETE FROM ${DB_Schema_MJPNL}.t_ili2db_basket WHERE t_id = 9999999;

--- a/arp_mjpnl_migration/mjpnl_postprocessing_vereinbarung_uzl-region.sql
+++ b/arp_mjpnl_migration/mjpnl_postprocessing_vereinbarung_uzl-region.sql
@@ -5,3 +5,6 @@ UPDATE
   FROM ${DB_Schema_MJPNL}.umweltziele_uzl_subregion uzl
     WHERE ST_Within(ST_PointOnSurface(vb.geometrie),uzl.geometrie)
 ;
+
+-- Lösche Dummy-UZL region
+DELETE FROM ${DB_Schema_MJPNL}.umweltziele_uzl_subregion WHERE t_id = 9999999;

--- a/arp_mjpnl_migration/mjpnl_vereinbarung.sql
+++ b/arp_mjpnl_migration/mjpnl_vereinbarung.sql
@@ -1,5 +1,5 @@
 SELECT
-  (SELECT t_id FROM ${DB_Schema_MJPNL}.t_ili2db_basket WHERE topic = 'SO_ARP_MJPNL_20201026.MJPNL' LIMIT 1) AS t_basket, --Basket für reguläre MJPNL-Daten (ausserhalb von Basisdaten)
+  9999999 AS t_basket, --Dummy-Basket für reguläre MJPNL-Daten (ausserhalb von Basisdaten)
   'bla' AS vereinbarungs_nr,--im Postprocessing zu ersetzen
   vbg.vbnr AS vereinbarungs_nr_alt,
   vbggeom.polyid AS flaechen_id_alt,
@@ -113,7 +113,7 @@ SELECT
       ',\n\n}',
       '\n}'
     ) AS bemerkung, --TODO: Zwischenparkieren weiterer alter Attribut-Werte
-  18::int8 AS uzl_subregion, -- im Postprocessing zu ersetzen
+  9999999 AS uzl_subregion, -- im Postprocessing zu ersetzen
   'migration' AS dateipfad_oder_url,
   COALESCE(vbg.gueltigab,'1900-01-01'::DATE) AS erstellungsdatum,
   COALESCE(RTRIM(vbg.bearbeiter),'unbekannt (Migration)') AS operator_erstellung

--- a/arp_mjpnl_migration/mjpnl_vereinbarung.sql
+++ b/arp_mjpnl_migration/mjpnl_vereinbarung.sql
@@ -1,5 +1,5 @@
 SELECT
-  5 AS t_basket, --Basket für reguläre MJPNL-Daten (ausserhalb von Basisdaten)
+  (SELECT t_id FROM ${DB_Schema_MJPNL}.t_ili2db_basket WHERE topic = 'SO_ARP_MJPNL_20201026.MJPNL' LIMIT 1) AS t_basket, --Basket für reguläre MJPNL-Daten (ausserhalb von Basisdaten)
   'bla' AS vereinbarungs_nr,--im Postprocessing zu ersetzen
   vbg.vbnr AS vereinbarungs_nr_alt,
   vbggeom.polyid AS flaechen_id_alt,


### PR DESCRIPTION
Und nutze Dummy-Baskets (sowie basket UZL Region) für die Datenrequests aus der alten DB (Leistungen, Vereinbarungen).

Man könnte den korrekten Basket auch ermitteln anhand der t_ili_tid, wenn diese stabil ist...