### PR TITLE
Arp planregister pub alles v4

### DIFF
--- a/arp_nutzungsplanung_planregister_pub_alles/build.gradle
+++ b/arp_nutzungsplanung_planregister_pub_alles/build.gradle
@@ -57,10 +57,10 @@ task zipPlanregister(type: Tar, dependsOn: 'export_planregister_pub') {
 
 task uploadPlanregister(dependsOn: 'zipPlanregister') {
 
-    def digiplanLogin = "_digiplan_:3cDK9qbnn9C"
+    def digiplanLogin = digiplanUser + ":" + digiplanPwd
     def zipFilePath = Paths.get(pathToTempFolder.toString(), PlanregisterZipFileName)
-    //def serverUrl = "https://so.ch/typo3/api/digiplan"
-    def serverUrl = "https://testweb.so.ch/typo3/api/digiplan"
+    def serverUrl = "https://so.ch/typo3/api/digiplan"
+    //def serverUrl = "https://testweb.so.ch/typo3/api/digiplan"
 
     doLast {
         def response = ["curl", "-i", "-v", "-u", digiplanLogin, "--data-binary", "@"+zipFilePath, "-H", "Content-Type: application/xml", "-H", "Content-Encoding: gzip", "-X", "POST", serverUrl].execute().text

--- a/arp_nutzungsplanung_planregister_pub_alles/build.gradle
+++ b/arp_nutzungsplanung_planregister_pub_alles/build.gradle
@@ -57,12 +57,21 @@ task zipPlanregister(type: Tar, dependsOn: 'export_planregister_pub') {
 
 task uploadPlanregister(type:Exec, dependsOn: 'zipPlanregister') {
 
-    def digiplanLogin = '_digiplan_:3cDK9qbnn9C'
+    def digiplanLogin = "_digiplan_:3cDK9qbnn9C"
     def zipFilePath = Paths.get(pathToTempFolder.toString(), PlanregisterZipFileName)
     //def serverUrl = "https://so.ch/typo3/api/digiplan"
-    def serverUrl = 'https://testweb.so.ch/typo3/api/digiplan'
+    def serverUrl = "https://testweb.so.ch/typo3/api/digiplan"
+
+    doLast {
+        def response = ["curl", "-v", "-u", digiplanLogin, "--data-binary", "@"+zipFilePath, "-H", "'Content-Type: application/xml'", "-H", "'Content-Encoding: gzip'", "-o", "-X", serverUrl].execute().text
+		
+		println(response)
+        if (response.contains("false") || response == null || response.trim().isEmpty()) {
+            throw new GradleException()
+        }
+	}
 	 
-    commandLine 'curl', '-v', '-u', digiplanLogin, '--data-binary', '@' + zipFilePath, '-H', 'Content-Type: application/xml', '-H', 'Content-Encoding: gzip', serverUrl
+    // commandLine 'curl', '-v', '-u', digiplanLogin, '--data-binary', '@' + zipFilePath, '-H', 'Content-Type: application/xml', '-H', 'Content-Encoding: gzip', serverUrl
 
        // Es kommt KEINE Rückmeldung!
 }

--- a/arp_nutzungsplanung_planregister_pub_alles/build.gradle
+++ b/arp_nutzungsplanung_planregister_pub_alles/build.gradle
@@ -55,7 +55,7 @@ task zipPlanregister(type: Tar, dependsOn: 'export_planregister_pub') {
     compression = Compression.GZIP
 }
 
-task uploadPlanregister(type:Exec, dependsOn: 'zipPlanregister') {
+task uploadPlanregister(dependsOn: 'zipPlanregister') {
 
     def digiplanLogin = "_digiplan_:3cDK9qbnn9C"
     def zipFilePath = Paths.get(pathToTempFolder.toString(), PlanregisterZipFileName)
@@ -63,15 +63,11 @@ task uploadPlanregister(type:Exec, dependsOn: 'zipPlanregister') {
     def serverUrl = "https://testweb.so.ch/typo3/api/digiplan"
 
     doLast {
-        def response = ["curl", "-v", "-u", digiplanLogin, "--data-binary", "@"+zipFilePath, "-H", "'Content-Type: application/xml'", "-H", "'Content-Encoding: gzip'", "-o", "-X", serverUrl].execute().text
-		
+        def response = ["curl", "-i", "-v", "-u", digiplanLogin, "--data-binary", "@"+zipFilePath, "-H", "Content-Type: application/xml", "-H", "Content-Encoding: gzip", "-X", "POST", serverUrl].execute().text
 		println(response)
-        if (response.contains("false") || response == null || response.trim().isEmpty()) {
+
+        if (!response.contains("HTTP/2 202")) {
             throw new GradleException()
         }
-	}
-	 
-    // commandLine 'curl', '-v', '-u', digiplanLogin, '--data-binary', '@' + zipFilePath, '-H', 'Content-Type: application/xml', '-H', 'Content-Encoding: gzip', serverUrl
-
-       // Es kommt KEINE Rückmeldung!
+    }
 }

--- a/arp_nutzungsplanung_planregister_pub_alles/delete_arp_nutzungsplanung_planregister_pub_doppelte_dokumente.sql
+++ b/arp_nutzungsplanung_planregister_pub_alles/delete_arp_nutzungsplanung_planregister_pub_doppelte_dokumente.sql
@@ -15,6 +15,8 @@ FROM
     arp_nutzungsplanung_planregister_pub_v1.planregister_dokument b
 WHERE
     a.dokument_url = b.dokument_url
+	AND
+	a.gemeinde = b.gemeinde
     AND
     a.t_id < b.t_id
 )


### PR DESCRIPTION
 nur doppelte Dokumente entfernen falls die Gemeinde und URL gleich ist. Senden an Typos3 angepasst.