### PR TITLE
[arp_nutzungsplanung_planregister_pub_alles] 

### DIFF
--- a/arp_nutzungsplanung_planregister_pub_alles/Jenkinsfile
+++ b/arp_nutzungsplanung_planregister_pub_alles/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
                 container('gretl') {
                     dir(env.JOB_BASE_NAME) {
                         sh 'gretl'
-						zip zipFile: 'xtfdata.zip', glob: '*', archive: true
+						zip zipFile: 'xtfdata.zip', glob: '*.gz', archive: true
                     }
                 }
             }

--- a/arp_nutzungsplanung_planregister_pub_alles/build.gradle
+++ b/arp_nutzungsplanung_planregister_pub_alles/build.gradle
@@ -15,8 +15,8 @@ def pathToTempFolder = System.getProperty("java.io.tmpdir")
 def iliModelPlanregister = "SO_Nutzungsplanung_Planregister_Publikation_20221115"
 def dbSchemaPlanregister = "arp_nutzungsplanung_planregister_pub_v1"
 def planregisterFileBaseName = "ch.so.arp.planregister"
-def PlanregisterXtfFileName = planregisterFileBaseName+".xml" //Muss xml heissen wegen Planregister
-def PlanregisterZipFileName = planregisterFileBaseName+".gz"
+def planregisterXtfFileName = planregisterFileBaseName+".xml" //Muss xml heissen wegen Planregister
+def planregisterZipFileName = planregisterFileBaseName+".gz"
 
 task transfer_planregister_alles(type: Db2Db) {
     sourceDb = [dbUriEdit, dbUserEdit, dbPwdEdit]
@@ -42,7 +42,7 @@ task export_planregister_pub(type: Ili2pgExport, dependsOn: 'deleteData_doppelte
     database = [dbUriPub, dbUserPub, dbPwdPub]
     models = iliModelPlanregister
     dbschema = dbSchemaPlanregister
-    dataFile = file(PlanregisterXtfFileName)
+    dataFile = file(planregisterXtfFileName)
     disableValidation = true
     // Kein Dataset, weil alle Daten enthalten sein sollen. 
 }
@@ -52,8 +52,9 @@ task zipPlanregister(type: Tar, dependsOn: 'export_planregister_pub') {
     destinationDirectory = file(pathToTempFolder)
     extension 'gz'
     compression = Compression.GZIP
-    from (pathToTempFolder) 
-    include planregisterXtfFileName
+    from (pathToTempFolder) {
+        include planregisterXtfFileName
+    }
 }
 /*
 task uploadPlanregister(dependsOn: 'zipPlanregister') {

--- a/arp_nutzungsplanung_planregister_pub_alles/build.gradle
+++ b/arp_nutzungsplanung_planregister_pub_alles/build.gradle
@@ -14,8 +14,9 @@ defaultTasks 'zipPlanregister'
 def pathToTempFolder = System.getProperty("java.io.tmpdir")
 def iliModelPlanregister = "SO_Nutzungsplanung_Planregister_Publikation_20221115"
 def dbSchemaPlanregister = "arp_nutzungsplanung_planregister_pub_v1"
-def PlanregisterXtfFileName = "ch.so.arp.planregister.xml" //Muss xml heissen wegen Planregister
-def PlanregisterZipFileName = "ch.so.arp.planregister.gz"
+def planregisterFileBaseName = "ch.so.arp.planregister"
+def PlanregisterXtfFileName = planregisterFileBaseName+".xml" //Muss xml heissen wegen Planregister
+def PlanregisterZipFileName = planregisterFileBaseName+".gz"
 
 task transfer_planregister_alles(type: Db2Db) {
     sourceDb = [dbUriEdit, dbUserEdit, dbPwdEdit]
@@ -47,12 +48,13 @@ task export_planregister_pub(type: Ili2pgExport, dependsOn: 'deleteData_doppelte
 }
 
 task zipPlanregister(type: Tar, dependsOn: 'export_planregister_pub') {
-    archiveFileName = PlanregisterZipFileName
-    from PlanregisterXtfFileName
-    // include PlanregisterXtfFileName
+    archiveBaseName = planregisterFileBaseName
     destinationDirectory = file(pathToTempFolder)
+    extension 'gz'
     compression = Compression.GZIP
-
+    from(pathToTempFolder) {
+        include planregisterXtfFileName
+    }
 }
 /*
 task uploadPlanregister(dependsOn: 'zipPlanregister') {

--- a/arp_nutzungsplanung_planregister_pub_alles/build.gradle
+++ b/arp_nutzungsplanung_planregister_pub_alles/build.gradle
@@ -52,9 +52,8 @@ task zipPlanregister(type: Tar, dependsOn: 'export_planregister_pub') {
     destinationDirectory = file(pathToTempFolder)
     extension 'gz'
     compression = Compression.GZIP
-    from(pathToTempFolder) {
-        include planregisterXtfFileName
-    }
+    from (pathToTempFolder) 
+    include planregisterXtfFileName
 }
 /*
 task uploadPlanregister(dependsOn: 'zipPlanregister') {

--- a/arp_nutzungsplanung_planregister_pub_alles/delete_arp_nutzungsplanung_planregister_pub_doppelte_dokumente.sql
+++ b/arp_nutzungsplanung_planregister_pub_alles/delete_arp_nutzungsplanung_planregister_pub_doppelte_dokumente.sql
@@ -1,6 +1,5 @@
--- In der Nutzungsplanung müssen komunale Dokumente in mehreren Gemeidnen erfasst werden, 
--- wenn die Nutzungsplanung über die Gemeindegrenze geht. Das kann zu doppelten Dokumenten 
--- führen die wir im Planregsiter nicht wollen. Deshalb diese Query, welche die Doppelten Einträge löscht.
+-- In der Nutzungsplanung werden kantonale und kommunale Nutzungspläne separat (Schemas nutzungsplanung, nutzungsplanung_kanton, statsiche_waldgrenze, gewaesserschutz, naturreservat) erfasst. 
+---Das kann zu doppelten Dokumenten führen, die wir im Planregsiter nicht wollen. Deshalb diese Query, welche die Doppelten Einträge löscht. 
 
 DELETE
 FROM
@@ -15,8 +14,10 @@ FROM
     arp_nutzungsplanung_planregister_pub_v1.planregister_dokument b
 WHERE
     a.dokument_url = b.dokument_url
-	AND
-	a.gemeinde = b.gemeinde
+    AND
+    a.gemeinde = b.gemeinde -- Für die Pläne, die über die Gemeindegrenze gehen. Diese werden pro Gemeinde erfasst. Hier ist es richtig, dass sie doppelt sind.
+    AND
+    a.offiziellenr = b.offiziellenr --Für die Dokumente die die URL https://planregister-data.so.ch/public/kanton/Dokument-nicht-digital-verfuegbar.pdf haben
     AND
     a.t_id < b.t_id
 )


### PR DESCRIPTION
task ziplanregister angepasst, SQL delete doppelte Einträge  mit "offiziellenr"  in der WHERE Bedingung  ergänzt , damit die doppelten Dokumente mit URL "nicht digital-verfügbar" nicht gelöscht werden.