### PR TITLE
[arp_mjpnl_migration] `abrechnung_per_leistung` Abrechnung_Status und Einmalig

### DIFF
--- a/arp_mjpnl_migration/build.gradle
+++ b/arp_mjpnl_migration/build.gradle
@@ -9,7 +9,7 @@ import ch.so.agi.gretl.api.TransferSet
 
 apply plugin: 'ch.so.agi.gretl'
 
-defaultTasks 'postprocessing_beurteilungen_erstellen'
+defaultTasks 'clean_mjpnl_after_import'
 
 def DB_Schema_MJPNL = "arp_mjpnl_v1"
 
@@ -79,21 +79,21 @@ task "postprocessing_gelan_bewirtschafter"(type: SqlExecutor,dependsOn: "postpro
     sqlFiles = ['mjpnl_postprocessing_vereinbarungen_gelan_bewirtschafter.sql']
 }
 
-task "postprocessing_abrechnung_leistungen"(type: SqlExecutor,dependsOn: "postprocessing_gelan_bewirtschafter") {
-    description = "Foreign keys zwischen Leistungen und Vereinbarungen wiederherstellen."
-    database = [dbUriEdit, dbUserEdit, dbPwdEdit]
-    sqlParameters = [DB_Schema_MJPNL:DB_Schema_MJPNL]
-    sqlFiles = ['mjpnl_postprocessing_leistungen_fkey_vereinbarungen.sql','mjpnl_postprocessing_abrechnung_per_vereinbarung.sql','mjpnl_postprocessing_abrechnung_per_bewirtschafter.sql']
-}
-
-task "postprocessing_beurteilungen_erstellen"(type: SqlExecutor,dependsOn: "postprocessing_abrechnung_leistungen") {
+task "postprocessing_beurteilungen_erstellen"(type: SqlExecutor,dependsOn: "postprocessing_gelan_bewirtschafter") {
     description = "Beurteilungen erstellen."
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     sqlParameters = [DB_Schema_MJPNL:DB_Schema_MJPNL]
     sqlFiles = ['mjpnl_postprocessing_beurteilungen_wiese.sql','mjpnl_postprocessing_beurteilungen_hecke.sql','mjpnl_postprocessing_beurteilungen_hostet.sql','mjpnl_postprocessing_beurteilungen_obl.sql','mjpnl_postprocessing_beurteilungen_weide_ln.sql','mjpnl_postprocessing_beurteilungen_weide_soeg.sql']
 }
 
-task "clean_mjpnl_after_import"(type: SqlExecutor,dependsOn: "postprocessing_beurteilungen_erstellen"){
+task "postprocessing_abrechnung_leistungen"(type: SqlExecutor,dependsOn: "postprocessing_beurteilungen_erstellen") {
+    description = "Foreign keys zwischen Leistungen und Vereinbarungen wiederherstellen."
+    database = [dbUriEdit, dbUserEdit, dbPwdEdit]
+    sqlParameters = [DB_Schema_MJPNL:DB_Schema_MJPNL]
+    sqlFiles = ['mjpnl_postprocessing_leistungen_fkey_vereinbarungen.sql','mjpnl_postprocessing_abrechnung_per_vereinbarung.sql','mjpnl_postprocessing_abrechnung_per_bewirtschafter.sql']
+}
+
+task "clean_mjpnl_after_import"(type: SqlExecutor,dependsOn: "postprocessing_abrechnung_leistungen"){
     description = "Dummy Daten löschen"
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     sqlParameters = [DB_Schema_MJPNL:DB_Schema_MJPNL]

--- a/arp_mjpnl_migration/delete_mjpnl_before_import.sql
+++ b/arp_mjpnl_migration/delete_mjpnl_before_import.sql
@@ -1,4 +1,9 @@
 -- delete previous data that should be replaced
+DELETE FROM ${DB_Schema_MJPNL}.mjpnl_beurteilung_hecke WHERE operator_erstellung = 'Migration';
+DELETE FROM ${DB_Schema_MJPNL}.mjpnl_beurteilung_hostet WHERE operator_erstellung = 'Migration';
+DELETE FROM ${DB_Schema_MJPNL}.mjpnl_beurteilung_obl WHERE operator_erstellung = 'Migration';
+DELETE FROM ${DB_Schema_MJPNL}.mjpnl_beurteilung_weide_ln WHERE operator_erstellung = 'Migration';
+DELETE FROM ${DB_Schema_MJPNL}.mjpnl_beurteilung_weide_soeg WHERE operator_erstellung = 'Migration';
 DELETE FROM ${DB_Schema_MJPNL}.mjpnl_beurteilung_wiese WHERE operator_erstellung = 'Migration';
 DELETE FROM ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_leistung;
 DELETE FROM ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_vereinbarung;

--- a/arp_mjpnl_migration/mjpnl_dummy_entries.sql
+++ b/arp_mjpnl_migration/mjpnl_dummy_entries.sql
@@ -45,8 +45,8 @@ VALUES(9999999, (SELECT t_id FROM ${DB_Schema_MJPNL}.t_ili2db_basket WHERE t_ili
 
 /* Dummy-Entry Abrechnung per Vereinbarung */
 INSERT INTO ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_vereinbarung
-(t_id, t_basket, t_ili_tid, vereinbarungs_nr, flurnamen, gemeinde, flaeche, gesamtbetrag, auszahlungsjahr, status_abrechnung, datum_abrechnung, bemerkung, abrechnungperbewirtschafter, vereinbarung, migriert)
-VALUES(9999999, (SELECT t_id FROM ${DB_Schema_MJPNL}.t_ili2db_basket WHERE t_ili_tid = 'SO_ARP_MJPNL_20201026.MJPNL' LIMIT 1), uuid_generate_v4(), '01_DUMMY_00001', 'Dummy-Flurnamen', 'Dummy-Gemeinde', 99, 99, 1900, 'initialisiert', '1990-01-01', 'Dummy Entry', 9999999, 9999999, TRUE);
+(t_id, t_basket, t_ili_tid, vereinbarungs_nr, gelan_bewe_id, gb_nr, flurnamen, gemeinde, flaeche, anzahl_baeume, betrag_flaeche, betrag_baeume, betrag_pauschal, gesamtbetrag, auszahlungsjahr, status_abrechnung, datum_abrechnung, bewirtschaftabmachung_messerbalkenmaehgeraet, bewirtschaftabmachung_herbstweide, bemerkung, abrechnungperbewirtschafter, vereinbarung, migriert)
+VALUES(9999999, (SELECT t_id FROM ${DB_Schema_MJPNL}.t_ili2db_basket WHERE t_ili_tid = 'SO_ARP_MJPNL_20201026.MJPNL' LIMIT 1), uuid_generate_v4(), '01_DUMMY_00001', 'GELAN_BEWE_DUMMY', '{"Dummy-GBNr"}', 'Dummy-Flurnamen', 'Dummy-Gemeinde', 99, 0, 99, 0, 0, 99, 1900, 'initialisiert', '1990-01-01', FALSE, FALSE, 'Dummy Entry', 9999999, 9999999, TRUE);
 
 /* Dummy-Entry in t_ili2db_basket um statische Baskets den Einträgen von mjpnl_leistung und mjpnl_vereinbarung zuzuweisen */
 INSERT

--- a/arp_mjpnl_migration/mjpnl_leistung.sql
+++ b/arp_mjpnl_migration/mjpnl_leistung.sql
@@ -48,7 +48,7 @@ SELECT
     CASE
         WHEN extract(YEAR FROM l.datum_auszahlung) = 2023 -- wenn aus diesem Jahr und bereits ausbezahlt
             OR lart.kurzbez IN ( 'Korrektur Vorjahr', 'Unterhaltsbeitrag', 'Pflanzmaterial', 'Kürzung', 'Saatgut' ) -- oder eines der spezifischen Arten
-            OR ( lart.kurzbez = 'Pauschale' AND substr(l.bemerkung,1,2) = 'e ' ) -- oder von der Art Pauschale, aber explizit in Bemerkung markiert
+            OR lart.bez IN ( 'Pauschale einmalig (ha)', 'Pauschale einmalig (p)' ) -- oder eine einmalige Pauschale
         THEN TRUE
         ELSE FALSE
     END AS einmalig,

--- a/arp_mjpnl_migration/mjpnl_leistung.sql
+++ b/arp_mjpnl_migration/mjpnl_leistung.sql
@@ -26,7 +26,7 @@ SELECT
         WHEN stat.kurzbez = 'freigegeben' THEN 'freigegeben'
         WHEN stat.kurzbez = 'in Bearbeitung' THEN 'in_bearbeitung'
         WHEN stat.kurzbez = 'Intern verrechnet' THEN 'intern_verrechnet'
-        WHEN stat.kurzbez IN ('ausbezahlt', 'erledigt LW', 'übernommen ARP', 'Archiv') THEN 'ausbezahlt'
+        WHEN stat.kurzbez IN ('ausbezahlt', 'erledigt LW', 'übernommen ARP') THEN 'ausbezahlt'
         ELSE 'in_bearbeitung'
     END AS status_abrechnung,
     CASE
@@ -51,8 +51,7 @@ SELECT
             OR ( lart.kurzbez = 'Pauschale' AND substr(l.bemerkung,1,2) = 'e ' ) -- oder von der Art Pauschale, aber explizit in Bemerkung markiert
         THEN TRUE
         ELSE FALSE
-    END AS einmalig
-AS einmalig,
+    END AS einmalig,
     9999999 AS abrechnungpervereinbarung,
     9999999 AS vereinbarung
 FROM mjpnatur.leistung l

--- a/arp_mjpnl_migration/mjpnl_leistung.sql
+++ b/arp_mjpnl_migration/mjpnl_leistung.sql
@@ -23,9 +23,11 @@ SELECT
         ELSE extract(YEAR FROM datum_auszahlung) 
     END AS auszahlungsjahr,
     CASE
-        WHEN stat.kurzbez = 'ausbezahlt' THEN 'ausbezahlt'
-        /*WHEN stat.kurzbez = 'übernommen ARP' THEN 'ausbezahlt_vomArpUebernommen'*/
-        ELSE 'bestaetigt'
+        WHEN stat.kurzbez = 'freigegeben' THEN 'freigegeben'
+        WHEN stat.kurzbez = 'in Bearbeitung' THEN 'in_bearbeitung'
+        WHEN stat.kurzbez = 'Intern verrechnet' THEN 'intern_verrechnet'
+        WHEN stat.kurzbez IN ('ausbezahlt', 'erledigt LW', 'übernommen ARP', 'Archiv') THEN 'ausbezahlt'
+        ELSE 'in_bearbeitung'
     END AS status_abrechnung,
     CASE
         WHEN datum_auszahlung = '9999-01-01' THEN NULL

--- a/arp_mjpnl_migration/mjpnl_postprocessing_abrechnung_per_vereinbarung.sql
+++ b/arp_mjpnl_migration/mjpnl_postprocessing_abrechnung_per_vereinbarung.sql
@@ -1,18 +1,27 @@
 /* Zusammenzug Zahlungen per Vereinbarung und Datum der Auszahlung */
 
 INSERT INTO ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_vereinbarung 
-  (t_basket, vereinbarungs_nr, flurnamen, gemeinde, flaeche, gesamtbetrag,
-   auszahlungsjahr, status_abrechnung, datum_abrechnung, abrechnungperbewirtschafter, vereinbarung, migriert)
+  (t_basket, vereinbarungs_nr, gelan_bewe_id, gb_nr, flurnamen, gemeinde, flaeche, anzahl_baeume, betrag_flaeche, betrag_baeume, betrag_pauschal, gesamtbetrag,
+   auszahlungsjahr, status_abrechnung, datum_abrechnung, bewirtschaftabmachung_schnittzeitpunkt_1, bewirtschaftabmachung_messerbalkenmaehgeraet, bewirtschaftabmachung_herbstweide,abrechnungperbewirtschafter, vereinbarung, migriert)
 SELECT
   (SELECT t_id FROM ${DB_Schema_MJPNL}.t_ili2db_basket WHERE t_ili_tid = 'SO_ARP_MJPNL_20201026.MJPNL' LIMIT 1) AS t_basket,
   vbg.vereinbarungs_nr,
+  vbg.gelan_bewe_id,
+  vbg.gb_nr, --should be in future: array_to_string(vbg.gb_nr,', ') AS gb_nr,
   array_to_string(vbg.flurname,', ') AS flurnamen,
   array_to_string(vbg.gemeinde,', ') AS gemeinde,
   vbg.flaeche,
-  SUM(lstg.betrag_total) AS gesamtbetrag,
+  COALESCE(SUM(lstg_stueck.anzahl_einheiten),0) AS anzahl_baeume,
+  COALESCE(SUM(lstg_ha.betrag_total),0) AS betrag_flaeche,
+  COALESCE(SUM(lstg_stueck.betrag_total),0) AS betrag_baeume,
+  COALESCE(SUM(lstg_pauschal.betrag_total),0) AS betrag_pauschal,
+  COALESCE(SUM(lstg.betrag_total),0) AS gesamtbetrag,
   lstg.auszahlungsjahr,
   lstg.status_abrechnung,
   lstg.datum_abrechnung,
+  bw.bewirtschaftabmachung_schnittzeitpunkt_1,
+  COALESCE(bw.bewirtschaftabmachung_messerbalkenmaehgeraet, FALSE) as bewirtschaftabmachung_messerbalkenmaehgeraet,
+  COALESCE(bw.bewirtschaftabmachung_herbstweide, FALSE) as bewirtschaftabmachung_herbstweide,
   9999999 AS abrechnungperbewirtschafter,
   vbg.t_id AS vereinbarung,
   TRUE AS migriert
@@ -20,11 +29,20 @@ FROM
   ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_leistung lstg
   LEFT JOIN ${DB_Schema_MJPNL}.mjpnl_vereinbarung vbg
      ON lstg.vereinbarung = vbg.t_id
+  LEFT JOIN ${DB_Schema_MJPNL}.mjpnl_beurteilung_wiese bw
+     ON lstg.vereinbarung = bw.vereinbarung
+  LEFT JOIN ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_leistung lstg_stueck
+     ON lstg_stueck.t_id = lstg.t_id AND lstg_stueck.abgeltungsart = 'per_stueck'
+  LEFT JOIN ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_leistung lstg_ha
+     ON lstg_ha.t_id = lstg.t_id AND lstg_ha.abgeltungsart = 'per_ha'
+  LEFT JOIN ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_leistung lstg_pauschal
+     ON lstg_pauschal.t_id = lstg.t_id AND lstg_pauschal.abgeltungsart = 'pauschal'
   WHERE
     lstg.vereinbarung != 9999999
     AND vbg.t_id IS NOT NULL
-  GROUP BY vbg.t_id, vbg.vereinbarungs_nr, vbg.flurname, vbg.gemeinde, vbg.flaeche,
-           lstg.auszahlungsjahr, lstg.status_abrechnung, lstg.datum_abrechnung
+  GROUP BY vbg.t_id, vbg.vereinbarungs_nr, vbg.gelan_bewe_id, vbg.gb_nr, vbg.flurname, vbg.gemeinde, vbg.flaeche,
+           lstg.auszahlungsjahr, lstg.status_abrechnung, lstg.datum_abrechnung, 
+           bw.bewirtschaftabmachung_schnittzeitpunkt_1, bw.bewirtschaftabmachung_messerbalkenmaehgeraet, bw.bewirtschaftabmachung_herbstweide
   ORDER BY  vbg.vereinbarungs_nr, lstg.datum_abrechnung ASC
   ;
   

--- a/arp_mjpnl_migration/mjpnl_postprocessing_abrechnung_per_vereinbarung.sql
+++ b/arp_mjpnl_migration/mjpnl_postprocessing_abrechnung_per_vereinbarung.sql
@@ -29,6 +29,7 @@ FROM
   ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_leistung lstg
   LEFT JOIN ${DB_Schema_MJPNL}.mjpnl_vereinbarung vbg
      ON lstg.vereinbarung = vbg.t_id
+  -- technically there could be multiple beurteilungen, but in this migration case it's only one. And only for wiese (no entries in wbl_wiese).
   LEFT JOIN ${DB_Schema_MJPNL}.mjpnl_beurteilung_wiese bw
      ON lstg.vereinbarung = bw.vereinbarung
   LEFT JOIN ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_leistung lstg_stueck

--- a/arp_mjpnl_migration/mjpnl_vereinbarung.sql
+++ b/arp_mjpnl_migration/mjpnl_vereinbarung.sql
@@ -59,6 +59,10 @@ SELECT
   FALSE AS soemmerungsgebiet, --im Postprocessing zu ersetzen
   'MJPNL_2020' AS mjpnl_version,
   4::integer AS kontrollintervall,
+  CASE
+    WHEN  vbg.vbnr IN ( '12.388', '23.304' ) THEN TRUE -- nur Wallierhof (Schloss Wartenfels und AWJF haben keine relevanten Vereinbarungen)                      
+    ELSE FALSE
+  END AS kantonsintern,
   replace(
       COALESCE(vbg.notiz,'') || E'\n§\n' ||
       '{\n"vbart_vereinbarung_alt":"' || COALESCE(vbartvb.bez,'NULL') || '",\n' ||

--- a/arp_mjpnl_migration/mjpnl_vereinbarung.sql
+++ b/arp_mjpnl_migration/mjpnl_vereinbarung.sql
@@ -59,6 +59,7 @@ SELECT
   FALSE AS soemmerungsgebiet, --im Postprocessing zu ersetzen
   'MJPNL_2020' AS mjpnl_version,
   4::integer AS kontrollintervall,
+  NULL AS ablaufdatum,
   CASE
     WHEN  vbg.vbnr IN ( '12.388', '23.304' ) THEN TRUE -- nur Wallierhof (Schloss Wartenfels und AWJF haben keine relevanten Vereinbarungen)                      
     ELSE FALSE


### PR DESCRIPTION
### Mapping der `kurzbez` zu `abrechnung_per_leistung.status_abrechnung`

| stat.kurzbez | status_abrechnung|
|---|---|
| in Bearbeitung    | in_bearbeitung               | 
| freigegeben       | freigegeben                  | 
| ausbezahlt        | ausbezahlt                   | 
| ~fehlerhaft~      | *ist nicht vorhanden im Datensatz und wird ignoriert*      | 
| erledigt LW       | ausbezahlt                   | 
| Intern verrechnet | intern_verrechnet            | 
| ~Archiv~          | *ist nicht vorhanden im Datensatz und wird ignoriert*      | 
| ausbezahlt        | ausbezahlt                   | 
| übernommen ARP    | ausbezahlt                   | 

### Setzen von `abrechnung_per_leistung.einmalig`

`TRUE` wenn:
- das datum_auszahlung von diesem Jahr (2023) ist (was bedeutet es ist bereits ausbezahlt)
- die Kurzbezeichnung der Art von einem von diesem ist: 'Korrektur Vorjahr', 'Unterhaltsbeitrag', 'Pflanzmaterial', 'Kürzung', 'Saatgut'
- die Bezeichnung der Art 'Pauschale einmalig (ha)' oder 'Pauschale einmalig (p)' ist

### Kantonsinterne Vereinbarungen (`vereinbarung.kantonsintern`)

Markieren anhand davon, ob sie Vereinbarungen vom Wallierhof sind.

### Metainformationen in `abrechnung_per_vereinbarung`

- [x] GELAN_BewE_ID (string)
- [ ] GB_Nr (array) -> wird in followup angepasst
- [x] Anzahl_Baeume
- [x] Betrag_Flaeche
- [x] Betrag_Baeume (falls obl/hostet)
- [x] Betrag_Pauschal
- [x] BewirtschaftAbmachung_Schnittzeitpunkt_1 (falls wiese)
- [x] BewirtschaftAbmachung_MesserbalkenMaehgeraet (falls wiese)
- [x] BewirtschaftAbmachung_Herbstweide (falls wiese)

### Befristete Verträge (`vereinbarung.ablaufdatum`)

- [ ] Ablaufdatum -> wird in followup behandelt

### Abhängig von 
https://github.com/sogis/sogis-interlis-repository/pull/61