### PR TITLE
[arp_mjpnl_migration] Zusammenzug der Leistungen

### DIFF
--- a/arp_mjpnl_migration/mjpnl_postprocessing_abrechnung_per_bewirtschafter.sql
+++ b/arp_mjpnl_migration/mjpnl_postprocessing_abrechnung_per_bewirtschafter.sql
@@ -29,13 +29,22 @@ SELECT
    pers.ortschaft AS gelan_ortschaft,
    pers.iban,
    SUM(abrg_vbg.gesamtbetrag) AS betrag_total,
-   MIN(abrg_vbg.status_abrechnung) AS status_abrechnung,
-   MAX(abrg_vbg.datum_abrechnung) AS datum_abrechnung,
+   -- wenn es eine status_abrechnung "freigegeben" gibt, dann soll der status "freigegeben" sein
+   CASE WHEN (SELECT COUNT(*) FROM ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_vereinbarung v WHERE v.status_abrechnung = 'freigegeben' AND v.gelan_pid_gelan = pers.pid_gelan) > 0 
+     THEN 'freigegeben' 
+     -- ansonsten ist es für alle gleich ("ausbezahlt" oder "intern_verrechnet")
+     ELSE MAX(v.status_abrechnung) 
+   END AS status_abrechnung,
+   -- wenn es eine status_abrechnung "freigegeben" gibt, dann soll es noch kein datum_abrechnung haben
+   CASE WHEN (SELECT COUNT(*) FROM ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_vereinbarung v WHERE v.status_abrechnung = 'freigegeben' AND v.gelan_pid_gelan = pers.pid_gelan) > 0 
+     THEN NULL
+     -- ansonsten kann es das späteste datum nehmen
+     ELSE MAX(v.datum_abrechnung) 
+   END AS datum_abrechnung,
    abrg_vbg.auszahlungsjahr,
    'Migration' AS dateipfad_oder_url,
    COALESCE ( MAX(abrg_vbg.datum_abrechnung), now()::date ) AS erstellungsdatum,
    'Migration' AS operator_erstellung,
-   -- auch wenn diese Info redundant ist, bleibt es hilfreich um die migrierten Abrechnungen einheitlich filtern zu können
    TRUE AS migriert
 FROM
   gelan_persons pers
@@ -43,9 +52,11 @@ FROM
      ON pers.pid_gelan = vbg.gelan_pid_gelan
   LEFT JOIN ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_vereinbarung abrg_vbg
      ON vbg.vereinbarungs_nr = abrg_vbg.vereinbarungs_nr
-  WHERE abrg_vbg.gesamtbetrag IS NOT NULL AND abrg_vbg.auszahlungsjahr IS NOT NULL
-  GROUP BY pers.pid_gelan, pers.iban, pers.name_vorname, pers.ortschaft, abrg_vbg.auszahlungsjahr, abrg_vbg.status_abrechnung
-  ORDER BY pers.pid_gelan ASC, abrg_vbg.auszahlungsjahr ASC
+  WHERE 
+    abrg_vbg.gesamtbetrag IS NOT NULL 
+    AND abrg_vbg.auszahlungsjahr IS NOT NULL
+  GROUP BY pers.pid_gelan, pers.iban, pers.name_vorname, pers.ortschaft, abrg_vbg.auszahlungsjahr
+  ORDER BY pers.pid_gelan ASC
 ;
 
 /* Abrechnung per Vereinbarung aktualisieren mit Fremdschlüsseln zur Abrechnung per Bewirtschafter */


### PR DESCRIPTION
Berücksichtige die nicht-eindeutigen Status, wenn eine der Kind-Elemente "freigegeben" hat, ist der parent auch "freigegeben" und ansonsten sollten sich Status nicht unterscheiden (sind alle ausbezahlt oder alle intern_verrechnet).

- Hat eine Vereinbarung 3 Leistungen (eine `freigegeben` und zwei `ausbezahlt`), dann hat die `abrechnung_per_vereinbarung` den Status `freigegeben`.
- Hat eine Vereinbarung 3 Leistungen (alle `ausbezahlt`), dann hat die `abrechnung_per_vereinbarung` den Status `ausbezahlt`.
- Hat ein Bewirtschafter 3 Vereinbarungen (eine `freigegeben` und zwei `ausbezahlt`), dann hat die `abrechnung_per_bewirtschafter` den Status `freigegeben`.

Das heisst es werden auch die bereits ausbezahlten Leistungen berücksichtigt, auch wenn sie nicht "sichtbar" sind. Beispiel mit `abrechnung_per_bewirtschafter`:
Angenommen es gibt ein Bewirtschater mit nur solchen Vereinbarungen, die nur ausbezahlte Leistungen haben (was vermutlich nie der Fall ist, aber anyway), dann würde ein Eintrag geschrieben mit dem Status 'ausbezahlt' und mit dem Total 0. Diesen braucht es, dass überhaupt ein Brief gemacht wird (und auch zur Analyse über QGIS und Relation Editor etc.)
