### PR TITLE
[arp_mjpnl_migration] Fixes

### DIFF
--- a/arp_mjpnl_migration/mjpnl_postprocessing_abrechnung_per_bewirtschafter.sql
+++ b/arp_mjpnl_migration/mjpnl_postprocessing_abrechnung_per_bewirtschafter.sql
@@ -30,13 +30,13 @@ SELECT
    pers.iban,
    SUM(abrg_vbg.gesamtbetrag) AS betrag_total,
    -- wenn es eine status_abrechnung "freigegeben" gibt, dann soll der status "freigegeben" sein
-   CASE WHEN (SELECT COUNT(*) FROM ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_vereinbarung v WHERE v.status_abrechnung = 'freigegeben' AND v.gelan_pid_gelan = pers.pid_gelan) > 0 
+   CASE WHEN (SELECT COUNT(*) FROM ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_vereinbarung v WHERE v.status_abrechnung = 'freigegeben' AND v.gelan_pid_gelan = pers.pid_gelan AND v.auszahlungsjahr = abrg_vbg.auszahlungsjahr) > 0 
      THEN 'freigegeben' 
      -- ansonsten ist es für alle gleich ("ausbezahlt" oder "intern_verrechnet")
      ELSE MAX(abrg_vbg.status_abrechnung) 
    END AS status_abrechnung,
    -- wenn es eine status_abrechnung "freigegeben" gibt, dann soll es noch kein datum_abrechnung haben
-   CASE WHEN (SELECT COUNT(*) FROM ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_vereinbarung v WHERE v.status_abrechnung = 'freigegeben' AND v.gelan_pid_gelan = pers.pid_gelan) > 0 
+   CASE WHEN (SELECT COUNT(*) FROM ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_vereinbarung v WHERE v.status_abrechnung = 'freigegeben' AND v.gelan_pid_gelan = pers.pid_gelan AND v.auszahlungsjahr = abrg_vbg.auszahlungsjahr) > 0 
      THEN NULL
      -- ansonsten kann es das späteste datum nehmen
      ELSE MAX(abrg_vbg.datum_abrechnung) 

--- a/arp_mjpnl_migration/mjpnl_postprocessing_abrechnung_per_bewirtschafter.sql
+++ b/arp_mjpnl_migration/mjpnl_postprocessing_abrechnung_per_bewirtschafter.sql
@@ -29,14 +29,19 @@ SELECT
    pers.ortschaft AS gelan_ortschaft,
    pers.iban,
    SUM(abrg_vbg.gesamtbetrag) AS betrag_total,
-   -- wenn es eine status_abrechnung "freigegeben" gibt, dann soll der status "freigegeben" sein
-   CASE WHEN (SELECT COUNT(*) FROM ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_vereinbarung v WHERE v.status_abrechnung = 'freigegeben' AND v.gelan_pid_gelan = pers.pid_gelan AND v.auszahlungsjahr = abrg_vbg.auszahlungsjahr) > 0 
+   -- wenn es ein status_abrechnung "in_bearbeitung" oder wenn nicht dann "freigegeben" gibt, dann soll der status demensprechend gleich sein
+   CASE 
+     WHEN (SELECT COUNT(*) FROM ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_vereinbarung v WHERE v.status_abrechnung = 'in_bearbeitung' AND v.gelan_pid_gelan = pers.pid_gelan AND v.auszahlungsjahr = abrg_vbg.auszahlungsjahr) > 0 
+     THEN 'in_bearbeitung' 
+     WHEN (SELECT COUNT(*) FROM ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_vereinbarung v WHERE v.status_abrechnung = 'freigegeben' AND v.gelan_pid_gelan = pers.pid_gelan AND v.auszahlungsjahr = abrg_vbg.auszahlungsjahr) > 0 
      THEN 'freigegeben' 
      -- ansonsten ist es für alle gleich ("ausbezahlt" oder "intern_verrechnet")
      ELSE MAX(abrg_vbg.status_abrechnung) 
    END AS status_abrechnung,
-   -- wenn es eine status_abrechnung "freigegeben" gibt, dann soll es noch kein datum_abrechnung haben
-   CASE WHEN (SELECT COUNT(*) FROM ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_vereinbarung v WHERE v.status_abrechnung = 'freigegeben' AND v.gelan_pid_gelan = pers.pid_gelan AND v.auszahlungsjahr = abrg_vbg.auszahlungsjahr) > 0 
+   -- wenn es eine status_abrechnung "freigegeben" oder "in_bearbeitung" gibt, dann soll es noch kein datum_abrechnung haben
+   CASE 
+     WHEN (SELECT COUNT(*) FROM ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_vereinbarung v WHERE v.status_abrechnung = 'in_bearbeitung' AND v.gelan_pid_gelan = pers.pid_gelan AND v.auszahlungsjahr = abrg_vbg.auszahlungsjahr) > 0 
+     OR (SELECT COUNT(*) FROM ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_vereinbarung v WHERE v.status_abrechnung = 'freigegeben' AND v.gelan_pid_gelan = pers.pid_gelan AND v.auszahlungsjahr = abrg_vbg.auszahlungsjahr) > 0 
      THEN NULL
      -- ansonsten kann es das späteste datum nehmen
      ELSE MAX(abrg_vbg.datum_abrechnung) 

--- a/arp_mjpnl_migration/mjpnl_postprocessing_abrechnung_per_vereinbarung.sql
+++ b/arp_mjpnl_migration/mjpnl_postprocessing_abrechnung_per_vereinbarung.sql
@@ -21,13 +21,13 @@ SELECT
   COALESCE(SUM(lstg.betrag_total),0) AS gesamtbetrag,
   lstg.auszahlungsjahr,
   -- wenn es ein status_abrechnung "freigegeben" gibt, dann soll der status "freigegeben" sein
-  CASE WHEN (SELECT COUNT(*) FROM ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_leistung l WHERE l.status_abrechnung = 'freigegeben' AND l.vereinbarung = vbg.t_id) > 0 
+  CASE WHEN (SELECT COUNT(*) FROM ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_leistung l WHERE l.status_abrechnung = 'freigegeben' AND l.vereinbarung = vbg.t_id AND l.auszahlungsjahr = lstg.auszahlungsjahr) > 0 
    THEN 'freigegeben' 
    -- ansonsten ist es für alle gleich ("ausbezahlt" oder "intern_verrechnet")
    ELSE MAX(lstg.status_abrechnung) 
   END AS status_abrechnung,
   -- wenn es ein status_abrechnung "freigegeben" gibt, dann soll es noch kein datum_abrechnung haben
-  CASE WHEN (SELECT COUNT(*) FROM ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_leistung l WHERE l.status_abrechnung = 'freigegeben' AND l.vereinbarung = vbg.t_id) > 0 
+  CASE WHEN (SELECT COUNT(*) FROM ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_leistung l WHERE l.status_abrechnung = 'freigegeben' AND l.vereinbarung = vbg.t_id AND l.auszahlungsjahr = lstg.auszahlungsjahr) > 0 
    THEN NULL
    -- ansonsten kann es das späteste datum nehmen
    ELSE MAX(lstg.datum_abrechnung) 

--- a/arp_mjpnl_migration/mjpnl_postprocessing_abrechnung_per_vereinbarung.sql
+++ b/arp_mjpnl_migration/mjpnl_postprocessing_abrechnung_per_vereinbarung.sql
@@ -20,14 +20,19 @@ SELECT
   COALESCE(SUM(lstg_pauschal_einmalig_freigeg.betrag_total),0) AS betrag_pauschal_einmalig_freigegeben,
   COALESCE(SUM(lstg.betrag_total),0) AS gesamtbetrag,
   lstg.auszahlungsjahr,
-  -- wenn es ein status_abrechnung "freigegeben" gibt, dann soll der status "freigegeben" sein
-  CASE WHEN (SELECT COUNT(*) FROM ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_leistung l WHERE l.status_abrechnung = 'freigegeben' AND l.vereinbarung = vbg.t_id AND l.auszahlungsjahr = lstg.auszahlungsjahr) > 0 
+  -- wenn es ein status_abrechnung "in_bearbeitung" oder wenn nicht dann "freigegeben" gibt, dann soll der status demensprechend gleich sein
+  CASE 
+   WHEN (SELECT COUNT(*) FROM ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_leistung l WHERE l.status_abrechnung = 'in_bearbeitung' AND l.vereinbarung = vbg.t_id AND l.auszahlungsjahr = lstg.auszahlungsjahr) > 0 
+   THEN 'in_bearbeitung' 
+   WHEN (SELECT COUNT(*) FROM ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_leistung l WHERE l.status_abrechnung = 'freigegeben' AND l.vereinbarung = vbg.t_id AND l.auszahlungsjahr = lstg.auszahlungsjahr) > 0 
    THEN 'freigegeben' 
    -- ansonsten ist es für alle gleich ("ausbezahlt" oder "intern_verrechnet")
    ELSE MAX(lstg.status_abrechnung) 
   END AS status_abrechnung,
-  -- wenn es ein status_abrechnung "freigegeben" gibt, dann soll es noch kein datum_abrechnung haben
-  CASE WHEN (SELECT COUNT(*) FROM ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_leistung l WHERE l.status_abrechnung = 'freigegeben' AND l.vereinbarung = vbg.t_id AND l.auszahlungsjahr = lstg.auszahlungsjahr) > 0 
+  -- wenn es ein status_abrechnung "in_bearbeitung" oder "freigegeben" gibt, dann soll es noch kein datum_abrechnung haben
+  CASE 
+   WHEN (SELECT COUNT(*) FROM ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_leistung l WHERE l.status_abrechnung = 'freigegeben' AND l.vereinbarung = vbg.t_id AND l.auszahlungsjahr = lstg.auszahlungsjahr) > 0 
+   OR (SELECT COUNT(*) FROM ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_leistung l WHERE l.status_abrechnung = 'in_bearbeitung' AND l.vereinbarung = vbg.t_id AND l.auszahlungsjahr = lstg.auszahlungsjahr) > 0 
    THEN NULL
    -- ansonsten kann es das späteste datum nehmen
    ELSE MAX(lstg.datum_abrechnung) 
@@ -60,8 +65,8 @@ FROM
      ON lstg_pauschal_einmalig_freigeg.t_id = lstg.t_id AND lstg_pauschal_einmalig_freigeg.abgeltungsart = 'pauschal' AND lstg_pauschal_einmalig_freigeg.einmalig IS TRUE AND lstg_pauschal_einmalig_freigeg.status_abrechnung = 'freigegeben'
   WHERE
     vbg.t_id IS NOT NULL
-    -- berücksichtige nur relevante status
-    AND lstg.status_abrechnung NOT IN ('in_bearbeitung', 'abgeltungslos')
+    -- berücksichtige nur relevante status (in_bearbeitung wird berücksichtigt, aber der Status wird übernommen)
+    AND lstg.status_abrechnung != 'abgeltungslos'
     AND lstg.vereinbarung != 9999999
   GROUP BY vbg.t_id, vbg.vereinbarungs_nr, vbg.gelan_bewe_id, vbg.gb_nr, vbg.flurname, vbg.gemeinde, vbg.flaeche,
            lstg.auszahlungsjahr, bw.bewirtschaftabmachung_schnittzeitpunkt_1, bw.bewirtschaftabmachung_messerbalkenmaehgeraet, bw.bewirtschaftabmachung_herbstweide

--- a/arp_mjpnl_zahlungslauf/calc_mjpnl_abrechnung_per_bewirtschafter.sql
+++ b/arp_mjpnl_zahlungslauf/calc_mjpnl_abrechnung_per_bewirtschafter.sql
@@ -30,14 +30,19 @@ SELECT
    pers.ortschaft AS gelan_ortschaft,
    pers.iban,
    SUM(abrg_vbg.gesamtbetrag) AS betrag_total,
-   -- wenn es eine status_abrechnung "freigegeben" gibt, dann soll der status "freigegeben" sein
-   CASE WHEN (SELECT COUNT(*) FROM ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_vereinbarung v WHERE v.status_abrechnung = 'freigegeben' AND v.gelan_pid_gelan = pers.pid_gelan AND v.auszahlungsjahr = abrg_vbg.auszahlungsjahr) > 0 
+   -- wenn es ein status_abrechnung "in_bearbeitung" oder wenn nicht dann "freigegeben" gibt, dann soll der status demensprechend gleich sein
+   CASE 
+     WHEN (SELECT COUNT(*) FROM ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_vereinbarung v WHERE v.status_abrechnung = 'in_bearbeitung' AND v.gelan_pid_gelan = pers.pid_gelan AND v.auszahlungsjahr = abrg_vbg.auszahlungsjahr) > 0 
+     THEN 'in_bearbeitung' 
+     WHEN (SELECT COUNT(*) FROM ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_vereinbarung v WHERE v.status_abrechnung = 'freigegeben' AND v.gelan_pid_gelan = pers.pid_gelan AND v.auszahlungsjahr = abrg_vbg.auszahlungsjahr) > 0 
      THEN 'freigegeben' 
      -- ansonsten ist es für alle gleich ("ausbezahlt" oder "intern_verrechnet")
      ELSE MAX(abrg_vbg.status_abrechnung) 
    END AS status_abrechnung,
-   -- wenn es eine status_abrechnung "freigegeben" gibt, dann soll es noch kein datum_abrechnung haben
-   CASE WHEN (SELECT COUNT(*) FROM ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_vereinbarung v WHERE v.status_abrechnung = 'freigegeben' AND v.gelan_pid_gelan = pers.pid_gelan AND v.auszahlungsjahr = abrg_vbg.auszahlungsjahr) > 0 
+   -- wenn es eine status_abrechnung "freigegeben" oder "in_bearbeitung" gibt, dann soll es noch kein datum_abrechnung haben
+   CASE 
+     WHEN (SELECT COUNT(*) FROM ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_vereinbarung v WHERE v.status_abrechnung = 'freigegeben' AND v.gelan_pid_gelan = pers.pid_gelan AND v.auszahlungsjahr = abrg_vbg.auszahlungsjahr) > 0 
+     OR (SELECT COUNT(*) FROM ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_vereinbarung v WHERE v.status_abrechnung = 'freigegeben' AND v.gelan_pid_gelan = pers.pid_gelan AND v.auszahlungsjahr = abrg_vbg.auszahlungsjahr) > 0 
      THEN NULL
      -- ansonsten kann es das späteste datum nehmen
      ELSE MAX(abrg_vbg.datum_abrechnung) 

--- a/arp_mjpnl_zahlungslauf/calc_mjpnl_abrechnung_per_bewirtschafter.sql
+++ b/arp_mjpnl_zahlungslauf/calc_mjpnl_abrechnung_per_bewirtschafter.sql
@@ -31,13 +31,13 @@ SELECT
    pers.iban,
    SUM(abrg_vbg.gesamtbetrag) AS betrag_total,
    -- wenn es eine status_abrechnung "freigegeben" gibt, dann soll der status "freigegeben" sein
-   CASE WHEN (SELECT COUNT(*) FROM ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_vereinbarung v WHERE v.status_abrechnung = 'freigegeben' AND v.gelan_pid_gelan = pers.pid_gelan) > 0 
+   CASE WHEN (SELECT COUNT(*) FROM ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_vereinbarung v WHERE v.status_abrechnung = 'freigegeben' AND v.gelan_pid_gelan = pers.pid_gelan AND v.auszahlungsjahr = abrg_vbg.auszahlungsjahr) > 0 
      THEN 'freigegeben' 
      -- ansonsten ist es für alle gleich ("ausbezahlt" oder "intern_verrechnet")
      ELSE MAX(abrg_vbg.status_abrechnung) 
    END AS status_abrechnung,
    -- wenn es eine status_abrechnung "freigegeben" gibt, dann soll es noch kein datum_abrechnung haben
-   CASE WHEN (SELECT COUNT(*) FROM ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_vereinbarung v WHERE v.status_abrechnung = 'freigegeben' AND v.gelan_pid_gelan = pers.pid_gelan) > 0 
+   CASE WHEN (SELECT COUNT(*) FROM ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_vereinbarung v WHERE v.status_abrechnung = 'freigegeben' AND v.gelan_pid_gelan = pers.pid_gelan AND v.auszahlungsjahr = abrg_vbg.auszahlungsjahr) > 0 
      THEN NULL
      -- ansonsten kann es das späteste datum nehmen
      ELSE MAX(abrg_vbg.datum_abrechnung) 

--- a/arp_mjpnl_zahlungslauf/calc_mjpnl_abrechnung_per_vereinbarung.sql
+++ b/arp_mjpnl_zahlungslauf/calc_mjpnl_abrechnung_per_vereinbarung.sql
@@ -27,13 +27,13 @@ SELECT
   COALESCE(SUM(lstg.betrag_total),0) AS gesamtbetrag,
   lstg.auszahlungsjahr,
   -- wenn es ein status_abrechnung "freigegeben" gibt, dann soll der status "freigegeben" sein
-  CASE WHEN (SELECT COUNT(*) FROM ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_leistung l WHERE l.status_abrechnung = 'freigegeben' AND l.vereinbarung = vbg.t_id) > 0 
+  CASE WHEN (SELECT COUNT(*) FROM ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_leistung l WHERE l.status_abrechnung = 'freigegeben' AND l.vereinbarung = vbg.t_id AND l.auszahlungsjahr = lstg.auszahlungsjahr) > 0 
    THEN 'freigegeben' 
    -- ansonsten ist es für alle gleich ("ausbezahlt" oder "intern_verrechnet")
    ELSE MAX(lstg.status_abrechnung) 
   END AS status_abrechnung,
   -- wenn es ein status_abrechnung "freigegeben" gibt, dann soll es noch kein datum_abrechnung haben
-  CASE WHEN (SELECT COUNT(*) FROM ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_leistung l WHERE l.status_abrechnung = 'freigegeben' AND l.vereinbarung = vbg.t_id) > 0 
+  CASE WHEN (SELECT COUNT(*) FROM ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_leistung l WHERE l.status_abrechnung = 'freigegeben' AND l.vereinbarung = vbg.t_id AND l.auszahlungsjahr = lstg.auszahlungsjahr) > 0 
    THEN NULL
    -- ansonsten kann es das späteste datum nehmen
    ELSE MAX(lstg.datum_abrechnung) 

--- a/arp_mjpnl_zahlungslauf/calc_mjpnl_abrechnung_per_vereinbarung.sql
+++ b/arp_mjpnl_zahlungslauf/calc_mjpnl_abrechnung_per_vereinbarung.sql
@@ -26,14 +26,19 @@ SELECT
   COALESCE(SUM(lstg_pauschal_einmalig_freigeg.betrag_total),0) AS betrag_pauschal_einmalig_freigegeben,
   COALESCE(SUM(lstg.betrag_total),0) AS gesamtbetrag,
   lstg.auszahlungsjahr,
-  -- wenn es ein status_abrechnung "freigegeben" gibt, dann soll der status "freigegeben" sein
-  CASE WHEN (SELECT COUNT(*) FROM ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_leistung l WHERE l.status_abrechnung = 'freigegeben' AND l.vereinbarung = vbg.t_id AND l.auszahlungsjahr = lstg.auszahlungsjahr) > 0 
+  -- wenn es ein status_abrechnung "in_bearbeitung" oder wenn nicht dann "freigegeben" gibt, dann soll der status demensprechend gleich sein
+  CASE 
+   WHEN (SELECT COUNT(*) FROM ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_leistung l WHERE l.status_abrechnung = 'in_bearbeitung' AND l.vereinbarung = vbg.t_id AND l.auszahlungsjahr = lstg.auszahlungsjahr) > 0 
+   THEN 'in_bearbeitung' 
+   WHEN (SELECT COUNT(*) FROM ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_leistung l WHERE l.status_abrechnung = 'freigegeben' AND l.vereinbarung = vbg.t_id AND l.auszahlungsjahr = lstg.auszahlungsjahr) > 0 
    THEN 'freigegeben' 
    -- ansonsten ist es für alle gleich ("ausbezahlt" oder "intern_verrechnet")
    ELSE MAX(lstg.status_abrechnung) 
   END AS status_abrechnung,
-  -- wenn es ein status_abrechnung "freigegeben" gibt, dann soll es noch kein datum_abrechnung haben
-  CASE WHEN (SELECT COUNT(*) FROM ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_leistung l WHERE l.status_abrechnung = 'freigegeben' AND l.vereinbarung = vbg.t_id AND l.auszahlungsjahr = lstg.auszahlungsjahr) > 0 
+  -- wenn es ein status_abrechnung "in_bearbeitung" oder "freigegeben" gibt, dann soll es noch kein datum_abrechnung haben
+  CASE 
+   WHEN (SELECT COUNT(*) FROM ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_leistung l WHERE l.status_abrechnung = 'freigegeben' AND l.vereinbarung = vbg.t_id AND l.auszahlungsjahr = lstg.auszahlungsjahr) > 0 
+   OR (SELECT COUNT(*) FROM ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_leistung l WHERE l.status_abrechnung = 'freigegeben' AND l.vereinbarung = vbg.t_id AND l.auszahlungsjahr = lstg.auszahlungsjahr) > 0 
    THEN NULL
    -- ansonsten kann es das späteste datum nehmen
    ELSE MAX(lstg.datum_abrechnung) 
@@ -66,8 +71,8 @@ FROM
      ON lstg_pauschal_einmalig_freigeg.t_id = lstg.t_id AND lstg_pauschal_einmalig_freigeg.abgeltungsart = 'pauschal' AND lstg_pauschal_einmalig_freigeg.einmalig IS TRUE AND lstg_pauschal_einmalig_freigeg.status_abrechnung = 'freigegeben'
   WHERE
     vbg.t_id IS NOT NULL
-    -- berücksichtige nur relevante status
-    AND lstg.status_abrechnung NOT IN ('in_bearbeitung', 'abgeltungslos')
+    -- berücksichtige nur relevante status (in_bearbeitung wird berücksichtigt, aber der Status wird übernommen)
+    AND lstg.status_abrechnung != 'abgeltungslos'
     -- berücksichtige nur diesjährige Leistungen
     AND lstg.auszahlungsjahr = ${AUSZAHLUNGSJAHR}::integer
   GROUP BY vbg.t_id, vbg.vereinbarungs_nr, vbg.gelan_bewe_id, vbg.gb_nr, vbg.flurname, vbg.gemeinde, vbg.flaeche,


### PR DESCRIPTION
- Fix Status für Abrechnung per Bewirtschafter und per Vereinbarung bei Vor-Jahren (vorher waren alle auf freigegeben, sofern es 2023er mit freigegeben hatte)
- Berücksichtigen der Leistungen die "in_bearbeitung" sind in Abrechnung_per_Bewirtschafter und Abrechnung_per_Vereinbarung allerdings den Status auch demensprechen setzen. Es muss dann sichergestellt werden, dass es vor Zahlung kein "in_bearbeitung" gibt. Aufbauenda auf #1494
