### PR TITLE
Use sftpUrlSogis instead of sftpServerSogis variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ git checkout -b branchname
   * `ftpServerWaldportal`, `ftpUserWaldportal`, `ftpPwdWaldportal`
   * `ftpServerZivilschutz`, `ftpUserZivilschutz`, `ftpPwdZivilschutz`
   * `sftpServerGelan`, `sftpUserGelan`, `sftpPwdGelan`
-  * `sftpServerSogis`, `sftpUserSogis`, `sftpPwdSogis`
+  * `sftpUrlSogis`, `sftpUserSogis`, `sftpPwdSogis`
   * für Datentransfer Gemdat: `host = sftpServerSogis`, `user = sftpUserSogisGemdat`, `identity = file('/home/gradle/.sshkeys/id_rsa')`
   * `aiServer`, `aiUser`, `aiPwd`
   * `infofloraUser`, `infofloraPwd`

--- a/ada_archaeologie_pub/build.gradle
+++ b/ada_archaeologie_pub/build.gradle
@@ -100,7 +100,7 @@ task publishPub(type: Publisher, dependsOn: 'setEnumTxt') {
     modelsToPublish = "SO_ADA_Archaeologie_Publikation_20230417"
     userFormats = true
     validationConfig = "validation.toml"
-    target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+    target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
     kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
     kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]
     grooming = new File(file(projectDir).getParentFile(), "publisher_grooming.json")

--- a/afu_abbaustellen_pub/build.gradle
+++ b/afu_abbaustellen_pub/build.gradle
@@ -17,7 +17,7 @@ task publiedit(type: Publisher){
   dbSchema = "afu_abbaustellen_v1"
   modelsToPublish = "SO_AFU_ABBAUSTELLEN_20210630"
 
-  target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+  target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
   kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
   kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]
   grooming = new File(file(projectDir).getParentFile(), "publisher_grooming.json")
@@ -74,7 +74,7 @@ task publipub(type: Publisher, dependsOn:'writeToPub'){
   dbSchema = "afu_abbaustellen_pub_v2"
   modelsToPublish = "SO_AFU_ABBAUSTELLEN_Publikation_20221103"
 
-  target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+  target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
   kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
   kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]
   grooming = new File(file(projectDir).getParentFile(), "publisher_grooming.json")

--- a/afu_ara_einzugsgebiete_pub/build.gradle
+++ b/afu_ara_einzugsgebiete_pub/build.gradle
@@ -16,7 +16,7 @@ task publishEdit(type: Publisher) {
     // Damit stehen sie v.a. uns als XTF zur Verfügung. Müsste mit AfU
     // abgesprochen werden, ob sie "richtig" öffentlich gemacht werden 
     // sollen.
-    target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+    target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
     //target = ["/tmp/gretl-share"]
     //kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
     //kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]
@@ -43,7 +43,7 @@ task publishPub(type: Publisher, dependsOn: 'transferData') {
     // Damit stehen sie v.a. uns als XTF zur Verfügung. Müsste mit AfU
     // abgesprochen werden, ob sie "richtig" öffentlich gemacht werden 
     // sollen.
-    target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+    target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
     //kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
     //kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]
     grooming = new File(file(projectDir).getParentFile(), "publisher_grooming.json")

--- a/afu_baugrundklassen_pub/build.gradle
+++ b/afu_baugrundklassen_pub/build.gradle
@@ -12,7 +12,7 @@ task publishEdit(type: Publisher){
     dataIdent = "ch.so.afu.baugrundklassen.relational"
     dbSchema = "afu_baugrundklassen_v1"
     modelsToPublish = "SO_AFU_Baugrundklassen_20201023"
-    target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+    target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
     kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
     kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]
     grooming = new File(file(projectDir).getParentFile(), "publisher_grooming.json")
@@ -33,7 +33,7 @@ task publishPub(type: Publisher, dependsOn: 'transferAfuBaugrundklassenPub'){
     dbSchema = "afu_baugrundklassen_pub_v1"
     modelsToPublish = "SO_AFU_Baugrundklassen_Publikation_20201023"
     userFormats = true
-    target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+    target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
     kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
     kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]
     grooming = new File(file(projectDir).getParentFile(), "publisher_grooming.json")

--- a/afu_ekat_2005_pub/build.gradle
+++ b/afu_ekat_2005_pub/build.gradle
@@ -11,7 +11,7 @@ task publishPub(type: Publisher){
     dbSchema = "afu_ekat2005_pub_v1"
     modelsToPublish = "SO_AFU_Ekat_Publikation_20190222"
     userFormats = true
-    target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+    target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
     kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
     kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]
     grooming = new File(file(projectDir).getParentFile(), "publisher_grooming.json")

--- a/afu_ekat_2010_pub/build.gradle
+++ b/afu_ekat_2010_pub/build.gradle
@@ -11,7 +11,7 @@ task publishPub(type: Publisher){
     dbSchema = "afu_ekat2010_pub_v1"
     modelsToPublish = "SO_AFU_Ekat_Publikation_20190222"
     userFormats = true
-    target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+    target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
     kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
     kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]
     grooming = new File(file(projectDir).getParentFile(), "publisher_grooming.json")

--- a/afu_ekat_2015_pub/build.gradle
+++ b/afu_ekat_2015_pub/build.gradle
@@ -11,7 +11,7 @@ task publishPub(type: Publisher){
     dbSchema = "afu_ekat2015_pub"
     modelsToPublish = "SO_AFU_Ekat_Publikation_20190222"
     userFormats = true
-    target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+    target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
     kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
     kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]
     grooming = new File(file(projectDir).getParentFile(), "publisher_grooming.json")

--- a/afu_gefahrenkartierung_pub_export_ai/build.gradle
+++ b/afu_gefahrenkartierung_pub_export_ai/build.gradle
@@ -56,7 +56,7 @@ task publishPub(type: Publisher, dependsOn: 'pubGefkart'){
     dbSchema = "afu_gefahrenkartierung_pub"
     modelsToPublish = "SO_AfU_Gefahrenkartierung_20181129"
     userFormats = true
-    target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+    target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
     kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
     kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]
     grooming = new File(file(projectDir).getParentFile(), "publisher_grooming.json")

--- a/afu_geologie_pub/build.gradle
+++ b/afu_geologie_pub/build.gradle
@@ -25,7 +25,7 @@ task publishPub(type: Publisher, dependsOn: 'transferAfuGeologiePub'){
     dbSchema = "afu_geologie_pub_v1"
     modelsToPublish = "SO_AFU_Geologie_20200831"
     userFormats = true
-    target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+    target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
     kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
     kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]
     grooming = new File(file(projectDir).getParentFile(), "publisher_grooming.json")

--- a/afu_gewaesser_gewaessereigenschaften_pub/build.gradle
+++ b/afu_gewaesser_gewaessereigenschaften_pub/build.gradle
@@ -30,7 +30,7 @@ task publishPub(type: Publisher, dependsOn:refreshSolr){
     dbSchema = "afu_gewaesser_gewaessereigenschaften_pub_v1"
     modelsToPublish = "SO_AFU_Gewaesser_Gewaessereigenschaften_Publikation_20220427"
     userFormats = true
-    target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+    target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
     kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
     kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]
     grooming = new File(file(projectDir).getParentFile(), "publisher_grooming.json")

--- a/afu_gewaesser_oekomorphologie_pub/build.gradle
+++ b/afu_gewaesser_oekomorphologie_pub/build.gradle
@@ -64,7 +64,7 @@ task publishPub(type: Publisher, dependsOn:updateEnumTxtCols){
     dbSchema = "afu_gewaesser_oekomorphologie_pub_v1"
     modelsToPublish = "SO_AFU_Gewaesser_Oekomorphologie_Publikation_20220426"
     userFormats = true
-    target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+    target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
     kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
     kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]
     grooming = new File(file(projectDir).getParentFile(), "publisher_grooming.json")

--- a/afu_gewaesser_revitalisierung_pub/build.gradle
+++ b/afu_gewaesser_revitalisierung_pub/build.gradle
@@ -11,7 +11,7 @@ task publishEdit(type: Publisher){
     dataIdent = "ch.so.afu.fliessgewaesser.revitalisierung.relational"
     dbSchema = "afu_gewaesser_revitalisierung_v1"
     modelsToPublish = "SO_AFU_Gewaesser_Revitalisierung_20220629"
-    target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+    target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
     kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
     kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]
     grooming = new File(file(projectDir).getParentFile(), "publisher_grooming.json")
@@ -36,7 +36,7 @@ task publishPub(type: Publisher, dependsOn:transferData){
     dbSchema = "afu_gewaesser_revitalisierung_pub_v1"
     modelsToPublish = "SO_AFU_Gewaesser_Revitalisierung_20220629"
 	userFormats = true
-    target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+    target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
     kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
     kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]
     grooming = new File(file(projectDir).getParentFile(), "publisher_grooming.json")

--- a/afu_gewaesserschutz_bereiche_pub/build.gradle
+++ b/afu_gewaesserschutz_bereiche_pub/build.gradle
@@ -66,7 +66,7 @@ task publishPub(type: Publisher, dependsOn: 'zipXtf') {
     dbSchema = "afu_gewaesserschutz_pub_v1"
     modelsToPublish = "SO_AfU_Gewaesserschutz_Publikation_20220817"
     userFormats = true
-    target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+    target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
     kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
     kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]
     grooming = new File(file(projectDir).getParentFile(), "publisher_grooming.json")

--- a/afu_gewaesserschutz_zonen_areale_pub/build.gradle
+++ b/afu_gewaesserschutz_zonen_areale_pub/build.gradle
@@ -81,7 +81,7 @@ task publishPub(type: Publisher, dependsOn: 'transferGewaesserschutz_pub'){
     dbSchema = "afu_gewaesserschutz_pub_v1"
     modelsToPublish = "SO_AfU_Gewaesserschutz_Publikation_20220817"
     userFormats = true
-    target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+    target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
     kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
     kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]
     grooming = new File(file(projectDir).getParentFile(), "publisher_grooming.json")

--- a/afu_hydro_messstationen_pub/build.gradle
+++ b/afu_hydro_messstationen_pub/build.gradle
@@ -10,7 +10,7 @@ task publishEdit(type: Publisher){
     dataIdent = "ch.so.afu.hydrometrie.messstationen.relational"
     dbSchema = "afu_hydro_messstationen_v1"
     modelsToPublish = "SO_AFU_Hydro_Messstationen_20220706"
-    target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+    target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
     kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
     kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]
     grooming = new File(file(projectDir).getParentFile(), "publisher_grooming.json")
@@ -37,7 +37,7 @@ task publishPub(type: Publisher, dependsOn:updateTypTxt){
     dbSchema = "afu_hydro_messstationen_pub_v1"
     modelsToPublish = "SO_AFU_Hydro_Messstationen_Publikation_20220707"
 	userFormats = true
-    target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+    target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
     kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
     kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]
     grooming = new File(file(projectDir).getParentFile(), "publisher_grooming.json")

--- a/agi_av_dm01_mopublic_pub/0_dm01_so/build.gradle
+++ b/agi_av_dm01_mopublic_pub/0_dm01_so/build.gradle
@@ -75,7 +75,7 @@ task publish(type: Publisher, dependsOn:unzipFiles){
     region = '.*'
     sourcePath = new File(dm01SoDir, 'dummy.itf')
     //target = [file("$buildDir/published")]
-    target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+    target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
     if (findProperty('ilivalidatorModeldir')) modeldir = ilivalidatorModeldir
     kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
     kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]

--- a/agi_av_dm01_mopublic_pub/1_dm01_ch/build.gradle
+++ b/agi_av_dm01_mopublic_pub/1_dm01_ch/build.gradle
@@ -22,7 +22,7 @@ task publish(type: Publisher, dependsOn: createFederalFiles){
     sourcePath = new File(dm01ChDir, 'dummy.itf')
     if (findProperty('ilivalidatorModeldir')) modeldir = ilivalidatorModeldir
     validationConfig = "$projectDir/../novalidation.toml"
-    target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+    target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
     //target = [file("$buildDir/published")]
     kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
     kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]

--- a/agi_av_dm01_mopublic_pub/2_mopublic/build.gradle
+++ b/agi_av_dm01_mopublic_pub/2_mopublic/build.gradle
@@ -52,7 +52,7 @@ task publish(type: Publisher, dependsOn: refreshSolr){
     regions = project(':0_dm01_so').tasks.publish.publishedRegions
     userFormats = true
     //target = [file("$buildDir/published")]
-    target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+    target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
     if (findProperty('ilivalidatorModeldir')) modeldir = ilivalidatorModeldir
     validationConfig = "$projectDir/../novalidation.toml"
     kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]

--- a/agi_av_gb_administrative_einteilungen_pub/build.gradle
+++ b/agi_av_gb_administrative_einteilungen_pub/build.gradle
@@ -19,7 +19,7 @@ task publipub(type: Publisher, dependsOn:'transferAvGbAdminEinteilungen'){
   dbSchema = "agi_av_gb_admin_einteilung_pub"
   modelsToPublish = "SO_AGI_AV_GB_Administrative_Einteilungen_Publikation_20180822"
 
-  target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+  target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
   kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
   kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]
   grooming = new File(file(projectDir).getParentFile(), "publisher_grooming.json")

--- a/agi_hoheitsgrenzen_pub/build.gradle
+++ b/agi_hoheitsgrenzen_pub/build.gradle
@@ -89,7 +89,7 @@ task publishPub(type: Publisher, dependsOn:'refreshSolr'){
     dbSchema = "agi_hoheitsgrenzen_pub"
     modelsToPublish = "SO_Hoheitsgrenzen_Publikation_20170626"
     userFormats = true
-    target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+    target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
     kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
     kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]
     grooming = new File(file(projectDir).getParentFile(), "publisher_grooming.json")

--- a/agi_inventar_hoheitsgrenzen_pub/build.gradle
+++ b/agi_inventar_hoheitsgrenzen_pub/build.gradle
@@ -9,7 +9,7 @@ task publiedit(type: Publisher){
   dbSchema = "agi_inventar_hoheitsgrenzen"
   modelsToPublish = "SO_AGI_Inventar_Hoheitsgrenzen_20191129"
 
-  target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+  target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
   kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
   kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]
   grooming = new File(file(projectDir).getParentFile(), "publisher_grooming.json")
@@ -32,7 +32,7 @@ task publipub(type: Publisher, dependsOn:'transferAgiKantonsgrenzsteine'){
   dbSchema = "agi_inventar_hoheitsgrenzen_pub"
   modelsToPublish = "SO_AGI_Inventar_Hoheitsgrenzen_Publikation_20191129"
 
-  target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+  target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
   kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
   kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]
   grooming = new File(file(projectDir).getParentFile(), "publisher_grooming.json")

--- a/agi_polizeiregionen_pub/build.gradle
+++ b/agi_polizeiregionen_pub/build.gradle
@@ -26,7 +26,7 @@ task publipub(type: Publisher, dependsOn: 'transferAgiPolizeiregionen'){
   dbSchema = "agi_polizeiregionen_pub_v1"
   modelsToPublish = "SO_AGI_Polizeiregionen_20221010"
 
-  target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+  target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
   kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
   kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]
   grooming = new File(file(projectDir).getParentFile(), "publisher_grooming.json")

--- a/ags_religionsgemeinschaften_pub/build.gradle
+++ b/ags_religionsgemeinschaften_pub/build.gradle
@@ -9,7 +9,7 @@ task publiedit(type: Publisher){
   dbSchema = "ags_religionsgemeinschaften_v1"
   modelsToPublish = "SO_AGS_Religionsgemeinschaften_20220422"
 
-  target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+  target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
   kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
   kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]
   grooming = new File(file(projectDir).getParentFile(), "publisher_grooming.json")
@@ -31,7 +31,7 @@ task publipub(type: Publisher, dependsOn:'transferAgsReligionsgemeinschaften'){
   dbSchema = "ags_religionsgemeinschaften_pub_v1"
   modelsToPublish = "SO_AGS_Religionsgemeinschaften_Publikation_20220427"
 
-  target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+  target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
   kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
   kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]
   grooming = new File(file(projectDir).getParentFile(), "publisher_grooming.json")

--- a/alw_fruchtfolgeflaechen_pub/build.gradle
+++ b/alw_fruchtfolgeflaechen_pub/build.gradle
@@ -58,7 +58,7 @@ task publipub(type: Publisher, dependsOn:'statistik_to_pub_db'){
   dbSchema = "alw_fruchtfolgeflaechen_pub_v1"
   modelsToPublish = "SO_ALW_Fruchtfolgeflaechen_Publikation_20220110"
   
-  target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+  target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
   kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
   kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]
   grooming = new File(file(projectDir).getParentFile(), "publisher_grooming.json")

--- a/alw_strukturverbesserungen_pub/build.gradle
+++ b/alw_strukturverbesserungen_pub/build.gradle
@@ -11,7 +11,7 @@ task publiedit(type: Publisher){
   dbSchema = "alw_strukturverbesserungen"
   modelsToPublish = "SO_ALW_Strukturverbesserungen_20190912"
 
-  target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+  target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
   kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
   kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]
   grooming = new File(file(projectDir).getParentFile(), "publisher_grooming.json")
@@ -37,7 +37,7 @@ task publipub(type: Publisher, dependsOn:'transfer_SVGIS'){
   dbSchema = "alw_strukturverbesserungen_pub"
   modelsToPublish = "SO_ALW_Strukturverbesserungen_Publikation_20190905"
 
-  target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+  target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
   kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
   kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]
   grooming = new File(file(projectDir).getParentFile(), "publisher_grooming.json")

--- a/alw_tiergesundheit_massnahmen_pub/build.gradle
+++ b/alw_tiergesundheit_massnahmen_pub/build.gradle
@@ -19,7 +19,7 @@ task publishPub(type: Publisher, dependsOn: 'transferTiergesundheitMassnahmen'){
     dbSchema = "alw_tiergesundheit_massnahmen_pub"
     modelsToPublish = "SO_ALW_Tiergesundheit_Massnahmen_20210426"
     userFormats = true
-    target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+    target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
     kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
     kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]
     grooming = new File(file(projectDir).getParentFile(), "publisher_grooming.json")

--- a/amb_notfalltreffpunkte_pub/build.gradle
+++ b/amb_notfalltreffpunkte_pub/build.gradle
@@ -11,7 +11,7 @@ task publiedit(type: Publisher){
   dbSchema = "amb_notfalltreffpunkte"
   modelsToPublish = "SO_AMB_Notfalltreffpunkte_20180413"
 
-  target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+  target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
   kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
   kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]
   grooming = new File(file(projectDir).getParentFile(), "publisher_grooming.json")
@@ -33,7 +33,7 @@ task publipub(type: Publisher, dependsOn:'transferAmbNotfalltreffpunkte'){
   dbSchema = "amb_notfalltreffpunkte_pub"
   modelsToPublish = "SO_AMB_Notfalltreffpunkte_Publikation_20180822"
 
-  target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+  target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
   kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
   kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]
   grooming = new File(file(projectDir).getParentFile(), "publisher_grooming.json")

--- a/amb_regionale_fuehrungsstaebe_pub/build.gradle
+++ b/amb_regionale_fuehrungsstaebe_pub/build.gradle
@@ -22,7 +22,7 @@ task publipub(type: Publisher, dependsOn: 'transferRFS'){
   dbSchema = "amb_regionale_fuehrungsstaebe_pub_v1"
   modelsToPublish = "SO_AMB_Regionale_Fuehrungsstaebe_20230706"
 
-  target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+  target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
   kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
   kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]
   grooming = new File(file(projectDir).getParentFile(), "publisher_grooming.json")

--- a/arp_agglomerationsprogramme_pub/build.gradle
+++ b/arp_agglomerationsprogramme_pub/build.gradle
@@ -11,7 +11,7 @@ task publiedit(type: Publisher){
   dbSchema = "arp_agglomerationsprogramme"
   modelsToPublish = "SO_Agglomerationsprogramme_20200618"
 
-  target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+  target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
   kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
   kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]
   grooming = new File(file(projectDir).getParentFile(), "publisher_grooming.json")
@@ -42,7 +42,7 @@ task publipub(type: Publisher, dependsOn:'transferArpAggloprogramme'){
   dbSchema = "arp_agglomerationsprogramme_pub"
   modelsToPublish = "SO_Agglomerationsprogramme_Publikation_20200813"
 
-  target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+  target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
   kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
   kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]
   grooming = new File(file(projectDir).getParentFile(), "publisher_grooming.json")

--- a/arp_bauzonengrenzen_pub/build.gradle
+++ b/arp_bauzonengrenzen_pub/build.gradle
@@ -41,7 +41,7 @@ task publishPub(type: Publisher, dependsOn:'createAllData') {
     // Damit stehen sie v.a. uns als XTF zur Verfügung. Müsste mit ARP
     // abgesprochen werden, ob sie "richtig" öffentlich gemacht werden 
     // sollen.
-    target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+    target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
     //target = ["/tmp/gretl-share"]
     //kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
     //kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]
@@ -52,5 +52,5 @@ task publishPub(type: Publisher, dependsOn:'createAllData') {
 tasks.register('publishMetaFile', MetaPublisher) {
     dependsOn 'publishPub'
     metaConfigFile = file("meta.toml")
-    target =  ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+    target =  [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
 }

--- a/arp_nutzungsplanung_kanton_pub/build.gradle
+++ b/arp_nutzungsplanung_kanton_pub/build.gradle
@@ -57,7 +57,7 @@ task publishEdit(type: Publisher, dependsOn: validateDataEdit){
     modelsToPublish = 'SO_ARP_Nutzungsplanung_Nachfuehrung_20221118'
     sourcePath = file("kanton/kanton.xtf")
     if (findProperty('ilivalidatorModeldir')) modeldir = ilivalidatorModeldir
-    target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+    target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
     kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
     kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]
     grooming = new File(file(rootDir).getParentFile(), "publisher_grooming.json")
@@ -120,7 +120,7 @@ task publishPub(type: Publisher, dependsOn: importXTF_pub){
     userFormats = true
     sourcePath = file("kanton_pub/kanton_pub.xtf")
     if (findProperty('ilivalidatorModeldir')) modeldir = ilivalidatorModeldir
-    target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+    target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
     kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
     kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]
     grooming = new File(file(rootDir).getParentFile(), "publisher_grooming.json")
@@ -154,7 +154,7 @@ task publishAlt(type: Publisher, dependsOn: exportDataExport){
     modelsToPublish = 'SO_Nutzungsplanung_20171118'
     sourcePath = file("kanton_alt/kanton_modell_2017.xtf")
     if (findProperty('ilivalidatorModeldir')) modeldir = ilivalidatorModeldir
-    target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+    target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
     kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
     kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]
     grooming = new File(file(rootDir).getParentFile(), "publisher_grooming.json")

--- a/arp_richtplan_pub/build.gradle
+++ b/arp_richtplan_pub/build.gradle
@@ -23,7 +23,7 @@ task publiedit(type: Publisher, dependsOn: 'transferArpRichtplanPubSogis'){
   dbSchema = "arp_richtplan_v1"
   modelsToPublish = "SO_ARP_Richtplan_20220630"
 
-  target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+  target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
   kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
   kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]
   grooming = new File(file(projectDir).getParentFile(), "publisher_grooming.json")
@@ -66,7 +66,7 @@ task publipub(type: Publisher){
   dbSchema = "arp_richtplan_pub_v1"
   modelsToPublish = "SO_ARP_Richtplan_Publikation_20220630"
 
-  target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+  target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
   kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
   kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]
   grooming = new File(file(projectDir).getParentFile(), "publisher_grooming.json")

--- a/avt_gesamtverkehrsmodell2015_pub/build.gradle
+++ b/avt_gesamtverkehrsmodell2015_pub/build.gradle
@@ -12,7 +12,7 @@ task publishedit(type: Publisher){
   database = [dbUriEdit,dbUserEdit,dbPwdEdit]
   dbSchema = "avt_gesamtverkehrsmodell_2015_v1"
   modelsToPublish = "SO_AVT_Gesamtverkehrsmodell_2015_20220729"
-  target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+  target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
   kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
   kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]
   grooming = new File(file(projectDir).getParentFile(), "publisher_grooming.json")

--- a/avt_groblaermkataster_pub/build.gradle
+++ b/avt_groblaermkataster_pub/build.gradle
@@ -27,7 +27,7 @@ task publishPub(type: Publisher, dependsOn:replaceDataset){
     dbSchema = "avt_groblaermkataster_pub"
     modelsToPublish = "SO_AVT_Groblaermkataster_20190709"
     userFormats = true
-    target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+    target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
     kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
     kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]
     grooming = new File(file(projectDir).getParentFile(), "publisher_grooming.json")

--- a/avt_kantonsstrassen_pub/build.gradle
+++ b/avt_kantonsstrassen_pub/build.gradle
@@ -43,7 +43,7 @@ task publipub(type: Publisher, dependsOn: 'importPunkte'){
     dbSchema = "avt_kantonsstrassen_pub"
     modelsToPublish = "SO_AVT_Kantonsstrassen_Publikation_20200707"
 
-    target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+    target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
     kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
     kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]
     grooming = new File(file(projectDir).getParentFile(), "publisher_grooming.json")

--- a/avt_kunstbauten_pub/build.gradle
+++ b/avt_kunstbauten_pub/build.gradle
@@ -35,7 +35,7 @@ task publishPub(type: Publisher, dependsOn: writeToPub){
     dbSchema = "avt_kunstbauten_pub_v1"
     modelsToPublish = "SO_AVT_Kunstbauten_Publikation_20220207"
     userFormats = true
-    target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+    target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
     kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
     kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]
     grooming = new File(file(projectDir).getParentFile(), "publisher_grooming.json")

--- a/avt_oeffentlicher_verkehr_pub/build.gradle
+++ b/avt_oeffentlicher_verkehr_pub/build.gradle
@@ -19,7 +19,7 @@ task publishPub(type: Publisher, dependsOn: 'transferAvtOeffentlicherVerkehrPub'
     dbSchema = "avt_oeffentlicher_verkehr_pub"
     modelsToPublish = "SO_AVT_Oeffentlicher_Verkehr_20210205"
     userFormats = true
-    target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+    target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
     kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
     kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]
     grooming = new File(file(projectDir).getParentFile(), "publisher_grooming.json")

--- a/avt_oev_gueteklassen_import/build.gradle
+++ b/avt_oev_gueteklassen_import/build.gradle
@@ -40,7 +40,7 @@ task publipub(type: Publisher, dependsOn: import_to_pub){
     dbSchema = "avt_oev_gueteklassen_pub_v1"
     modelsToPublish = "SO_AVT_Oev_Gueteklassen_20220120"
 
-    target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+    target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
     kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
     kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]
     grooming = new File(file(projectDir).getParentFile(), "publisher_grooming.json")

--- a/avt_strassenlaerm/build.gradle
+++ b/avt_strassenlaerm/build.gradle
@@ -43,7 +43,7 @@ task publishEdit(type: Publisher, dependsOn: replaceDataset){
     dataIdent = "ch.so.avt.strassenlaerm.relational"
     dbSchema = "avt_strassenlaerm_v1"
     dataset = "data"
-    target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+    target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
     kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
     kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]
     grooming = new File(file(projectDir).getParentFile(), "publisher_grooming.json")
@@ -64,7 +64,7 @@ task publishPub(type: Publisher, dependsOn:transferData){
     dbSchema = "avt_strassenlaerm_pub_v1"
     modelsToPublish = "SO_AVT_Strassenlaerm_Publikation_20190802"
     userFormats = true
-    target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+    target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
     kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
     kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]
     grooming = new File(file(projectDir).getParentFile(), "publisher_grooming.json")

--- a/avt_verkehrszaehlstellen_pub/build.gradle
+++ b/avt_verkehrszaehlstellen_pub/build.gradle
@@ -11,7 +11,7 @@ task publiedit(type: Publisher){
     dbSchema = "avt_verkehrszaehlstellen"
     modelsToPublish = "SO_AVT_Verkehrszaehlstellen_20190206"
 
-    target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+    target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
     kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
     kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]
     grooming = new File(file(projectDir).getParentFile(), "publisher_grooming.json")
@@ -35,7 +35,7 @@ task publipub(type: Publisher, dependsOn: 'transferAvtVerkehrszaehlstellen'){
     dbSchema = "avt_verkehrszaehlstellen_pub"
     modelsToPublish = "SO_AVT_Verkehrszaehlstellen_Publikation_20190206"
 
-    target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+    target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
     kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
     kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]
     grooming = new File(file(projectDir).getParentFile(), "publisher_grooming.json")

--- a/awa_stromversorgungssicherheit_netzgebiete_pub/build.gradle
+++ b/awa_stromversorgungssicherheit_netzgebiete_pub/build.gradle
@@ -30,7 +30,7 @@ task publipub(type: Publisher, dependsOn:'transferNetzgebiete'){
   dbSchema = "awa_stromversorgungssicherheit_pub"
   modelsToPublish = "SO_AWA_Stromversorgungssicherheit_Publikation_20210629"
 
-  target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+  target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
   kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
   kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]
   grooming = new File(file(projectDir).getParentFile(), "publisher_grooming.json")

--- a/awjf_forstreviere_pub/build.gradle
+++ b/awjf_forstreviere_pub/build.gradle
@@ -11,7 +11,7 @@ task publiedit(type: Publisher){
     dbSchema = "awjf_forstreviere"
     modelsToPublish = "SO_Forstreviere_20170512"
 
-    target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+    target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
     kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
     kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]
     grooming = new File(file(projectDir).getParentFile(), "publisher_grooming.json")
@@ -37,7 +37,7 @@ task publipub(type: Publisher, dependsOn: 'transferAwjfForstreviere'){
     dbSchema = "awjf_forstreviere_pub"
     modelsToPublish = "SO_Forstreviere_Publikation_20170428"
 
-    target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+    target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
     kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
     kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]
     grooming = new File(file(projectDir).getParentFile(), "publisher_grooming.json")

--- a/awjf_gewaesser_fischerei_pub/build.gradle
+++ b/awjf_gewaesser_fischerei_pub/build.gradle
@@ -23,7 +23,7 @@ task publishPub(type: Publisher, dependsOn: 'refreshSolr'){
     dbSchema = "awjf_gewaesser_fischerei_pub_v1"
     modelsToPublish = "SO_AWJF_Gewaesser_Fischerei_Publikation_20220429"
     userFormats = true
-    target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+    target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
     kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
     kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]
     grooming = new File(file(projectDir).getParentFile(), "publisher_grooming.json")

--- a/awjf_jagdreviere_jagdbanngebiete_pub/build.gradle
+++ b/awjf_jagdreviere_jagdbanngebiete_pub/build.gradle
@@ -10,7 +10,7 @@ task publishEdit(type: Publisher){
     dataIdent = "ch.so.awjf.jagdreviere.relational"
     dbSchema = "awjf_jagdreviere_jagdbanngebiete_v1"
     modelsToPublish = "SO_AWJF_Jagdreviere_Jagdbanngebiete_202000804"
-    target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+    target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
     kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
     kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]
     grooming = new File(file(projectDir).getParentFile(), "publisher_grooming.json")
@@ -35,7 +35,7 @@ task publishPub(type: Publisher, dependsOn:transferAwjfJagd){
     dbSchema = "awjf_jagdreviere_jagdbanngebiete_pub_v1"
     modelsToPublish = "SO_AWJF_Jagdreviere_Jagdbanngebiete_Publikation_202000804"
     userFormats = true
-    target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+    target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
     kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
     kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]
     grooming = new File(file(projectDir).getParentFile(), "publisher_grooming.json")

--- a/awjf_naturgefahrenhinweiskarte_pub/build.gradle
+++ b/awjf_naturgefahrenhinweiskarte_pub/build.gradle
@@ -10,7 +10,7 @@ task publiedit(type: Publisher){
   dataIdent = "ch.so.awjf.naturgefahrenhinweiskarte.relational"
   dbSchema = "awjf_naturgefahrenhinweiskarte_v1"
   modelsToPublish = "SO_AWJF_Naturgefahrenhinweiskarte_20220125"
-  target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+  target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
   kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
   kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]
   grooming = new File(file(projectDir).getParentFile(), "publisher_grooming.json")
@@ -40,7 +40,7 @@ task publishPub(type: Publisher, dependsOn: 'transferAwjfNaturgefahrenhinweiskar
     dbSchema = "awjf_naturgefahrenhinweiskarte_pub_v1"
     modelsToPublish = "SO_AWJF_Naturgefahrenhinweiskarte_Publikation_20220125"
     userFormats = true
-    target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+    target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
     kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
     kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]
     grooming = new File(file(projectDir).getParentFile(), "publisher_grooming.json")

--- a/awjf_seltene_baeume_pub/build.gradle
+++ b/awjf_seltene_baeume_pub/build.gradle
@@ -11,7 +11,7 @@ task publiedit(type: Publisher){
     dbSchema = "awjf_seltene_baeume"
     modelsToPublish = "SO_AWJF_Seltene_Baumarten_20190211"
 
-    target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+    target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
     kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
     kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]
     grooming = new File(file(projectDir).getParentFile(), "publisher_grooming.json")
@@ -35,7 +35,7 @@ task publipub(type: Publisher, dependsOn: 'transferAwjfSelteneBaeume'){
     dbSchema = "awjf_seltene_baeume_pub"
     modelsToPublish = "SO_AWJF_Seltene_Baumarten_Publikation_20191015"
 
-    target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+    target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
     kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
     kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]
     grooming = new File(file(projectDir).getParentFile(), "publisher_grooming.json")

--- a/awjf_statische_waldgrenze_pub/build.gradle
+++ b/awjf_statische_waldgrenze_pub/build.gradle
@@ -28,7 +28,7 @@ task publiedit(type: Publisher){
   dataIdent = "ch.so.awjf.statische_waldgrenze.relational"
   dbSchema = "awjf_statische_waldgrenze"
   modelsToPublish = "SO_AWJF_Statische_Waldgrenzen_20191119"
-  target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+  target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
   kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
   kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]
   grooming = new File(file(projectDir).getParentFile(), "publisher_grooming.json")
@@ -99,7 +99,7 @@ task publishPub(type: Publisher, dependsOn: 'importXTF_pub'){
     dbSchema = "awjf_statische_waldgrenze_pub_v1"
     modelsToPublish = "SO_AWJF_Statische_Waldgrenzen_Publikation_20191119"
     userFormats = true
-    target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+    target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
     kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
     kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]
     grooming = new File(file(projectDir).getParentFile(), "publisher_grooming.json")

--- a/awjf_wald_pub/build.gradle
+++ b/awjf_wald_pub/build.gradle
@@ -11,7 +11,7 @@ task publishEdit(type: Publisher) {
     dataIdent = "ch.so.awjf.waldstandorte.relational"
     dbSchema = "awjf_waldstandorte_v1"
     modelsToPublish = "SO_AWJF_Waldstandorte_20211027"
-    target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+    target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
     kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
     kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]
     grooming = new File(file(projectDir).getParentFile(), "publisher_grooming.json")
@@ -33,7 +33,7 @@ task publipubOberhoehenbonitaet(type: Publisher, dependsOn: 'transferAwjfEdit') 
     database = [dbUriPub,dbUserPub,dbPwdPub]
     dbSchema = "awjf_wald_oberhoehenbonitaet_pub_v1"
     modelsToPublish = "SO_AWJF_Wald_Oberhoehenbonitaet_20211027"
-    target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+    target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
     kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
     kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]
     grooming = new File(file(projectDir).getParentFile(), "publisher_grooming.json")
@@ -46,7 +46,7 @@ task publishPub(type: Publisher, dependsOn: 'publipubOberhoehenbonitaet') {
     dbSchema = "awjf_waldstandorte_pub_v1"
     modelsToPublish = "SO_AWJF_Waldstandorte_Publikation_20211027"
     userFormats = true
-    target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+    target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
     kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
     kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]
     grooming = new File(file(projectDir).getParentFile(), "publisher_grooming.json")

--- a/awjf_waldpflege_kontrolle_pub/build.gradle
+++ b/awjf_waldpflege_kontrolle_pub/build.gradle
@@ -43,7 +43,7 @@ task publipub(type: Publisher, dependsOn: 'deleteFromWaldpflegeKontrolle'){
   dbSchema = "awjf_waldpflege_kontrolle_pub"
   modelsToPublish = "SO_AWJF_Waldpflege_Kontrolle_20210202"
 
-  target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+  target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
   kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
   kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]
   grooming = new File(file(projectDir).getParentFile(), "publisher_grooming.json")

--- a/awjf_waldplan_bestandeskarte_pub/build.gradle
+++ b/awjf_waldplan_bestandeskarte_pub/build.gradle
@@ -33,7 +33,7 @@ task publishPub(type: Publisher, dependsOn: 'refreshSolr') {
     modelsToPublish = "SO_AWJF_Waldplan_Bestandeskarte_Publikation_20230111"
 //     userFormats = true
     validationConfig = "novalidation.toml"
-    target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+    target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
     kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
     kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]
     grooming = new File(file(projectDir).getParentFile(), "publisher_grooming.json")

--- a/awjf_waldportal/build.gradle
+++ b/awjf_waldportal/build.gradle
@@ -71,7 +71,7 @@ task publish (type: Publisher, dependsOn: importWaldportal){
     modelsToPublish = 'SO_AWJF_Waldportal_20230719'
     userFormats = true
     if (findProperty('ilivalidatorModeldir')) modeldir = ilivalidatorModeldir
-    target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+    target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
     kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
     kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]
     grooming = new File(file(rootDir).getParentFile(), "publisher_grooming.json")

--- a/awjf_waldwanderwege_pub/build.gradle
+++ b/awjf_waldwanderwege_pub/build.gradle
@@ -11,7 +11,7 @@ task publishEdit (type: Publisher){
     dbSchema = "awjf_waldwanderwege"
     modelsToPublish = "SO_AWJF_Waldwanderwege_202000804"
     userFormats = true
-    target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+    target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
     kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
     kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]
     grooming = new File(file(projectDir).getParentFile(), "publisher_grooming.json")

--- a/awjf_wildtierkorridore_pub/build.gradle
+++ b/awjf_wildtierkorridore_pub/build.gradle
@@ -24,7 +24,7 @@ task publipub(type: Publisher, dependsOn:'transferAwjfWildtierkorridorePub'){
     dbSchema = "awjf_wildtierkorridore_pub_v1"
     modelsToPublish = "SO_AWJF_Wildtierkorridore_20210831"
 
-    target = ["sftp://$sftpServerSogis/$sftpUserSogis", sftpUserSogis, sftpPwdSogis]
+    target = [sftpUrlSogis, sftpUserSogis, sftpPwdSogis]
     kgdiService = [simiMetadataServiceUrl, simiMetadataServiceUser, simiMetadataServicePwd]
     kgdiTokenService = [simiTokenServiceUrl, simiTokenServiceUser, simiTokenServicePwd]
     grooming = new File(file(projectDir).getParentFile(), "publisher_grooming.json")


### PR DESCRIPTION
Dank dieser Änderung ist es künftig möglich, die Publisher-Tasks auch lokal auszuführen, indem man die Variable `sftpUrlSogis=build` setzt. So werden vom Publisher generierte Dateien in einen Unterordner `build` im Job-Ordner platziert.

Die Variable `sftpServerSogis` bleibt aber weiterhin bestehen, weil sie im Zusammenhang mit dem "Datentransfer Gemdat" verwendet wird/worden ist/werden wird.