### PR TITLE
[arp_nutzungsplanung_pub] im Modell 2017 …

### DIFF
--- a/arp_nutzungsplanung_kanton_pub/insert_arp_nutzungsplanung_export_kanton_20222208.sql
+++ b/arp_nutzungsplanung_kanton_pub/insert_arp_nutzungsplanung_export_kanton_20222208.sql
@@ -77,6 +77,8 @@ SELECT
     rechtsvorschrift
 FROM
     arp_nutzungsplanung_kanton_v1.rechtsvorschrften_dokument
+WHERE
+    rechtsstatus = 'inKraft' -- nur die inKraft sind, weil es aufgehobene Pläne gibt ohne Datum und bei Modell 2017 ist das Attribut "publiziertab" MANDATORY!
 ;
 
 --überlagernde Fläche

--- a/arp_nutzungsplanung_pub/insert_arp_nutzungsplanung_export_2017.sql
+++ b/arp_nutzungsplanung_pub/insert_arp_nutzungsplanung_export_2017.sql
@@ -25,7 +25,7 @@ FROM
     ON basket.dataset=dataset.t_id
 WHERE
     topic != 'SO_ARP_Nutzungsplanung_Nachfuehrung_20201005.Laermempfindlichkeitsstufen'
-AND
+    AND
     dataset.datasetname::int4 = ${bfsnr_param}
 ;
 
@@ -56,6 +56,8 @@ FROM
     arp_nutzungsplanung_v1.rechtsvorschrften_dokument
 WHERE
     t_datasetname::int4 = ${bfsnr_param}
+    AND
+    rechtsstatus = 'inKraft' -- nur die inKraft sind, weil es aufgehobene Pläne gibt ohne Datum und bei Modell 2017 ist das Attribut "publiziertab" MANDATORY!
 ;
 
 -- Grundnutzung


### PR DESCRIPTION
…werden nur noch die Dokumente in Kraft exportiert. Weil "publiziertab" in diesem Modell MANDATORY ist und aufgehobene Dokumente nicht immer ein Datum haben.