### PR TITLE
[arp_mjpnl_gelan_update] Update bewe_id mit Status "ungeprüft" und PID update

### DIFF
--- a/arp_mjpnl_gelan_update/build.gradle
+++ b/arp_mjpnl_gelan_update/build.gradle
@@ -13,7 +13,7 @@ import java.io.File
 apply plugin: 'ch.so.agi.gretl'
 apply plugin: 'org.hidetake.ssh'
 
-defaultTasks 'BetriebZuBFFFlaechenZuweisen'
+defaultTasks 'BewirtschafterZuVereinbarungZuweisen'
 
 def pathToTempFolder = System.getProperty("java.io.tmpdir")
 def DB_Schema_MJPNL = "arp_mjpnl_v1"
@@ -64,4 +64,18 @@ task BetriebZuBFFFlaechenZuweisen(type: SqlExecutor, dependsOn: GelanBezugsjahrB
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     sqlParameters = [DB_Schema_MJPNL:DB_Schema_MJPNL]
     sqlFiles = ['update_betrieb_bff2-flaechen.sql']
+}
+
+task BetriebZuVereinbarungZuweisen(type: SqlExecutor,dependsOn: BetriebZuBFFFlaechenZuweisen) {
+    description = "Spatial join von Vereinbarung zu GELAN Bewirtschaftungseinheit herstellen und bewe_id_geprueft invalidieren"
+    database = [dbUriEdit, dbUserEdit, dbPwdEdit]
+    sqlParameters = [DB_Schema_MJPNL:DB_Schema_MJPNL]
+    sqlFiles = ['mjpnl_update_vereinbarungen_gelan_bewirtschaftungseinheiten.sql']
+}
+
+task BewirtschafterZuVereinbarungZuweisen(type: SqlExecutor,dependsOn: BetriebZuVereinbarungZuweisen) {
+    description = "GELAN Bewirtschafter zuweisen sofern keine Übersteuerung aktiv"
+    database = [dbUriEdit, dbUserEdit, dbPwdEdit]
+    sqlParameters = [DB_Schema_MJPNL:DB_Schema_MJPNL]
+    sqlFiles = ['mjpnl_update_vereinbarungen_gelan_bewirtschafter.sql']
 }

--- a/arp_mjpnl_gelan_update/mjpnl_update_vereinbarungen_gelan_bewirtschafter.sql
+++ b/arp_mjpnl_gelan_update/mjpnl_update_vereinbarungen_gelan_bewirtschafter.sql
@@ -14,5 +14,5 @@ UPDATE
 		),9999999)
      )
  WHERE
-  vbg.gelan_pid_gelan = 9999999 AND vbg.gelan_bewe_id != '9999999'
+  vbg.uebersteuerung_bewirtschafter IS FALSE
 ;

--- a/arp_mjpnl_gelan_update/mjpnl_update_vereinbarungen_gelan_bewirtschaftungseinheiten.sql
+++ b/arp_mjpnl_gelan_update/mjpnl_update_vereinbarungen_gelan_bewirtschaftungseinheiten.sql
@@ -1,0 +1,30 @@
+--Setze zuerst von denen, die wechseln werden, den Status bewe_id_geprueft auf false
+UPDATE ${DB_Schema_MJPNL}.mjpnl_vereinbarung
+SET bewe_id_geprueft = false
+WHERE t_id IN (
+SELECT
+  vbg.t_id
+FROM
+	${DB_Schema_MJPNL}.mjpnl_vereinbarung AS vbg
+JOIN
+    ${DB_Schema_MJPNL}.betrbsdttrktrdten_bewirtschaftungseinheit bw
+  ON
+    ST_Within(ST_PointOnSurface(vbg.geometrie),bw.geometrie)
+WHERE 
+  vbg.gelan_bewe_id != bw.bewe_id
+);
+
+--GELAN Bewirtschaftungseinheit zuweisen
+UPDATE
+   ${DB_Schema_MJPNL}.mjpnl_vereinbarung AS vbg
+     SET gelan_bewe_id=(
+       COALESCE(
+        (SELECT
+         bw.bewe_id
+        FROM
+           ${DB_Schema_MJPNL}.betrbsdttrktrdten_bewirtschaftungseinheit bw
+         WHERE
+           ST_Within(ST_PointOnSurface(vbg.geometrie),bw.geometrie)
+        ),'9999999')
+     )
+;


### PR DESCRIPTION
Neu setzen aller bewe_ids in `vereinbarung` aufgrund von intersections mit Bewirtschatungsflaechen.

Falls sie geändert hat, setzen des `bewe_id_ungeprueft`. 

Zusätzliches update der `gelan_pid_gelan` (bewirtschafter), falls nicht übersteuert.