### PR TITLE
[arp_mjpnl_migration] Migriere Berater gemäss Bezirke

### DIFF
--- a/arp_mjpnl_migration/mjpnl_postprocessing_beurteilungen_hecke.sql
+++ b/arp_mjpnl_migration/mjpnl_postprocessing_beurteilungen_hecke.sql
@@ -128,7 +128,7 @@ SELECT
    0 AS abgeltung_total,
    now()::date AS erstellungsdatum,
    'Migration' AS operator_erstellung,
-   (SELECT t_id FROM ${DB_Schema_MJPNL}.mjpnl_berater WHERE aname = 'Bruggisser') AS berater,
+   (SELECT t_id FROM ${DB_Schema_MJPNL}.mjpnl_berater WHERE aname = 'Jäggi') AS berater,
    t_id AS vereinbarung
 FROM
   tmp

--- a/arp_mjpnl_migration/mjpnl_postprocessing_beurteilungen_hostet.sql
+++ b/arp_mjpnl_migration/mjpnl_postprocessing_beurteilungen_hostet.sql
@@ -38,7 +38,8 @@ WITH tmp AS (
         t_id,
         t_basket,
         vereinbarungs_nr,
-        (string_to_array(bemerkung,'§'))[2]::jsonb AS old_attr
+        (string_to_array(bemerkung,'§'))[2]::jsonb AS old_attr,
+        geometrie
     FROM ${DB_Schema_MJPNL}.mjpnl_vereinbarung
         WHERE vereinbarungsart = 'Hostet' AND vereinbarungs_nr != '01_DUMMY_00001'
 ),
@@ -99,7 +100,17 @@ SELECT
    0 AS abgeltung_total,
    now()::date AS erstellungsdatum,
    'Migration' AS operator_erstellung,
-   (SELECT t_id FROM ${DB_Schema_MJPNL}.mjpnl_berater WHERE aname = 'Bruggisser') AS berater,
+   (SELECT t_id FROM ${DB_Schema_MJPNL}.mjpnl_berater WHERE aname = 
+    (SELECT 
+        CASE 
+            WHEN b.bezirksname IN ('Dorneck') THEN 'Meier'
+            ELSE 'Gschwind-Holzherr'
+        END AS ermittelter_berater
+    FROM agi_hoheitsgrenzen_pub.hoheitsgrenzen_bezirksgrenze b
+    WHERE ST_Intersects(tmp2.geometrie, b.geometrie)
+    LIMIT 1
+    )
+   ) AS berater,
    t_id AS vereinbarung
 FROM
   tmp2

--- a/arp_mjpnl_migration/mjpnl_postprocessing_beurteilungen_weide_ln.sql
+++ b/arp_mjpnl_migration/mjpnl_postprocessing_beurteilungen_weide_ln.sql
@@ -78,7 +78,8 @@ WITH tmp AS (
         t_basket,
         vereinbarungs_nr,
         flaeche,
-        (string_to_array(bemerkung,'§'))[2]::jsonb AS old_attr
+        (string_to_array(bemerkung,'§'))[2]::jsonb AS old_attr,
+        geometrie
     FROM ${DB_Schema_MJPNL}.mjpnl_vereinbarung
         WHERE vereinbarungsart = 'Weide_LN' AND vereinbarungs_nr != '01_DUMMY_00001'
 ),
@@ -157,7 +158,23 @@ SELECT
    Round(abgeltung_per_ha_total * flaeche,2) AS abgeltung_total,
    now()::date AS erstellungsdatum,
    'Migration' AS operator_erstellung,
-   (SELECT t_id FROM ${DB_Schema_MJPNL}.mjpnl_berater WHERE aname = 'Bruggisser') AS berater,
+   (SELECT t_id FROM ${DB_Schema_MJPNL}.mjpnl_berater WHERE aname = 
+    (SELECT 
+        CASE 
+            WHEN b.bezirksname IN ('Solothurn', 'Lebern', 'Wasseramt') THEN 'Staub'
+            WHEN b.bezirksname IN ('Bucheggberg') THEN 'Bruggisser'
+            WHEN b.bezirksname IN ('Olten', 'Gösgen') THEN 'Jäggi'
+            WHEN b.bezirksname IN ('Thal', 'Gäu') THEN 'Solothurnmann'
+            WHEN b.bezirksname IN ('Dorneck') THEN 'Borer'
+            WHEN b.bezirksname IN ('Thierstein') THEN 'Weber'
+            --fallback
+            ELSE 'Bruggisser'
+        END AS ermittelter_berater
+    FROM agi_hoheitsgrenzen_pub.hoheitsgrenzen_bezirksgrenze b
+    WHERE ST_Intersects(tmp2.geometrie, b.geometrie)
+    LIMIT 1
+    )
+   ) AS berater,
    t_id AS vereinbarung
 FROM
   tmp2


### PR DESCRIPTION
- "Jäggi" in allen **Hecken**
- "Meier" in allen **OBL** und **Hostet** von 'Dorneck'
- "Gschwind-Holzherr" in allen **OBL** und **Hostet** ausser 'Dorneck'
- "Staub" in **Wiese**, **Weide_LN** und **Weide_Sög** von 'Solothurn', 'Lebern', 'Wasseramt'
- "Bruggisser" in **Wiese**, **Weide_LN** und **Weide_Sög** von 'Bucheggberg'
- "Jäggi" in **Wiese**, **Weide_LN** und **Weide_Sög** von 'Olten', 'Gösgen'
- "Solothurnmann" in **Wiese**, **Weide_LN** und **Weide_Sög** von 'Thal', 'Gäu'
- "Borer" in **Wiese**, **Weide_LN** und **Weide_Sög** von 'Dorneck'
- "Weber" in **Wiese**, **Weide_LN** und **Weide_Sög** von 'Thierstein'

**Nicht berücksichtigt wurden:**:
- Gschwind in Metzerlen (es ist  Meier anstelle drin) 
- Lüthy in Bettlach und Grenchen  (es ist  Staub anstelle drin) 

