### PR TITLE
[arp_mjpnl_migration] Anpassungen nach Feedback (Rebound 8)

### DIFF
--- a/arp_mjpnl_migration/mjpnl_postprocessing_abrechnung_per_bewirtschafter.sql
+++ b/arp_mjpnl_migration/mjpnl_postprocessing_abrechnung_per_bewirtschafter.sql
@@ -1,4 +1,4 @@
-/* Zusammenzug Zahlungen per Bewirtschafter, Auszahlungsjahr und Status Zahlung */
+/* Zusammenzug Zahlungen per Bewirtschafter, Auszahlungsjahr und Status Zahlung nur für das Jahr 2023 (da wir die Historisierung der Bewirtschafter der Vorjahren nicht haben).*/
 
 INSERT INTO ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_bewirtschafter 
 (t_basket, gelan_pid_gelan, gelan_person, gelan_ortschaft, gelan_iban, betrag_total, status_abrechnung,
@@ -59,7 +59,7 @@ FROM
      ON vbg.vereinbarungs_nr = abrg_vbg.vereinbarungs_nr
   WHERE 
     abrg_vbg.gesamtbetrag IS NOT NULL 
-    AND abrg_vbg.auszahlungsjahr IS NOT NULL
+    AND abrg_vbg.auszahlungsjahr = 2023
   GROUP BY pers.pid_gelan, pers.iban, pers.name_vorname, pers.ortschaft, abrg_vbg.auszahlungsjahr
   ORDER BY pers.pid_gelan ASC
 ;

--- a/arp_mjpnl_migration/mjpnl_postprocessing_beurteilungen_hecke.sql
+++ b/arp_mjpnl_migration/mjpnl_postprocessing_beurteilungen_hecke.sql
@@ -26,7 +26,7 @@ INSERT
        --ignored: bewirtschaftung_hecke_typ_niederhecke,
        --ignored: bewirtschaftung_hecke_typ_hochhecke,
        --ignored: bewirtschaftung_hecke_typ_baumhecke,
-       --ignored: bewirtschaftung_hecke_typ_lebhag,
+       bewirtschaftung_hecke_typ_lebhag,
        --ignored: bewirtschaftung_hecke_unterhalt,
        --ignored: bewirtschaftung_hecke_unterhaltsintervall,
        bewirtschaftung_hecke_letzterunterhalt,
@@ -75,6 +75,7 @@ WITH tmp AS (
         t_id,
         t_basket,
         vereinbarungs_nr,
+        vereinbarungsart,
         flaeche,
         (string_to_array(bemerkung,'§'))[2]::jsonb AS old_attr
     FROM ${DB_Schema_MJPNL}.mjpnl_vereinbarung
@@ -101,6 +102,7 @@ SELECT
    FALSE AS einstufungbeurteilungistzustand_hoehlenbaeume_biotpbm_ttholz,
    FALSE AS einstufungbeurteilungistzustand_sitzwarte,
    0 AS einstufungbeurteilungistzustand_abgeltung_ha,
+   CASE WHEN vereinbarungsart = 'Lebhag' THEN TRUE ELSE FALSE END AS bewirtschaftung_hecke_typ_lebhag,
    substring(old_attr->>'letzter_unterhalt', 0, 5)::integer AS bewirtschaftung_hecke_letzterunterhalt,
    FALSE AS bewirtschaftung_krautsaum,
    FALSE AS bewirtschaftung_krautsaum_schnittzeitpunkte,
@@ -108,7 +110,7 @@ SELECT
    FALSE AS bewirtschaftung_krautsaum_keine_beweidung,
    FALSE AS bewirtschaftung_krautsaum_beweidung_nach_absprache,
    0 AS bewirtschaftung_krautsaum_abgeltung_ha,
-   (old_attr->>'hecken_laufmeter')::integer AS bewirtschaftung_lebhag_laufmeter,
+   CASE WHEN vereinbarungsart = 'Lebhag' THEN (old_attr->>'hecken_laufmeter')::integer ELSE 0 END AS bewirtschaftung_lebhag_laufmeter,
    FALSE AS erschwernis_massnahme1,
    0 AS erschwernis_massnahme1_abgeltung_ha,
    FALSE AS erschwernis_massnahme2,

--- a/arp_mjpnl_migration/mjpnl_vereinbarung.sql
+++ b/arp_mjpnl_migration/mjpnl_vereinbarung.sql
@@ -156,6 +156,7 @@ FROM mjpnatur.flaechen mjpfl
       ON vbg.statuscd = stat.statuscd AND stat.statustypid = 'FLA'
 WHERE
     mjpfl.archive = 0
+    AND vbg.vbnr IS NOT NULL -- um zu verhindern, dass "tote" links leere Vereinbarungen mitziehen
     AND vbggeom.wkb_geometry IS NOT NULL
     AND ST_IsValid(vbggeom.wkb_geometry)
     AND Round((ST_Area(vbggeom.wkb_geometry) / 10000)::NUMERIC,2) > 0 --IGNORE small OR emptry geometries

--- a/arp_mjpnl_zahlungslauf/calc_mjpnl_abrechnung_per_bewirtschafter.sql
+++ b/arp_mjpnl_zahlungslauf/calc_mjpnl_abrechnung_per_bewirtschafter.sql
@@ -1,5 +1,5 @@
 /* Zusammenzug Zahlungen per Bewirtschafter, Auszahlungsjahr und Status Zahlung */
-/* Entspricht arp_mjpnl_migration/mjpnl_postprocessing_abrechnung_per_bewirtschafter.sql muss allerdings nur die diesjährigen Leistungen berücksichtigen */
+/* Entspricht arp_mjpnl_migration/mjpnl_postprocessing_abrechnung_per_bewirtschafter.sql muss allerdings nur die diesjährigen Leistungen berücksichtigen - somit stimmt auch die Historisierung, weil es den aktuellen Bewirtschafter nimmt. */
 
 INSERT INTO ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_bewirtschafter 
 (t_basket, gelan_pid_gelan, gelan_person, gelan_ortschaft, gelan_iban, betrag_total, status_abrechnung,


### PR DESCRIPTION
- Verhindern, dass Flächen, die tote Links auf in existente Vereinbarungen enthalten, migriert werden.
- Kalkuliere nur abrechnung_per_bewirtschafter für das aktuelle Jahr (2023), denn für die anderen Jahren könnte es sein dass der Bewirtschafter nicht mehr der gleiche ist.
- Berücksichtige Lebhag und nehme nur dann die Meter für die Laufmeter.