### PR TITLE
Verbesserte Bauzonengrenzen

### DIFF
--- a/arp_bauzonengrenzen_pub/create_bauzonengrenzen.sql
+++ b/arp_bauzonengrenzen_pub/create_bauzonengrenzen.sql
@@ -12,35 +12,134 @@ INSERT INTO
         zonentyp
     )
 
+WITH bauzonen_ohne_gewaesser AS 
+(
+    SELECT 
+        ST_Multi(ST_Union(geometrie, 0.001)) AS geometrie,
+        bfs_nr AS bfsnr,
+        'Bauzone' AS zonentyp
+    FROM 
+        arp_nutzungsplanung_pub_v1.nutzungsplanung_grundnutzung
+    WHERE 
+        bfs_nr = ${bfsnr}
+        AND 
+        (
+            substring(typ_kt from 2 for 2)::int < 20  
+        )
+    GROUP BY
+        bfs_nr
+    
+    UNION ALL
+    
+    SELECT 
+        ST_Multi(ST_Union(geometrie, 0.001)) AS geometrie,
+        bfs_nr AS bfsnr,
+        'Reservezone' AS zonentyp
+    FROM 
+        arp_nutzungsplanung_pub_v1.nutzungsplanung_grundnutzung
+    WHERE 
+        bfs_nr = ${bfsnr}
+        AND 
+        (
+            substring(typ_kt from 2 for 2)::int = 43
+        )
+    GROUP BY
+        bfs_nr
+)
+,
+gewaesser_intersection AS 
+(
+    SELECT 
+        t_id,
+        bfs_nr AS bfsnr,
+        bauzonen_ohne_gewaesser.zonentyp,
+        --ST_Intersects(bauzonen_ohne_gewaesser.geometrie, g.geometrie), 
+        ST_Length(ST_CollectionExtract(ST_Intersection(bauzonen_ohne_gewaesser.geometrie, g.geometrie),2)) / ST_Perimeter(g.geometrie) AS ratio, 
+        ST_Perimeter(g.geometrie),
+        g.geometrie
+    FROM 
+        arp_nutzungsplanung_pub_v1.nutzungsplanung_grundnutzung AS g
+        LEFT JOIN bauzonen_ohne_gewaesser
+        ON ST_Intersects(bauzonen_ohne_gewaesser.geometrie, g.geometrie) 
+    WHERE 
+        bfs_nr = ${bfsnr}
+        AND 
+        (
+            substring(typ_kt from 2 for 3)::int = 320  
+        )
+        AND 
+            ST_Intersection(bauzonen_ohne_gewaesser.geometrie, g.geometrie) IS NOT NULL
+)
+,
+gewaesser_filter AS 
+(
+    SELECT
+        geometrie,
+        bfsnr,
+        zonentyp
+    FROM 
+        gewaesser_intersection
+    WHERE 
+        ratio > 0.9
+)
+,
+bauzone_mit_gewaesser AS 
+(
+    SELECT 
+        geometrie,
+        bfsnr,
+        zonentyp
+    FROM 
+        bauzonen_ohne_gewaesser
+    
+    UNION ALL 
+    
+    SELECT 
+        geometrie,
+        bfsnr,
+        zonentyp
+    FROM 
+        gewaesser_filter
+)
 SELECT 
-    ST_Multi(ST_Union(geometrie, 0.001)),
-    bfs_nr AS bfsnr,
-    'Bauzone' AS zonentyp
+    ST_Union(geometrie) AS geometrie,
+    bfsnr,
+    zonentyp
 FROM 
-    arp_nutzungsplanung_pub_v1.nutzungsplanung_grundnutzung
-WHERE 
-    bfs_nr = ${bfsnr}
-    AND 
-    (
-        substring(typ_kt from 2 for 2)::int < 20  
-    )
+    bauzone_mit_gewaesser
 GROUP BY
-    bfs_nr
-
-UNION ALL
-
-SELECT 
-    ST_Multi(ST_Union(geometrie, 0.001)),
-    bfs_nr AS bfsnr,
-    'Reservezone' AS zonentyp
-FROM 
-    arp_nutzungsplanung_pub_v1.nutzungsplanung_grundnutzung
-WHERE 
-    bfs_nr = ${bfsnr}
-    AND 
-    (
-        substring(typ_kt from 2 for 2)::int = 43
-    )
-GROUP BY
-    bfs_nr
+    zonentyp, bfsnr
 ;
+
+-- SELECT 
+--     ST_Multi(ST_Union(geometrie, 0.001)),
+--     bfs_nr AS bfsnr,
+--     'Bauzone' AS zonentyp
+-- FROM 
+--     arp_nutzungsplanung_pub_v1.nutzungsplanung_grundnutzung
+-- WHERE 
+--     bfs_nr = ${bfsnr}
+--     AND 
+--     (
+--         substring(typ_kt from 2 for 2)::int < 20  
+--     )
+-- GROUP BY
+--     bfs_nr
+
+-- UNION ALL
+
+-- SELECT 
+--     ST_Multi(ST_Union(geometrie, 0.001)),
+--     bfs_nr AS bfsnr,
+--     'Reservezone' AS zonentyp
+-- FROM 
+--     arp_nutzungsplanung_pub_v1.nutzungsplanung_grundnutzung
+-- WHERE 
+--     bfs_nr = ${bfsnr}
+--     AND 
+--     (
+--         substring(typ_kt from 2 for 2)::int = 43
+--     )
+-- GROUP BY
+--     bfs_nr
+-- ;

--- a/arp_bauzonengrenzen_pub/create_bauzonengrenzen.sql
+++ b/arp_bauzonengrenzen_pub/create_bauzonengrenzen.sql
@@ -69,7 +69,6 @@ gewaesser_gewaesserraum AS
 gewaesser_intersection AS 
 (
     SELECT 
-        --t_id,
         bauzonen_ohne_gewaesser.bfsnr,
         bauzonen_ohne_gewaesser.zonentyp,
         --ST_Intersects(bauzonen_ohne_gewaesser.geometrie, g.geometrie), 
@@ -91,10 +90,6 @@ gewaesser_intersection AS
         AND 
             ST_Intersection(bauzonen_ohne_gewaesser.geometrie, g.geometrie) IS NOT NULL
 )
---SELECT 
---*
---FROM 
---gewaesser_intersection
 ,
 gewaesser_filter AS 
 (
@@ -135,36 +130,3 @@ FROM
 GROUP BY
     zonentyp, bfsnr
 ;
-
--- SELECT 
---     ST_Multi(ST_Union(geometrie, 0.001)),
---     bfs_nr AS bfsnr,
---     'Bauzone' AS zonentyp
--- FROM 
---     arp_nutzungsplanung_pub_v1.nutzungsplanung_grundnutzung
--- WHERE 
---     bfs_nr = ${bfsnr}
---     AND 
---     (
---         substring(typ_kt from 2 for 2)::int < 20  
---     )
--- GROUP BY
---     bfs_nr
-
--- UNION ALL
-
--- SELECT 
---     ST_Multi(ST_Union(geometrie, 0.001)),
---     bfs_nr AS bfsnr,
---     'Reservezone' AS zonentyp
--- FROM 
---     arp_nutzungsplanung_pub_v1.nutzungsplanung_grundnutzung
--- WHERE 
---     bfs_nr = ${bfsnr}
---     AND 
---     (
---         substring(typ_kt from 2 for 2)::int = 43
---     )
--- GROUP BY
---     bfs_nr
--- ;

--- a/arp_bauzonengrenzen_pub/create_bauzonengrenzen.sql
+++ b/arp_bauzonengrenzen_pub/create_bauzonengrenzen.sql
@@ -102,7 +102,7 @@ bauzone_mit_gewaesser AS
         gewaesser_filter
 )
 SELECT 
-    ST_Union(geometrie) AS geometrie,
+    ST_Multi(ST_Union(geometrie)) AS geometrie,
     bfsnr,
     zonentyp
 FROM 


### PR DESCRIPTION
Es werden Gewässer und der Gewässerraum innerhalb der Bauzonen mitberücksichtigt. Insbesondere aus ästhetischen Gründen. In Absprache mit ARP. 
Es wird mit Toleranzen gearbeiten. Wenn 80% (momementan) des Umrisses innerhalb der Bauzone sind, wird es zur Bauzonen gerechnet. Gibt jedoch immer noch paar Edge Cases (Gewässer liegt z.B. zwischen Reserverzone und Bauzone).