### PR TITLE
[arp_mjpnl_zahlungslauf] Löschen von diesjährigen Leistungen ohne Vereinbarung

### DIFF
--- a/arp_mjpnl_migration/mjpnl_postprocessing_abrechnung_per_bewirtschafter.sql
+++ b/arp_mjpnl_migration/mjpnl_postprocessing_abrechnung_per_bewirtschafter.sql
@@ -29,19 +29,16 @@ SELECT
    pers.ortschaft AS gelan_ortschaft,
    pers.iban,
    SUM(abrg_vbg.gesamtbetrag) AS betrag_total,
-   -- wenn es ein status_abrechnung "in_bearbeitung" oder wenn nicht dann "freigegeben" gibt, dann soll der status demensprechend gleich sein
+   -- wenn es ein status_abrechnung "freigegeben" gibt, dann soll der status demensprechend gleich sein
    CASE 
-     WHEN (SELECT COUNT(*) FROM ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_vereinbarung v WHERE v.status_abrechnung = 'in_bearbeitung' AND v.gelan_pid_gelan = pers.pid_gelan AND v.auszahlungsjahr = abrg_vbg.auszahlungsjahr) > 0 
-     THEN 'in_bearbeitung' 
      WHEN (SELECT COUNT(*) FROM ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_vereinbarung v WHERE v.status_abrechnung = 'freigegeben' AND v.gelan_pid_gelan = pers.pid_gelan AND v.auszahlungsjahr = abrg_vbg.auszahlungsjahr) > 0 
      THEN 'freigegeben' 
      -- ansonsten ist es für alle gleich ("ausbezahlt" oder "intern_verrechnet")
      ELSE MAX(abrg_vbg.status_abrechnung) 
    END AS status_abrechnung,
-   -- wenn es eine status_abrechnung "freigegeben" oder "in_bearbeitung" gibt, dann soll es noch kein datum_abrechnung haben
+   -- wenn es eine status_abrechnung "freigegeben" gibt, dann soll es noch kein datum_abrechnung haben
    CASE 
-     WHEN (SELECT COUNT(*) FROM ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_vereinbarung v WHERE v.status_abrechnung = 'in_bearbeitung' AND v.gelan_pid_gelan = pers.pid_gelan AND v.auszahlungsjahr = abrg_vbg.auszahlungsjahr) > 0 
-     OR (SELECT COUNT(*) FROM ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_vereinbarung v WHERE v.status_abrechnung = 'freigegeben' AND v.gelan_pid_gelan = pers.pid_gelan AND v.auszahlungsjahr = abrg_vbg.auszahlungsjahr) > 0 
+     WHEN (SELECT COUNT(*) FROM ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_vereinbarung v WHERE v.status_abrechnung = 'freigegeben' AND v.gelan_pid_gelan = pers.pid_gelan AND v.auszahlungsjahr = abrg_vbg.auszahlungsjahr) > 0 
      THEN NULL
      -- ansonsten kann es das späteste datum nehmen
      ELSE MAX(abrg_vbg.datum_abrechnung) 

--- a/arp_mjpnl_migration/mjpnl_postprocessing_abrechnung_per_vereinbarung.sql
+++ b/arp_mjpnl_migration/mjpnl_postprocessing_abrechnung_per_vereinbarung.sql
@@ -21,19 +21,16 @@ SELECT
   COALESCE(SUM(lstg_pauschal_einmalig_freigeg.betrag_total),0) AS betrag_pauschal_einmalig_freigegeben,
   COALESCE(SUM(lstg.betrag_total),0) AS gesamtbetrag,
   lstg.auszahlungsjahr,
-  -- wenn es ein status_abrechnung "in_bearbeitung" oder wenn nicht dann "freigegeben" gibt, dann soll der status demensprechend gleich sein
+  -- wenn es ein status_abrechnung "freigegeben" gibt, dann soll der status demensprechend gleich sein
   CASE 
-   WHEN (SELECT COUNT(*) FROM ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_leistung l WHERE l.status_abrechnung = 'in_bearbeitung' AND l.vereinbarung = vbg.t_id AND l.auszahlungsjahr = lstg.auszahlungsjahr) > 0 
-   THEN 'in_bearbeitung' 
    WHEN (SELECT COUNT(*) FROM ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_leistung l WHERE l.status_abrechnung = 'freigegeben' AND l.vereinbarung = vbg.t_id AND l.auszahlungsjahr = lstg.auszahlungsjahr) > 0 
    THEN 'freigegeben' 
    -- ansonsten ist es für alle gleich ("ausbezahlt" oder "intern_verrechnet")
    ELSE MAX(lstg.status_abrechnung) 
   END AS status_abrechnung,
-  -- wenn es ein status_abrechnung "in_bearbeitung" oder "freigegeben" gibt, dann soll es noch kein datum_abrechnung haben
+  -- wenn es ein status_abrechnung "freigegeben" gibt, dann soll es noch kein datum_abrechnung haben
   CASE 
-   WHEN (SELECT COUNT(*) FROM ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_leistung l WHERE l.status_abrechnung = 'freigegeben' AND l.vereinbarung = vbg.t_id AND l.auszahlungsjahr = lstg.auszahlungsjahr) > 0 
-   OR (SELECT COUNT(*) FROM ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_leistung l WHERE l.status_abrechnung = 'in_bearbeitung' AND l.vereinbarung = vbg.t_id AND l.auszahlungsjahr = lstg.auszahlungsjahr) > 0 
+   WHEN (SELECT COUNT(*) FROM ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_leistung l WHERE l.status_abrechnung = 'freigegeben' AND l.vereinbarung = vbg.t_id AND l.auszahlungsjahr = lstg.auszahlungsjahr) > 0
    THEN NULL
    -- ansonsten kann es das späteste datum nehmen
    ELSE MAX(lstg.datum_abrechnung) 

--- a/arp_mjpnl_migration/mjpnl_postprocessing_abrechnung_per_vereinbarung.sql
+++ b/arp_mjpnl_migration/mjpnl_postprocessing_abrechnung_per_vereinbarung.sql
@@ -62,9 +62,13 @@ FROM
   LEFT JOIN ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_leistung lstg_pauschal_einmalig_freigeg
      ON lstg_pauschal_einmalig_freigeg.t_id = lstg.t_id AND lstg_pauschal_einmalig_freigeg.abgeltungsart = 'pauschal' AND lstg_pauschal_einmalig_freigeg.einmalig IS TRUE AND lstg_pauschal_einmalig_freigeg.status_abrechnung = 'freigegeben'
   WHERE
-    vbg.t_id IS NOT NULL AND vbg.status_vereinbarung = 'aktiv' AND vbg.bewe_id_geprueft IS TRUE
-    -- berücksichtige nur relevante status (in_bearbeitung wird berücksichtigt, aber der Status wird übernommen)
-    AND lstg.status_abrechnung != 'abgeltungslos'
+    vbg.t_id IS NOT NULL AND (
+      ( vbg.status_vereinbarung = 'aktiv' AND vbg.bewe_id_geprueft IS TRUE )
+      OR
+      lstg.status_abrechnung != 'freigegeben' -- freigegebene Leistungen werden nur für aktive und geprüfte Vereinbarungen miteinbezogen
+    )
+    -- berücksichtige nur relevante status ('freigegeben', 'ausbezahlt', 'intern_verrechnet') 
+    AND lstg.status_abrechnung NOT IN ('abgeltungslos', 'in_bearbeitung')
     AND lstg.vereinbarung != 9999999
   GROUP BY vbg.t_id, vbg.vereinbarungs_nr, vbg.gelan_bewe_id, vbg.gb_nr, vbg.flurname, vbg.kultur_id, vbg.gemeinde, vbg.flaeche,
            lstg.auszahlungsjahr, bw.bewirtschaftabmachung_schnittzeitpunkt_1, bw.bewirtschaftabmachung_messerbalkenmaehgeraet, bw.bewirtschaftabmachung_herbstweide

--- a/arp_mjpnl_zahlungslauf/build.gradle
+++ b/arp_mjpnl_zahlungslauf/build.gradle
@@ -28,8 +28,7 @@ task "cleanup_abrechnung_per_leistung_orphans"(type: SqlExecutor,dependsOn: "cle
 }
 
 task "cleanup_status_abrechnung_per_leistung"(type: SqlExecutor,dependsOn: "cleanup_abrechnung_per_leistung") {
-    description = "Setze die Status aller diesjährigen freigegeben-Leistungen, die einmalig oder migriert sind und *keine aktive* Vereinbarungen haben auf in_bearbeitung
-    Setze die Status aller diesjährigen in_bearbeitung-Leistungen, die migriert sind und eine *aktive* Vereinbarungen haben auf freigegeben"
+    description = "Setze die Status aller diesjährigen freigegeben-Leistungen, die einmalig oder migriert sind und *keine aktive* Vereinbarungen haben auf in_bearbeitung - Setze die Status aller diesjährigen in_bearbeitung-Leistungen, die migriert sind und eine *aktive* Vereinbarungen haben auf freigegeben"
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     sqlParameters = [DB_Schema_MJPNL:DB_Schema_MJPNL,AUSZAHLUNGSJAHR:AUSZAHLUNGSJAHR]
     sqlFiles = ['cleanup_mjpnl_abrechnung_per_leistung_status.sql']

--- a/arp_mjpnl_zahlungslauf/build.gradle
+++ b/arp_mjpnl_zahlungslauf/build.gradle
@@ -21,13 +21,21 @@ task "cleanup_abrechnung_per_leistung"(type: SqlExecutor) {
 }
 
 task "cleanup_abrechnung_per_leistung_orphans"(type: SqlExecutor,dependsOn: "cleanup_abrechnung_per_leistung") {
-    description = "Löscht alle diesjährigen Leistungen, deren Vereinbarung manuell gelöscht wurden"
+    description = "Löscht alle diesjährigen Leistungen, deren Vereinbarung manuell gelöscht wurden (was eigentlich nicht gemacht wird ausser bei Bereinigung nach Migration)"
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     sqlParameters = [DB_Schema_MJPNL:DB_Schema_MJPNL,AUSZAHLUNGSJAHR:AUSZAHLUNGSJAHR]
     sqlFiles = ['cleanup_mjpnl_abrechnung_per_leistung_orphans.sql']
 }
 
-task "cleanup_abrechnungen_per_bewirtschafter_und_vereinbarung"(type: SqlExecutor,dependsOn: "cleanup_abrechnung_per_leistung_orphans") {
+task "cleanup_status_abrechnung_per_leistung"(type: SqlExecutor,dependsOn: "cleanup_abrechnung_per_leistung") {
+    description = "Setze die Status aller diesjährigen freigegeben-Leistungen, die einmalig oder migriert sind und *keine aktive* Vereinbarungen haben auf in_bearbeitung
+    Setze die Status aller diesjährigen in_bearbeitung-Leistungen, die migriert sind und eine *aktive* Vereinbarungen haben auf freigegeben"
+    database = [dbUriEdit, dbUserEdit, dbPwdEdit]
+    sqlParameters = [DB_Schema_MJPNL:DB_Schema_MJPNL,AUSZAHLUNGSJAHR:AUSZAHLUNGSJAHR]
+    sqlFiles = ['cleanup_mjpnl_abrechnung_per_leistung_status.sql']
+}
+
+task "cleanup_abrechnungen_per_bewirtschafter_und_vereinbarung"(type: SqlExecutor,dependsOn: "cleanup_status_abrechnung_per_leistung") {
     description = "Löscht alle diesjährigen zusammengefassten Abrechnungen"
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     sqlParameters = [DB_Schema_MJPNL:DB_Schema_MJPNL,AUSZAHLUNGSJAHR:AUSZAHLUNGSJAHR]

--- a/arp_mjpnl_zahlungslauf/build.gradle
+++ b/arp_mjpnl_zahlungslauf/build.gradle
@@ -20,7 +20,14 @@ task "cleanup_abrechnung_per_leistung"(type: SqlExecutor) {
     sqlFiles = ['cleanup_mjpnl_abrechnung_per_leistung.sql']
 }
 
-task "cleanup_abrechnungen_per_bewirtschafter_und_vereinbarung"(type: SqlExecutor,dependsOn: "cleanup_abrechnung_per_leistung") {
+task "cleanup_abrechnung_per_leistung_orphans"(type: SqlExecutor,dependsOn: "cleanup_abrechnung_per_leistung") {
+    description = "Löscht alle diesjährigen Leistungen, deren Vereinbarung manuell gelöscht wurden"
+    database = [dbUriEdit, dbUserEdit, dbPwdEdit]
+    sqlParameters = [DB_Schema_MJPNL:DB_Schema_MJPNL,AUSZAHLUNGSJAHR:AUSZAHLUNGSJAHR]
+    sqlFiles = ['cleanup_mjpnl_abrechnung_per_leistung_orphans.sql']
+}
+
+task "cleanup_abrechnungen_per_bewirtschafter_und_vereinbarung"(type: SqlExecutor,dependsOn: "cleanup_abrechnung_per_leistung_orphans") {
     description = "Löscht alle diesjährigen zusammengefassten Abrechnungen"
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     sqlParameters = [DB_Schema_MJPNL:DB_Schema_MJPNL,AUSZAHLUNGSJAHR:AUSZAHLUNGSJAHR]

--- a/arp_mjpnl_zahlungslauf/calc_mjpnl_abrechnung_per_bewirtschafter.sql
+++ b/arp_mjpnl_zahlungslauf/calc_mjpnl_abrechnung_per_bewirtschafter.sql
@@ -6,7 +6,7 @@ INSERT INTO ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_bewirtschafter
  datum_abrechnung, auszahlungsjahr, dateipfad_oder_url, erstellungsdatum, operator_erstellung, migriert)
 
 WITH gelan_persons AS (
-/* zuerst alle GELAN Personen filtern die eine aktive Vereinbarung haben */
+/* zuerst alle GELAN Personen filtern die eine aktive Vereinbarung haben oder eine mit bereits ausbezahlten Leistungen */
 SELECT 
     DISTINCT
       pers.pid_gelan,
@@ -19,7 +19,13 @@ FROM
       ON vbg.gelan_pid_gelan = pers.pid_gelan
    WHERE
      pers.pid_gelan IS NOT NULL AND pers.iban IS NOT NULL
-     AND vbg.status_vereinbarung = 'aktiv' AND vbg.bewe_id_geprueft IS TRUE
+     AND (
+        -- aktive und geprüfte Vereinbarungen
+        (vbg.status_vereinbarung = 'aktiv' AND vbg.bewe_id_geprueft IS TRUE)
+        OR
+        -- mind. eine diesjährige Leistung, die bereits ausbezahlt ist
+        (SELECT COUNT(*) FROM ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_leistung l WHERE l.status_abrechnung IN ('ausbezahlt','intern_verrechnet') AND l.vereinbarung = vbg.t_id AND l.auszahlungsjahr = ${AUSZAHLUNGSJAHR}::integer) > 0 
+     )
    ORDER BY pers.pid_gelan ASC
 )
 /* Dann Abrechnungsdaten per Bewirtschafter und Auszahlungsjahr und Status aggregieren */

--- a/arp_mjpnl_zahlungslauf/calc_mjpnl_abrechnung_per_bewirtschafter.sql
+++ b/arp_mjpnl_zahlungslauf/calc_mjpnl_abrechnung_per_bewirtschafter.sql
@@ -30,19 +30,16 @@ SELECT
    pers.ortschaft AS gelan_ortschaft,
    pers.iban,
    SUM(abrg_vbg.gesamtbetrag) AS betrag_total,
-   -- wenn es ein status_abrechnung "in_bearbeitung" oder wenn nicht dann "freigegeben" gibt, dann soll der status demensprechend gleich sein
+   -- wenn es ein status_abrechnung "freigegeben" gibt, dann soll der status demensprechend gleich sein
    CASE 
-     WHEN (SELECT COUNT(*) FROM ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_vereinbarung v WHERE v.status_abrechnung = 'in_bearbeitung' AND v.gelan_pid_gelan = pers.pid_gelan AND v.auszahlungsjahr = abrg_vbg.auszahlungsjahr) > 0 
-     THEN 'in_bearbeitung' 
      WHEN (SELECT COUNT(*) FROM ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_vereinbarung v WHERE v.status_abrechnung = 'freigegeben' AND v.gelan_pid_gelan = pers.pid_gelan AND v.auszahlungsjahr = abrg_vbg.auszahlungsjahr) > 0 
      THEN 'freigegeben' 
      -- ansonsten ist es für alle gleich ("ausbezahlt" oder "intern_verrechnet")
      ELSE MAX(abrg_vbg.status_abrechnung) 
    END AS status_abrechnung,
-   -- wenn es eine status_abrechnung "freigegeben" oder "in_bearbeitung" gibt, dann soll es noch kein datum_abrechnung haben
+   -- wenn es eine status_abrechnung "freigegeben" gibt, dann soll es noch kein datum_abrechnung haben
    CASE 
      WHEN (SELECT COUNT(*) FROM ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_vereinbarung v WHERE v.status_abrechnung = 'freigegeben' AND v.gelan_pid_gelan = pers.pid_gelan AND v.auszahlungsjahr = abrg_vbg.auszahlungsjahr) > 0 
-     OR (SELECT COUNT(*) FROM ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_vereinbarung v WHERE v.status_abrechnung = 'freigegeben' AND v.gelan_pid_gelan = pers.pid_gelan AND v.auszahlungsjahr = abrg_vbg.auszahlungsjahr) > 0 
      THEN NULL
      -- ansonsten kann es das späteste datum nehmen
      ELSE MAX(abrg_vbg.datum_abrechnung) 

--- a/arp_mjpnl_zahlungslauf/calc_mjpnl_abrechnung_per_vereinbarung.sql
+++ b/arp_mjpnl_zahlungslauf/calc_mjpnl_abrechnung_per_vereinbarung.sql
@@ -27,19 +27,16 @@ SELECT
   COALESCE(SUM(lstg_pauschal_einmalig_freigeg.betrag_total),0) AS betrag_pauschal_einmalig_freigegeben,
   COALESCE(SUM(lstg.betrag_total),0) AS gesamtbetrag,
   lstg.auszahlungsjahr,
-  -- wenn es ein status_abrechnung "in_bearbeitung" oder wenn nicht dann "freigegeben" gibt, dann soll der status demensprechend gleich sein
+  -- wenn es ein status_abrechnung "freigegeben" gibt, dann soll der status demensprechend gleich sein
   CASE 
-   WHEN (SELECT COUNT(*) FROM ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_leistung l WHERE l.status_abrechnung = 'in_bearbeitung' AND l.vereinbarung = vbg.t_id AND l.auszahlungsjahr = lstg.auszahlungsjahr) > 0 
-   THEN 'in_bearbeitung' 
    WHEN (SELECT COUNT(*) FROM ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_leistung l WHERE l.status_abrechnung = 'freigegeben' AND l.vereinbarung = vbg.t_id AND l.auszahlungsjahr = lstg.auszahlungsjahr) > 0 
    THEN 'freigegeben' 
    -- ansonsten ist es für alle gleich ("ausbezahlt" oder "intern_verrechnet")
    ELSE MAX(lstg.status_abrechnung) 
   END AS status_abrechnung,
-  -- wenn es ein status_abrechnung "in_bearbeitung" oder "freigegeben" gibt, dann soll es noch kein datum_abrechnung haben
+  -- wenn es ein status_abrechnung "freigegeben" gibt, dann soll es noch kein datum_abrechnung haben
   CASE 
-   WHEN (SELECT COUNT(*) FROM ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_leistung l WHERE l.status_abrechnung = 'freigegeben' AND l.vereinbarung = vbg.t_id AND l.auszahlungsjahr = lstg.auszahlungsjahr) > 0 
-   OR (SELECT COUNT(*) FROM ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_leistung l WHERE l.status_abrechnung = 'freigegeben' AND l.vereinbarung = vbg.t_id AND l.auszahlungsjahr = lstg.auszahlungsjahr) > 0 
+   WHEN (SELECT COUNT(*) FROM ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_leistung l WHERE l.status_abrechnung = 'freigegeben' AND l.vereinbarung = vbg.t_id AND l.auszahlungsjahr = lstg.auszahlungsjahr) > 0
    THEN NULL
    -- ansonsten kann es das späteste datum nehmen
    ELSE MAX(lstg.datum_abrechnung) 
@@ -72,8 +69,8 @@ FROM
      ON lstg_pauschal_einmalig_freigeg.t_id = lstg.t_id AND lstg_pauschal_einmalig_freigeg.abgeltungsart = 'pauschal' AND lstg_pauschal_einmalig_freigeg.einmalig IS TRUE AND lstg_pauschal_einmalig_freigeg.status_abrechnung = 'freigegeben'
   WHERE
     vbg.t_id IS NOT NULL AND vbg.status_vereinbarung = 'aktiv' AND vbg.bewe_id_geprueft IS TRUE
-    -- berücksichtige nur relevante status (in_bearbeitung wird berücksichtigt, aber der Status wird übernommen)
-    AND lstg.status_abrechnung != 'abgeltungslos'
+    -- berücksichtige nur relevante status ('freigegeben', 'ausbezahlt', 'intern_verrechnet') 
+    AND lstg.status_abrechnung NOT IN ('abgeltungslos', 'in_bearbeitung')
     -- berücksichtige nur diesjährige Leistungen
     AND lstg.auszahlungsjahr = ${AUSZAHLUNGSJAHR}::integer
   GROUP BY vbg.t_id, vbg.vereinbarungs_nr, vbg.gelan_bewe_id, vbg.gb_nr, vbg.flurname, vbg.kultur_id, vbg.gemeinde, vbg.flaeche,

--- a/arp_mjpnl_zahlungslauf/calc_mjpnl_abrechnung_per_vereinbarung.sql
+++ b/arp_mjpnl_zahlungslauf/calc_mjpnl_abrechnung_per_vereinbarung.sql
@@ -68,7 +68,12 @@ FROM
   LEFT JOIN ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_leistung lstg_pauschal_einmalig_freigeg
      ON lstg_pauschal_einmalig_freigeg.t_id = lstg.t_id AND lstg_pauschal_einmalig_freigeg.abgeltungsart = 'pauschal' AND lstg_pauschal_einmalig_freigeg.einmalig IS TRUE AND lstg_pauschal_einmalig_freigeg.status_abrechnung = 'freigegeben'
   WHERE
-    vbg.t_id IS NOT NULL AND vbg.status_vereinbarung = 'aktiv' AND vbg.bewe_id_geprueft IS TRUE
+    vbg.t_id IS NOT NULL AND 
+    (
+      ( vbg.status_vereinbarung = 'aktiv' AND vbg.bewe_id_geprueft IS TRUE )
+      OR
+      lstg.status_abrechnung != 'freigegeben' -- freigegebene Leistungen werden nur für aktive und geprüfte Vereinbarungen miteinbezogen
+    )
     -- berücksichtige nur relevante status ('freigegeben', 'ausbezahlt', 'intern_verrechnet') 
     AND lstg.status_abrechnung NOT IN ('abgeltungslos', 'in_bearbeitung')
     -- berücksichtige nur diesjährige Leistungen

--- a/arp_mjpnl_zahlungslauf/cleanup_mjpnl_abrechnung_per_leistung_orphans.sql
+++ b/arp_mjpnl_zahlungslauf/cleanup_mjpnl_abrechnung_per_leistung_orphans.sql
@@ -1,5 +1,6 @@
 -- wir löschen alle diesjährigen Leitungen ohne Vereinbarung
 -- denn die Leistungen sind nicht über CASCADE abhängig von Vereinbarungen und bleiben so auch bei manuellem Löschen einer Vereinbarung bestehen
+-- eigentlich wird zwar eine Vereinbarung nicht gelöscht, sondern auf inaktiv gesetzt, doch es kann dennoch der Fall sein (e.g. Bereinigung nach Migration)
 DELETE FROM
     ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_leistung
 WHERE 

--- a/arp_mjpnl_zahlungslauf/cleanup_mjpnl_abrechnung_per_leistung_orphans.sql
+++ b/arp_mjpnl_zahlungslauf/cleanup_mjpnl_abrechnung_per_leistung_orphans.sql
@@ -1,0 +1,11 @@
+-- wir löschen alle diesjährigen Leitungen ohne Vereinbarung
+-- denn die Leistungen sind nicht über CASCADE abhängig von Vereinbarungen und bleiben so auch bei manuellem Löschen einer Vereinbarung bestehen
+DELETE FROM
+    ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_leistung
+WHERE 
+    auszahlungsjahr = ${AUSZAHLUNGSJAHR}::integer
+    AND (
+        -- wenn NULL oder nicht in vereinbarungen
+        vereinbarung IS NULL
+        OR vereinbarung NOT IN (SELECT t_id FROM ${DB_Schema_MJPNL}.mjpnl_vereinbarung)
+    )

--- a/arp_mjpnl_zahlungslauf/cleanup_mjpnl_abrechnung_per_leistung_status.sql
+++ b/arp_mjpnl_zahlungslauf/cleanup_mjpnl_abrechnung_per_leistung_status.sql
@@ -1,0 +1,28 @@
+-- Setze die Status aller diesjährigen freigegeben-Leistungen, die einmalig oder migriert sind und *keine aktive* Vereinbarungen haben auf in_bearbeitung
+
+UPDATE ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_leistung l
+SET status_abrechnung = 'in_bearbeitung'
+FROM ${DB_Schema_MJPNL}.mjpnl_vereinbarung vbg
+WHERE 
+    l.vereinbarung = vbg.t_id
+    AND vbg.status_vereinbarung != 'aktiv'
+    AND l.auszahlungsjahr = ${AUSZAHLUNGSJAHR}::integer
+    AND l.status_abrechnung = 'freigegeben'
+    AND (
+        l.einmalig = TRUE
+        OR l.migriert = TRUE
+    )
+;
+
+-- Setze die Status aller diesjährigen in_bearbeitung-Leistungen, die migriert sind und eine *aktive* Vereinbarungen haben auf freigegeben
+-- Die einmaligen setzen wir nicht auf freigegeben (weil wir ja nicht wissen, ob sie absichtlich auf 'in_bearbeitung' standen vorher)
+UPDATE ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_leistung l
+SET status_abrechnung = 'freigegeben'
+FROM ${DB_Schema_MJPNL}.mjpnl_vereinbarung vbg
+WHERE 
+    l.vereinbarung = vbg.t_id
+    AND vbg.status_vereinbarung = 'aktiv'
+    AND l.auszahlungsjahr = ${AUSZAHLUNGSJAHR}::integer
+    AND l.status_abrechnung = 'in_bearbeitung'
+    AND l.migriert = TRUE
+;

--- a/arp_mjpnl_zahlungslauf/cleanup_mjpnl_abrechnung_per_leistung_status.sql
+++ b/arp_mjpnl_zahlungslauf/cleanup_mjpnl_abrechnung_per_leistung_status.sql
@@ -5,7 +5,10 @@ SET status_abrechnung = 'in_bearbeitung'
 FROM ${DB_Schema_MJPNL}.mjpnl_vereinbarung vbg
 WHERE 
     l.vereinbarung = vbg.t_id
-    AND vbg.status_vereinbarung != 'aktiv'
+    AND NOT (
+        vbg.status_vereinbarung = 'aktiv'
+        AND vbg.bewe_id_geprueft IS TRUE
+    )
     AND l.auszahlungsjahr = ${AUSZAHLUNGSJAHR}::integer
     AND l.status_abrechnung = 'freigegeben'
     AND (
@@ -21,7 +24,10 @@ SET status_abrechnung = 'freigegeben'
 FROM ${DB_Schema_MJPNL}.mjpnl_vereinbarung vbg
 WHERE 
     l.vereinbarung = vbg.t_id
-    AND vbg.status_vereinbarung = 'aktiv'
+    AND (
+        vbg.status_vereinbarung = 'aktiv'
+        AND vbg.bewe_id_geprueft IS TRUE
+    )
     AND l.auszahlungsjahr = ${AUSZAHLUNGSJAHR}::integer
     AND l.status_abrechnung = 'in_bearbeitung'
     AND l.migriert = TRUE

--- a/arp_mjpnl_zahlungslauf/copy_mjpnl_abrechnung_per_leistung.sql
+++ b/arp_mjpnl_zahlungslauf/copy_mjpnl_abrechnung_per_leistung.sql
@@ -45,7 +45,7 @@ WITH alle_beurteilungen AS (
   FROM ${DB_Schema_MJPNL}.mjpnl_beurteilung_wiese
 ),
 relevante_vereinbarungen AS (
-  -- alle vereinbarungen mit unbesprochener oder keiner beurteilung
+  -- alle aktiven vereinbarungen mit unbesprochener oder keiner beurteilung
   -- ...und keinen migrierten Leistungen (Berücksichtigung Migrationsjahr)
   SELECT * 
   FROM ${DB_Schema_MJPNL}.mjpnl_vereinbarung vbg


### PR DESCRIPTION
- Löschen von diesjährigen Leistungen ohne Vereinbarung (die wahrscheinlich manuell gelöscht wurden - normalerweise wird das nicht gemacht, sondern es wird eine Vereinbarung auf inaktiv geschalten). Dies ist wichtig, weil Leistungen nicht CASCADE verknüpft sind, damit die Daten bereinigt sind, falls man doch mal löscht.
- Setze für Vereinbarungen, die nicht aktiv sind oder nicht bewe-geprueft alle migrierten und einmaligen Leistungen, die `freigegeben` sind auf `in_bearbeitung`
- Setze für Vereinbarungen, die aktiv und bewe-geprueft sind alle migrierten Leistungen (nicht die einmaligen) die `in_bearbeitung` sind auf `freigegeben`.
- Berücksichtige in Zusammenfassungen (`abrechnung_per_vereinbarung` und `abrechnung_per_bewirtschafter`):
  - nicht Leistungen die `in_bearbeitung` sind
  - Leistungen, die bereits ausbezahlt sind, selbst wenn die Vereinbarung nicht aktiv oder nicht bewe-geprueft ist 

## Manueller Schnelltest
### 01_HE_00003:
- Bes. Arten: 7.-
- Erschwernis (E): 21.-
- Neue einmalig erfassen 'ausbezahlt': 600.-
- Neue einmalig erfassen 'freigegeben': 400.-

Zahlungslauf: Summe 1028

- Vereinbarung auf zurückgestellt setzen

Zahlungslauf: Summe 600 (nur ausbezahlt)

- Vereinbarung auf aktiv setzen

Zahlungslauf: Summe 628 (ausbezahlt und migrierte)

- in_bearbeitung auf freigegeben setzen

Zahlungslauf: Summe 1028
