### PR TITLE
Inherit from gretl pod template

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,6 @@ parameters.fileParam=filename.xtf
 parameters.stringParams=parameterName;default value;parameter description
 triggers.upstream=other_job_name
 authorization.permissions=gretl-users-barpa
-nodeLabel=gretl-bigtmp
 ```
 
 Mit `logRotator.numToKeep` kann eingestellt werden, wieviele Ausführungen des Jobs aufbewahrt werden sollen, d.h. für wieviele Ausführungen beispielsweise das Logfile vorgehalten wird. Standardwert ist 15. Wenn man diese Einstellung weglässt, werden also die 15 letzten Ausführungen aufbewahrt.
@@ -224,16 +223,16 @@ Folgende GRETL-spezifischen Benutzergruppen stehen im Moment zur Verfügung:
 
 Allerdings können auch diejenigen Benutzer oder Gruppen, welche durch globale Berechtigungseinstellungen in Jenkins dazu bereichtigt sind, den Job starten. Wenn man diese Einstellung weglässt, ist es von den globalen Berechtigungseinstellungen abhängig, wer den Job manuell starten darf.
 
-Mit `nodeLabel` kann bestimmt werden,
+Zudem kann mit der Eigenschaft `nodeLabel` bestimmt werden,
 auf welchem Node der Job ausgeführt werden soll.
-Erlaubt ist hier der Wert `gretl-bigtmp`
-damit der Job auf einem Jenkins Agent
-mit einem grösseren `/tmp`-Verzeichnis ausgeführt wird.
-Und der Wert `gretl-2.2`,
+Möglich ist hier der Wert `gretl-2.2`,
 damit der Job auf einem Jenkins Agent
 mit GRETL Version 2.2 ausgeführt wird.
 (Im Moment zeigt allerdings auch der normale Jenkins Agent
 auf Version 2.2; es gibt also keinen Unterschied.)
+Diese Property dient primär dazu,
+dass bei einem grösseren Versionssprung von GRETL
+nicht alle Jobs gleichzeitig umgestellt werden müssen.
 Lässt man diese Property weg,
 wird der Job auf dem normalen Jenkins Agent
 (mit dem Label `gretl`) ausgeführt.

--- a/afu_gefahrenkartierung_pub_export_ai/Jenkinsfile
+++ b/afu_gefahrenkartierung_pub_export_ai/Jenkinsfile
@@ -1,0 +1,45 @@
+pipeline {
+    agent {
+        kubernetes {
+            inheritFrom params.nodeLabel ?: 'gretl'
+            yamlMergeStrategy merge()
+            yaml """
+            spec:
+              containers:
+              - name: gretl
+                volumeMounts:
+                - name: gretl-tmp-volume
+                  mountPath: /tmp
+                  subPath: gretl
+              volumes:
+              - name: gretl-tmp-volume
+                persistentVolumeClaim:
+                    claimName: ${env.OPENSHIFT_PROJECT_NAME}-lowback
+"""
+        }
+    }
+    options {
+        timeout(time: 6, unit: 'HOURS')
+    }
+    stages {
+        stage('Run GRETL job') {
+            steps {
+                git url: "${env.GIT_REPO_URL}", branch: "${params.BRANCH ?: 'main'}", changelog: false
+                container('gretl') {
+                    dir(env.JOB_BASE_NAME) {
+                        sh 'gretl'
+                    }
+                }
+            }
+        }
+    }
+    post {
+        unsuccessful {
+            emailext (
+                to: "${currentBuild.getBuildCauses()[0]._class == 'hudson.model.Cause$UserIdCause' ? emailextrecipients([requestor()]) : '$DEFAULT_RECIPIENTS'}",
+                subject: "GRETL-Job ${JOB_NAME} (${BUILD_DISPLAY_NAME}) ist fehlgeschlagen",
+                body: "Die Ausführung des GRETL-Jobs ${JOB_NAME} (${BUILD_DISPLAY_NAME}) war nicht erfolgreich. Details dazu finden Sie in den Log-Meldungen unter ${RUN_DISPLAY_URL}."
+            )
+        }
+    }
+}

--- a/afu_gefahrenkartierung_pub_export_ai/job.properties
+++ b/afu_gefahrenkartierung_pub_export_ai/job.properties
@@ -1,2 +1,1 @@
 authorization.permissions=gretl-users-bdafu
-nodeLabel=gretl-bigtmp


### PR DESCRIPTION
Instead of providing and using a separate pod template with a bigger tmp volume, inherit from the _gretl_ pod template and add the volume mount using YAML. This allows to mount a sub path.