### PR TITLE
Avt kantonstrassen pub validator

### DIFF
--- a/avt_kantonsstrassen_pub/build.gradle
+++ b/avt_kantonsstrassen_pub/build.gradle
@@ -15,12 +15,17 @@ task unpackShapes(type: Copy) {
     into pathToShpFolder
 }
 
-task validate(type: ShpValidator, dependsOn: unpackShapes){
+task validate_achsen(type: ShpValidator, dependsOn: unpackShapes){
     models = "SO_AVT_Kantonsstrassen_Publikation_20200707"
-    dataFiles = [Paths.get(pathToShpFolder, shpNamePunkte),Paths.get(pathToShpFolder, shpNameAchsen)]
+    dataFiles = [Paths.get(pathToShpFolder, shpNameAchsen)]
 } 
 
-task deleteAllFeatures(type: SqlExecutor, dependsOn: validate){
+task validate_punkte(type: ShpValidator, dependsOn: validate_achsen){
+    models = "SO_AVT_Kantonsstrassen_Publikation_20200707"
+    dataFiles = [Paths.get(pathToShpFolder, shpNamePunkte)]
+} 
+
+task deleteAllFeatures(type: SqlExecutor, dependsOn: validate_punkte){
     database = [dbUriPub, dbUserPub, dbPwdPub]
     sqlFiles = ['delete_achsen_u_punkte.sql']
 }

--- a/avt_kantonsstrassen_pub/build.gradle
+++ b/avt_kantonsstrassen_pub/build.gradle
@@ -15,7 +15,12 @@ task unpackShapes(type: Copy) {
     into pathToShpFolder
 }
 
-task deleteAllFeatures(type: SqlExecutor, dependsOn: unpackShapes){
+task validate(type: ShpValidator, dependsOn: unpackShapes){
+    models = "SO_AVT_Achsen_Publikation_20200707"
+    dataFiles = [Paths.get(pathToShpFolder, shpNamePunkte),Paths.get(pathToShpFolder, shpNameAchsen)]
+} 
+
+task deleteAllFeatures(type: SqlExecutor, dependsOn: validate){
     database = [dbUriPub, dbUserPub, dbPwdPub]
     sqlFiles = ['delete_achsen_u_punkte.sql']
 }
@@ -53,11 +58,4 @@ task publipub(type: Publisher, dependsOn: 'importPunkte'){
 task refreshSolr(type:Exec, dependsOn:'publipub') {
         commandLine 'curl', '-i', '--max-time', '5', solrIndexupdaterBaseUrl + '/queue?ds=ch.so.avt.kantonsstrassen_achsen,ch.so.avt.kantonsstrassen_bezugspunkte'
 }
-
-/* 
-task validate(type: ShpValidator){
-    models = "SO_AVT_Achsen_Publikation_20200707"
-    dataFiles = ["_shp/Bezugspunkte_ohneK2_point_point.shp","_shp/Achsen_line_line.shp"]
-}
-*/
 

--- a/avt_kantonsstrassen_pub/build.gradle
+++ b/avt_kantonsstrassen_pub/build.gradle
@@ -16,7 +16,7 @@ task unpackShapes(type: Copy) {
 }
 
 task validate(type: ShpValidator, dependsOn: unpackShapes){
-    models = "SO_AVT_Achsen_Publikation_20200707"
+    models = "SO_AVT_Kantonsstrassen_Publikation_20200707"
     dataFiles = [Paths.get(pathToShpFolder, shpNamePunkte),Paths.get(pathToShpFolder, shpNameAchsen)]
 } 
 


### PR DESCRIPTION
Shape-Validator wieder aktiviert. Musste allerdings in 2 Tasks aufgeteilt werden, da das Validieren von mehreren Shapefiles nicht funktioniert (Siehe Doku des SHP-Validators)