### PR TITLE
[arp_mjpnl_zahlungslauf] Prüfe nicht ob die beurteilung besprochen ist

### DIFF
--- a/arp_mjpnl_zahlungslauf/calc_mjpnl_abrechnung_per_vereinbarung.sql
+++ b/arp_mjpnl_zahlungslauf/calc_mjpnl_abrechnung_per_vereinbarung.sql
@@ -5,9 +5,9 @@ INSERT INTO ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_vereinbarung
   (t_basket, vereinbarungs_nr, gelan_pid_gelan, gelan_bewe_id, gb_nr, flurnamen, kultur_ids, gemeinde, bemerkung, flaeche, anzahl_baeume, betrag_flaeche, betrag_baeume, betrag_pauschal_regulaer, betrag_pauschal_einmalig_ausbezahlt, betrag_pauschal_einmalig_freigegeben, gesamtbetrag,
    auszahlungsjahr, status_abrechnung, datum_abrechnung, bewirtschaftabmachung_schnittzeitpunkt_1, bewirtschaftabmachung_messerbalkenmaehgeraet, bewirtschaftabmachung_herbstweide, vereinbarung, migriert)
 WITH beurteilungs_metainfo_wiesen AS (
-	SELECT vereinbarung, beurteilungsdatum, bewirtschaftabmachung_schnittzeitpunkt_1, bewirtschaftabmachung_messerbalkenmaehgeraet, bewirtschaftabmachung_herbstweide FROM ${DB_Schema_MJPNL}.mjpnl_beurteilung_wiese WHERE mit_bewirtschafter_besprochen
+	SELECT vereinbarung, beurteilungsdatum, bewirtschaftabmachung_schnittzeitpunkt_1, bewirtschaftabmachung_messerbalkenmaehgeraet, bewirtschaftabmachung_herbstweide FROM ${DB_Schema_MJPNL}.mjpnl_beurteilung_wiese
 	UNION 
-	SELECT vereinbarung, beurteilungsdatum, bewirtschaftabmachung_schnittzeitpunkt_1, bewirtschaftabmachung_messerbalkenmaehgeraet, bewirtschaftabmachung_herbstweide FROM ${DB_Schema_MJPNL}.mjpnl_beurteilung_wbl_wiese WHERE mit_bewirtschafter_besprochen
+	SELECT vereinbarung, beurteilungsdatum, bewirtschaftabmachung_schnittzeitpunkt_1, bewirtschaftabmachung_messerbalkenmaehgeraet, bewirtschaftabmachung_herbstweide FROM ${DB_Schema_MJPNL}.mjpnl_beurteilung_wbl_wiese
 )
 SELECT
   vbg.t_basket,


### PR DESCRIPTION
... um die info über schnittzeitpunkt etc. zu kriegen.

### Infofelder von Beurteilung in Abrechnung_per_Vereinbarung
In Abrechnung_per_Vereinbarung braucht es (für den Brief) einige Informationen wie zBs. der Schnittzeitpunkt. Diese werden aus der (evtl. migrierten und nicht besprochenen) Beurteilung gelesen. Dass diese nicht besprochen sein könnten, inkludiert gewissermassen "ungültige" Werte, die wir aber brauchen.