### PR TITLE
[arp_mjpnl_zahlungslauf] Setze 2023 auf Statisch für nächtliche Jobs

### DIFF
--- a/arp_mjpnl_zahlungslauf/build.gradle
+++ b/arp_mjpnl_zahlungslauf/build.gradle
@@ -13,7 +13,7 @@ apply plugin: 'ch.so.agi.gretl'
 defaultTasks 'calculate_abrechnung_per_bewirtschafter'
 
 def DB_Schema_MJPNL = "arp_mjpnl_v1"
-def AUSZAHLUNGSJAHR = auszahlungsjahr ?: new SimpleDateFormat("yyyy").format(new Date())
+def AUSZAHLUNGSJAHR = auszahlungsjahr ?: 2023 // new SimpleDateFormat("yyyy").format(new Date())
 
 task "cleanup_abrechnung_per_leistung"(type: SqlExecutor) {
     description = "Löscht alle diesjährigen Leistungen (die nicht einmalig oder migriert sind) und setzt FKs auf NULL"

--- a/arp_mjpnl_zahlungslauf/build.gradle
+++ b/arp_mjpnl_zahlungslauf/build.gradle
@@ -13,7 +13,7 @@ apply plugin: 'ch.so.agi.gretl'
 defaultTasks 'calculate_abrechnung_per_bewirtschafter'
 
 def DB_Schema_MJPNL = "arp_mjpnl_v1"
-def AUSZAHLUNGSJAHR = auszahlungsjahr ?: 2023 // new SimpleDateFormat("yyyy").format(new Date())
+def AUSZAHLUNGSJAHR = auszahlungsjahr ?: "2023" // new SimpleDateFormat("yyyy").format(new Date())
 
 task "cleanup_abrechnung_per_leistung"(type: SqlExecutor) {
     description = "Löscht alle diesjährigen Leistungen (die nicht einmalig oder migriert sind) und setzt FKs auf NULL"


### PR DESCRIPTION
Da ab 1.1.2024 noch nicht fürs 2024 berechnet werden soll. Statisch, bis wir eine Lösung haben.