### PR TITLE
[arp_nutzungsplanung_pub] Mount a volume for tmp directory

### DIFF
--- a/afu_gefahrenkartierung_pub_export_ai/Jenkinsfile
+++ b/afu_gefahrenkartierung_pub_export_ai/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
                   volumeMounts:
                     - name: gretl-tmp-volume
                       mountPath: /tmp
-                      subPath: gretl
+                      subPath: gretl/${env.JOB_BASE_NAME}
               volumes:
                 - name: gretl-tmp-volume
                   persistentVolumeClaim:

--- a/arp_nutzungsplanung_pub/Jenkinsfile
+++ b/arp_nutzungsplanung_pub/Jenkinsfile
@@ -6,7 +6,25 @@ pipeline {
     }
     stages {
         stage('Import into staging schema') {
-            agent { label 'gretl' }
+            agent {
+                kubernetes {
+                    inheritFrom params.nodeLabel ?: 'gretl'
+                    yamlMergeStrategy merge()
+                    yaml """
+                    spec:
+                      containers:
+                        - name: gretl
+                          volumeMounts:
+                            - name: gretl-tmp-volume
+                              mountPath: /tmp
+                              subPath: gretl/${env.JOB_BASE_NAME}
+                      volumes:
+                        - name: gretl-tmp-volume
+                          persistentVolumeClaim:
+                            claimName: ${env.OPENSHIFT_PROJECT_NAME}-lowback
+"""
+                }
+            }
             steps {
                 script { currentBuild.description = "${params.buildDescription}" }
                 git url: "${env.GIT_REPO_URL}", branch: "${params.BRANCH ?: 'main'}", changelog: false
@@ -31,7 +49,25 @@ pipeline {
             }
         }
         stage('Import into pub schema') {
-            agent { label 'gretl' }
+            agent {
+                kubernetes {
+                    inheritFrom params.nodeLabel ?: 'gretl'
+                    yamlMergeStrategy merge()
+                    yaml """
+                    spec:
+                      containers:
+                        - name: gretl
+                          volumeMounts:
+                            - name: gretl-tmp-volume
+                              mountPath: /tmp
+                              subPath: gretl/${env.JOB_BASE_NAME}
+                      volumes:
+                        - name: gretl-tmp-volume
+                          persistentVolumeClaim:
+                            claimName: ${env.OPENSHIFT_PROJECT_NAME}-lowback
+"""
+                }
+            }
             steps {
                 unstash name: "gretljob"
                 container('gretl') {


### PR DESCRIPTION
Nach dem Merge: PVC aufräumen, weil bisher der `subPath` anders war und dort wahrscheinlich noch einige Dateien liegen.