### PR TITLE
[afu_wasserbewirtschftung_pub] Anpassung auf neue Quell-Schemas

### DIFF
--- a/afu_wasserbewirtschaftung_pub/afu_wasserbewirtschaftung_fassung_pub.sql
+++ b/afu_wasserbewirtschaftung_pub/afu_wasserbewirtschaftung_fassung_pub.sql
@@ -1,132 +1,54 @@
-(SELECT 
-     'Sodbrunnen' AS fassungstyp, 
-     sodbrunnen.menge AS konzessionsmenge, 
-     sodbrunnen.schutzzone, 
-     CASE 
-         WHEN sodbrunnen.nutzungsart = 3 
-         THEN 'privat'
-         WHEN sodbrunnen.nutzungsart = 2 
-         THEN 'privat_oeffentliches_Interesse'
-         WHEN sodbrunnen.nutzungsart = 1 
-         THEN 'oeffentlich'
-     END AS nutzungstyp, 
-     CASE 
-         WHEN sodbrunnen.verwendung = 1 
-         THEN 'Trinkwasser' 
-         WHEN sodbrunnen.verwendung = 2 
-         THEN 'Brauchwasser'
-         WHEN sodbrunnen.verwendung = 3
-         THEN 'Notbrunnen'
-     END AS verwendungszweck,
-     'Sodbrunnen' AS objekttyp_anzeige,
-     sodbrunnen.bezeichnung AS objektname, 
-     sodbrunnen.mobj_id AS objektnummer,
-     sodbrunnen.beschreibung AS technische_angabe,
-     sodbrunnen.bemerkung AS bemerkung,
-     array_to_json(dokumente.dokumente) AS dokumente, 
-     wkb_geometry AS geometrie
- FROM (SELECT * FROM vegas.obj_objekt_v where objekttyp_id = 6 AND archive=0) sodbrunnen
- LEFT JOIN 
-     (SELECT 
-          array_agg('https://geo.so.ch/docs/ch.so.afu.grundwasserbewirtschaftung/'||y.vegas_id||'_'||x.dokument_id||'.'||x.dateiendung) AS dokumente, 
-          y.vegas_id
-      FROM 
-          vegas.adm_dokument x, 
-          vegas.adm_objekt_dokument y 
-      WHERE x.dokument_id = y.dokument_id
-      GROUP BY y.vegas_id) dokumente ON sodbrunnen.vegas_id = dokumente.vegas_id)
-UNION ALL 
-(SELECT 
-     'Horizontalfilterbrunnen' AS fassungstyp, 
-     horizontalfilterbrunnen.menge AS konzessionsmenge, 
-     horizontalfilterbrunnen.schutzzone, 
-     CASE 
-         WHEN horizontalfilterbrunnen.nutzungsart = 3 
-         THEN 'privat'
-         WHEN horizontalfilterbrunnen.nutzungsart = 2 
-         THEN 'privat_oeffentliches_Interesse'
-         WHEN horizontalfilterbrunnen.nutzungsart = 1 
-         THEN 'oeffentlich'
-     END AS nutzungstyp, 
-     CASE 
-         WHEN horizontalfilterbrunnen.verwendung = 1 
-         THEN 'Trinkwasser' 
-         WHEN horizontalfilterbrunnen.verwendung = 2 
-         THEN 'Brauchwasser'
-         WHEN horizontalfilterbrunnen.verwendung = 3
-         THEN 'Notbrunnen'
-     END AS verwendungszweck,
-     CASE 
-         WHEN horizontalfilterbrunnen.nutzungsart = 3 
-         THEN 'Horizontalfilterbrunnen mit privater Nutzung'
-         WHEN horizontalfilterbrunnen.nutzungsart = 2 
-         THEN 'Horizontalfilterbrunnen mit privater Nutzung von öffentlichem Interesse'
-         WHEN horizontalfilterbrunnen.nutzungsart = 1 
-         THEN 'Horizontalfilterbrunnen für die öffentliche Wasserversorgung' 
-         WHEN horizontalfilterbrunnen.nutzungsart IS NULL OR horizontalfilterbrunnen.nutzungsart > 3 
-         THEN 'Horizontalfilterbrunnen'
-     END AS objekttyp_anzeige,
-     horizontalfilterbrunnen.bezeichnung AS objektname, 
-     horizontalfilterbrunnen.mobj_id AS objektnummer,
-     horizontalfilterbrunnen.beschreibung AS technische_angabe,
-     horizontalfilterbrunnen.bemerkung AS bemerkung,
-     array_to_json(dokumente.dokumente) AS dokumente, 
-     wkb_geometry AS geometrie
- FROM (SELECT * FROM vegas.obj_objekt_v where objekttyp_id = 7 AND subtyp = 2 AND archive=0) horizontalfilterbrunnen
- LEFT JOIN 
-     (SELECT 
-          array_agg('https://geo.so.ch/docs/ch.so.afu.grundwasserbewirtschaftung/'||y.vegas_id||'_'||x.dokument_id||'.'||x.dateiendung) AS dokumente,
-          y.vegas_id
-      FROM 
-          vegas.adm_dokument x, 
-          vegas.adm_objekt_dokument y 
-      WHERE x.dokument_id = y.dokument_id
-      GROUP BY y.vegas_id) dokumente ON horizontalfilterbrunnen.vegas_id = dokumente.vegas_id)
-UNION ALL 
-(SELECT 
-     'Vertikalfilterbrunnen' AS fassungstyp, 
-     vertikalfilterbrunnen.menge AS konzessionsmenge, 
-     vertikalfilterbrunnen.schutzzone, 
-     CASE 
-         WHEN vertikalfilterbrunnen.nutzungsart = 3 
-         THEN 'privat'
-         WHEN vertikalfilterbrunnen.nutzungsart = 2 
-         THEN 'privat_oeffentliches_Interesse'
-         WHEN vertikalfilterbrunnen.nutzungsart = 1 
-         THEN 'oeffentlich'
-     END AS nutzungstyp, 
-     CASE 
-         WHEN vertikalfilterbrunnen.verwendung = 1 
-         THEN 'Trinkwasser' 
-         WHEN vertikalfilterbrunnen.verwendung = 2 
-         THEN 'Brauchwasser'
-         WHEN vertikalfilterbrunnen.verwendung = 3
-         THEN 'Notbrunnen'
-     END AS verwendungszweck,
-     CASE 
-         WHEN vertikalfilterbrunnen.nutzungsart = 3 
-         THEN 'Vertikalfilterbrunnen mit privater Nutzung'
-         WHEN vertikalfilterbrunnen.nutzungsart = 2 
-         THEN 'Vertikalfilterbrunnen mit privater Nutzung von öffentlichem Interesse'
-         WHEN vertikalfilterbrunnen.nutzungsart = 1 
-         THEN 'Vertikalfilterbrunnen für die öffentliche Wasserversorgung' 
-         WHEN vertikalfilterbrunnen.nutzungsart IS NULL OR vertikalfilterbrunnen.nutzungsart > 3 
-         THEN 'Vertikalfilterbrunnen'
-     END AS objekttyp_anzeige,
-     vertikalfilterbrunnen.bezeichnung AS objektname, 
-     vertikalfilterbrunnen.mobj_id AS objektnummer,
-     vertikalfilterbrunnen.beschreibung AS technische_angabe,
-     vertikalfilterbrunnen.bemerkung AS bemerkung,
-     array_to_json(dokumente.dokumente) AS dokumente, 
-     wkb_geometry AS geometrie
- FROM (SELECT * FROM vegas.obj_objekt_v where objekttyp_id = 7 AND subtyp = 1 AND archive=0) vertikalfilterbrunnen
- LEFT JOIN 
-     (SELECT 
-          array_agg('https://geo.so.ch/docs/ch.so.afu.grundwasserbewirtschaftung/'||y.vegas_id||'_'||x.dokument_id||'.'||x.dateiendung) AS dokumente,
-          y.vegas_id
-      FROM 
-          vegas.adm_dokument x, 
-          vegas.adm_objekt_dokument y 
-      WHERE x.dokument_id = y.dokument_id
-      GROUP BY y.vegas_id) dokumente ON vertikalfilterbrunnen.vegas_id = dokumente.vegas_id)
-;
+WITH
+
+sodbrunnen AS (
+	SELECT 
+		'Sodbrunnen' AS fassungstyp,
+		konzessionsmenge,
+		FALSE AS schutzzone,
+		NULL AS nutzungstyp,
+		verwendung AS verwendungszweck,
+		'Sodbrunnen' AS objekttyp_anzeige,
+		bezeichnung AS objektname,
+		objekt_id AS objektnummer,
+		beschreibung AS technische_angabe,
+		bemerkung,
+		geometrie
+	FROM
+		afu_grundwasserschutz_obj_v1.sodbrunnen
+),
+
+horizontalfilterbrunnen AS (
+	SELECT 
+		'Horizontalfilterbrunnen' AS fassungstyp,
+		konzessionsmenge,
+		schutzzone,
+	 	CASE nutzungsart
+	 		WHEN 'Oeffentliche_Fassung' THEN 'oeffentlich'
+	 		WHEN 'Private_Fassung' THEN 'privat'
+	 		WHEN 'Private_Fassung_von_oeffentlichem_Interesse' THEN 'privat_oeffentliches_Interesse'
+	 		ELSE NULL
+	 	END AS nutzungstyp,
+		verwendung AS verwendungszweck,
+	 	CASE nutzungsart
+	 		WHEN 'Oeffentliche_Fassung' THEN 'Horizontalfilterbrunnen für die öffentliche Wasserversorgung'
+	 		WHEN 'Private_Fassung' THEN 'Horizontalfilterbrunnen mit privater Nutzung'
+	 		WHEN 'Private_Fassung_von_oeffentlichem_Interesse' THEN 'Horizontalfilterbrunnen mit privater Nutzung von öffentlichem Interesse'
+	 		ELSE 'Horizontalfilterbrunnen'
+	 	END AS objekttyp_anzeige,
+		bezeichnung AS objektname,
+		objekt_id AS objektnummer,
+		beschreibung AS technische_angabe,
+		bemerkung,
+		geometrie
+	FROM
+		afu_wasserversorg_obj_v1.filterbrunnen
+		WHERE typ = 'horizontal'
+),
+
+fassung AS (
+	SELECT * FROM sodbrunnen
+	UNION ALL
+	SELECT * FROM horizontalfilterbrunnen
+)
+
+SELECT * FROM fassung;

--- a/afu_wasserbewirtschaftung_pub/afu_wasserbewirtschaftung_grundwassereinbauten_pub.sql
+++ b/afu_wasserbewirtschaftung_pub/afu_wasserbewirtschaftung_grundwassereinbauten_pub.sql
@@ -1,168 +1,98 @@
-(SELECT 
-    'weitere_Einbauten' AS objektart, 
-    'Weitere Einbauten' AS objekttyp_anzeige,
-    weitere_einbauten.bezeichnung AS objektname, 
-    weitere_einbauten.mobj_id AS objektnummer, 
-    weitere_einbauten.beschreibung AS technische_angabe, 
-    weitere_einbauten.bemerkung AS bemerkung, 
-    array_to_json(dokumente.dokumente) AS dokumente, 
-    wkb_geometry AS geometrie
-FROM 
-    (SELECT * FROM vegas.obj_objekt_v2 where objekttyp_id = 25 AND ARCHIVE = 0) weitere_einbauten
-LEFT JOIN 
-    (SELECT 
-         array_agg('https://geo.so.ch/docs/ch.so.afu.grundwasserbewirtschaftung/'||y.vegas_id||'_'||x.dokument_id||'.'||x.dateiendung) AS dokumente, 
-         y.vegas_id
-     FROM 
-         vegas.adm_dokument x, 
-         vegas.adm_objekt_dokument y 
-     WHERE 
-         x.dokument_id = y.dokument_id
-     GROUP BY 
-         y.vegas_id
-     ) dokumente ON weitere_einbauten.vegas_id = dokumente.vegas_id )
-UNION ALL 
-(SELECT 
-    'Versickerungsschacht' AS objektart, 
-    'Versickerungsschacht' AS objekttyp_anzeige,
-    versickerungsschacht.bezeichnung AS objektname, 
-    versickerungsschacht.mobj_id AS objektnummer, 
-    versickerungsschacht.beschreibung AS technische_angabe, 
-    versickerungsschacht.bemerkung AS bemerkung, 
-    array_to_json(dokumente.dokumente) AS dokumente, 
-    wkb_geometry AS geometrie
-FROM 
-    (SELECT * FROM vegas.obj_objekt_v2 where (objekttyp_id = 18) AND (schachttyp = 2) AND (zustand != 4) AND ARCHIVE = 0) versickerungsschacht
-LEFT JOIN 
-    (SELECT 
-         array_agg('https://geo.so.ch/docs/ch.so.afu.grundwasserbewirtschaftung/'||y.vegas_id||'_'||x.dokument_id||'.'||x.dateiendung) AS dokumente, 
-         y.vegas_id
-     FROM 
-         vegas.adm_dokument x, 
-         vegas.adm_objekt_dokument y 
-     WHERE 
-         x.dokument_id = y.dokument_id
-     GROUP BY 
-         y.vegas_id
-     ) dokumente ON versickerungsschacht.vegas_id = dokumente.vegas_id )
+WITH
 
-UNION ALL 
-    (SELECT 
-        'Grundwasserbeobachtung.Piezometer.Bohrung' AS objektart,
-        'Bohrung mit Piezometer' AS objekttyp_anzeige, 
-        bohrung.bezeichnung AS objektname, 
-        bohrung.mobj_id AS objektnummer,
-        bohrung.beschreibung AS technische_angabe,
-        bohrung.bemerkung AS bemerkung, 
-        array_to_json(dokumente.dokumente) AS dokumente, 
-        wkb_geometry AS geometrie
-    FROM 
-        (SELECT * FROM vegas.obj_bohrung WHERE piezometer IS TRUE AND "archive" = 0) bohrung 
-    LEFT JOIN 
-        (SELECT 
-             array_agg('https://geo.so.ch/docs/ch.so.afu.grundwasserbewirtschaftung/'||y.vegas_id||'_'||x.dokument_id||'.'||x.dateiendung) AS dokumente, 
-             y.vegas_id
-         FROM 
-             vegas.adm_dokument x, 
-             vegas.adm_objekt_dokument y 
-         WHERE 
-             x.dokument_id = y.dokument_id
-         GROUP BY 
-             y.vegas_id
-         ) dokumente ON bohrung.vegas_id = dokumente.vegas_id )
-UNION ALL 
-    (SELECT 
-        'Grundwasserbeobachtung.Piezometer.Gerammt' AS objektart,
-        'Piezometer gerammt' AS objekttyp_anzeige, 
-        gerammt.bezeichnung AS objektname, 
-        gerammt.mobj_id AS objektnummer,
-        gerammt.beschreibung AS technische_angabe,
-        gerammt.bemerkung AS bemerkung, 
-        array_to_json(dokumente.dokumente) AS dokumente, 
-        wkb_geometry AS geometrie
-    FROM 
-        (SELECT * FROM vegas.obj_objekt_v2 WHERE objekttyp_id = 35 AND "archive" = 0) gerammt
-    LEFT JOIN 
-        (SELECT 
-             array_agg('https://geo.so.ch/docs/ch.so.afu.grundwasserbewirtschaftung/'||y.vegas_id||'_'||x.dokument_id||'.'||x.dateiendung) AS dokumente, 
-             y.vegas_id
-         FROM 
-             vegas.adm_dokument x, 
-             vegas.adm_objekt_dokument y 
-         WHERE 
-             x.dokument_id = y.dokument_id
-         GROUP BY 
-             y.vegas_id
-         ) dokumente ON gerammt.vegas_id = dokumente.vegas_id )
-UNION ALL 
-    (SELECT 
-        'Grundwasserbeobachtung.Sondierung.Bohrung' AS objektart,
-        'Sondierungsbohrung' AS objekttyp_anzeige, 
-        sondierung.bezeichnung AS objektname, 
-        sondierung.mobj_id AS objektnummer,
-        sondierung.beschreibung AS technische_angabe,
-        sondierung.bemerkung AS bemerkung, 
-        array_to_json(dokumente.dokumente) AS dokumente, 
-        wkb_geometry AS geometrie
-    FROM 
-        (SELECT * FROM vegas.obj_bohrung WHERE piezometer IS FALSE AND "archive" = 0) sondierung 
-    LEFT JOIN 
-        (SELECT 
-             array_agg('https://geo.so.ch/docs/ch.so.afu.grundwasserbewirtschaftung/'||y.vegas_id||'_'||x.dokument_id||'.'||x.dateiendung) AS dokumente, 
-             y.vegas_id
-         FROM 
-             vegas.adm_dokument x, 
-             vegas.adm_objekt_dokument y 
-         WHERE 
-             x.dokument_id = y.dokument_id
-         GROUP BY 
-             y.vegas_id
-         ) dokumente ON sondierung.vegas_id = dokumente.vegas_id )
-UNION ALL 
-    (SELECT 
-        'Grundwasserbeobachtung.Sondierung.Baggerschlitz' AS objektart, 
-        'Sondierungsbaggerschlitz' AS objekttyp_anzeige,
-        baggerschlitz.bezeichnung AS objektname, 
-        baggerschlitz.mobj_id AS objektnummer,
-        baggerschlitz.beschreibung AS technische_angabe,
-        baggerschlitz.bemerkung AS bemerkung, 
-        array_to_json(dokumente.dokumente) AS dokumente, 
-        wkb_geometry AS geometrie
-    FROM 
-        (SELECT * FROM vegas.obj_objekt_v2 WHERE objekttyp_id = 21 AND "archive" = 0) baggerschlitz
-    LEFT JOIN 
-        (SELECT 
-             array_agg('https://geo.so.ch/docs/ch.so.afu.grundwasserbewirtschaftung/'||y.vegas_id||'_'||x.dokument_id||'.'||x.dateiendung) AS dokumente, 
-             y.vegas_id
-         FROM 
-             vegas.adm_dokument x, 
-             vegas.adm_objekt_dokument y 
-         WHERE 
-             x.dokument_id = y.dokument_id
-         GROUP BY 
-             y.vegas_id
-         ) dokumente ON baggerschlitz.vegas_id = dokumente.vegas_id )
-UNION ALL 
-    (SELECT 
-        'Grundwasserbeobachtung.Limnigraf' AS objektart,
-        'Limnigraf' AS objekttyp_anzeige, 
-        limnigraf.bezeichnung AS objektname, 
-        limnigraf.mobj_id AS objektnummer,
-        limnigraf.beschreibung AS technische_angabe,
-        limnigraf.bemerkung AS bemerkung, 
-        array_to_json(dokumente.dokumente) AS dokumente, 
-        wkb_geometry AS geometrie
-    FROM 
-        (SELECT * FROM vegas.obj_messstation WHERE objekttyp_id = 22 AND limnigraf IS TRUE AND "archive" = 0) limnigraf
-    LEFT JOIN 
-        (SELECT 
-             array_agg('https://geo.so.ch/docs/ch.so.afu.grundwasserbewirtschaftung/'||y.vegas_id||'_'||x.dokument_id||'.'||x.dateiendung) AS dokumente, 
-             y.vegas_id
-         FROM 
-             vegas.adm_dokument x, 
-             vegas.adm_objekt_dokument y 
-         WHERE 
-             x.dokument_id = y.dokument_id
-         GROUP BY 
-             y.vegas_id
-         ) dokumente ON limnigraf.vegas_id = dokumente.vegas_id );
+sondierungsbohrung AS (
+	SELECT 
+		'Grundwasserbeobachtung.Sondierung.Bohrung' AS objektart,
+		'Sondierungsbohrung' AS objekttyp_anzeige,
+		bezeichnung AS objektname,
+		objekt_id AS objektnummer,
+		beschreibung AS technische_angabe,
+		bemerkung,
+		geometrie
+	FROM
+		afu_grundwasserschutz_obj_v1.bohrung
+		WHERE piezometer = FALSE
+),
+
+piezometerbohrung AS (
+	SELECT 
+		'Grundwasserbeobachtung.Piezometer.Bohrung' AS objektart,
+		'Bohrung mit Piezometer' AS objekttyp_anzeige,
+		bezeichnung AS objektname,
+		objekt_id AS objektnummer,
+		beschreibung AS technische_angabe,
+		bemerkung,
+		geometrie
+	FROM
+		afu_grundwasserschutz_obj_v1.bohrung
+		WHERE piezometer = TRUE
+),
+
+einbaute AS (
+	SELECT 
+		'weitere_Einbauten' AS objektart,
+		'Weitere Einbauten' AS objekttyp_anzeige,
+		bezeichnung AS objektname,
+		objekt_id AS objektnummer,
+		beschreibung AS technische_angabe,
+		bemerkung,
+		geometrie
+	FROM
+		afu_grundwasserschutz_obj_v1.einbaute
+),
+
+baggerschlitz AS (
+	SELECT 
+		'Grundwasserbeobachtung.Sondierung.Baggerschlitz' AS objektart,
+		'Sondierungsbaggerschlitz' AS objekttyp_anzeige,
+		bezeichnung AS objektname,
+		objekt_id AS objektnummer,
+		beschreibung AS technische_angabe,
+		bemerkung,
+		geometrie
+	FROM
+		afu_grundwasserschutz_obj_v1.baggerschlitz
+),
+
+piezometer_gerammt AS (
+	SELECT 
+		'Grundwasserbeobachtung.Piezometer.Gerammt' AS objektart,
+		'Piezometer gerammt' AS objekttyp_anzeige,
+		bezeichnung AS objektname,
+		objekt_id AS objektnummer,
+		beschreibung AS technische_angabe,
+		bemerkung,
+		geometrie
+	FROM
+		afu_grundwasserschutz_obj_v1.piezometer_gerammt
+),
+
+versickerungsschacht AS (
+	SELECT 
+		'Versickerungsschacht' AS objektart,
+		'Versickerungsschacht' AS objekttyp_anzeige,
+		bezeichnung AS objektname,
+		objekt_id AS objektnummer,
+		beschreibung AS technische_angabe,
+		bemerkung,
+		geometrie
+	FROM
+		afu_grundwasserschutz_obj_v1.grundwasserwaermepumpe
+		WHERE schachttyp = 'Rueckgabe'
+),
+
+grundwassereinbauten AS (
+	SELECT * FROM sondierungsbohrung
+	UNION ALL
+	SELECT * FROM piezometerbohrung
+	UNION ALL
+	SELECT * FROM einbaute
+	UNION ALL
+	SELECT * FROM baggerschlitz
+	UNION ALL
+	SELECT * FROM piezometer_gerammt
+	UNION ALL
+	SELECT * FROM versickerungsschacht
+)
+
+SELECT * FROM grundwassereinbauten;

--- a/afu_wasserbewirtschaftung_pub/afu_wasserbewirtschaftung_grundwasserwaermepumpen_entnahmeschacht_pub.sql
+++ b/afu_wasserbewirtschaftung_pub/afu_wasserbewirtschaftung_grundwasserwaermepumpen_entnahmeschacht_pub.sql
@@ -1,41 +1,59 @@
-SELECT 
-    CASE 
-        WHEN (objekt.aufnahmedatum < (SELECT date('now') - interval '5 years') AND grundwasserwaerme.zustand = 4) 
-            THEN 'alte_Voranfrage' 
-        WHEN (objekt.aufnahmedatum >= (SELECT date('now') - interval '5 years') AND grundwasserwaerme.zustand = 4) 
-            THEN 'neue_Voranfrage' 
-        WHEN (grundwasserwaerme.schachttyp != 2 AND grundwasserwaerme.zustand != 4) 
-            THEN 'bewilligt'
-        ELSE 'unbekannter_Verfahrensstand'
-    END AS verfahrensstand, 
-    'Grundwasserwärmepumpen Entnahmeschacht' AS objekttyp_anzeige,
-    grundwasserwaerme.bezeichnung AS objektname, 
-    grundwasserwaerme.mobj_id AS objektnummer, 
-    grundwasserwaerme.beschreibung AS technische_angabe, 
-    grundwasserwaerme.bemerkung AS bemerkung, 
-    array_to_json(dokumente.dokumente) AS dokumente, 
-    grundwasserwaerme.wkb_geometry AS geometrie
-FROM 
-    vegas.obj_grundwasserwaerme grundwasserwaerme,
-    vegas.obj_objekt objekt
-LEFT JOIN 
-    (SELECT 
-         array_agg('https://geo.so.ch/docs/ch.so.afu.grundwasserbewirtschaftung/'||y.vegas_id||'_'||x.dokument_id||'.'||x.dateiendung) AS dokumente, 
-         y.vegas_id
-     FROM 
-         vegas.adm_dokument x, 
-         vegas.adm_objekt_dokument y 
-     WHERE x.dokument_id = y.dokument_id
-     GROUP BY y.vegas_id) dokumente ON objekt.vegas_id = dokumente.vegas_id
-WHERE 
-    grundwasserwaerme.mobj_id = objekt.mobj_id
-    AND 
-    objekt.objekttyp_id = 18
-    AND 
-    -- Da der Verfahrensstand zwingend gegeben sein muss, muss sichergestellt werden, dass dieser keinen NULL-Wert enthält! 
-    ((grundwasserwaerme.zustand = 4) OR (grundwasserwaerme.schachttyp != 2))
-    AND 
-    objekt."archive" = 0 
-    AND 
-    grundwasserwaerme."archive" = 0
-;
+WITH
+
+nvoranfrage AS (
+	SELECT 
+	'neue_Voranfrage' AS verfahrensstand,
+	'Grundwasserwärmepumpen Entnahmeschacht' AS objekttyp_anzeige,
+	bezeichnung AS objektname,
+	objekt_id AS objektnummer,
+	beschreibung AS technische_angabe,
+	bemerkung,
+	geometrie
+	FROM afu_grundwasserschutz_obj_v1.grundwasserwaermepumpe
+	WHERE schachttyp != 'Rueckgabe'
+	AND
+	zustand = 'Voranfrage'
+	AND
+	aufnahmedatum >= current_date - INTERVAL '5 years'
+),
+
+avoranfrage AS (
+	SELECT  
+	'alte_Voranfrage' AS verfahrensstand,
+	'Grundwasserwärmepumpen Entnahmeschacht' AS objekttyp_anzeige,
+	bezeichnung AS objektname,
+	objekt_id AS objektnummer,
+	beschreibung AS technische_angabe,
+	bemerkung,
+	geometrie	
+	FROM afu_grundwasserschutz_obj_v1.grundwasserwaermepumpe
+	WHERE schachttyp != 'Rueckgabe'
+	AND
+	zustand = 'Voranfrage'
+	AND
+	aufnahmedatum < current_date - INTERVAL '5 years'
+),
+
+bewilligt AS (
+	SELECT
+	'bewilligt' AS verfahrensstand,
+	'Grundwasserwärmepumpen Entnahmeschacht' AS objekttyp_anzeige,
+	bezeichnung AS objektname,
+	objekt_id AS objektnummer,
+	beschreibung AS technische_angabe,
+	bemerkung,
+	geometrie	
+	FROM afu_grundwasserschutz_obj_v1.grundwasserwaermepumpe
+	WHERE schachttyp != 'Rueckgabe'
+	AND zustand = 'in_Betrieb'
+),
+
+gwwpumpe_entnahme AS(
+	SELECT * FROM nvoranfrage
+	UNION ALL
+	SELECT * FROM avoranfrage
+	UNION ALL
+	SELECT * from bewilligt
+)
+
+SELECT * FROM gwwpumpe_entnahme

--- a/afu_wasserbewirtschaftung_pub/afu_wasserbewirtschaftung_quellen_pub.sql
+++ b/afu_wasserbewirtschaftung_pub/afu_wasserbewirtschaftung_quellen_pub.sql
@@ -1,80 +1,30 @@
-(SELECT 
-    TRUE AS gefasst,
-    NULL AS eigentuemer, 
-    a.min_schuettung, 
-    a.max_schuettung,
-    coalesce(a.schutzzone,FALSE) AS schutzzone, 
-    CASE 
-        WHEN a.nutzungsart_schutzzone = 3 
-        THEN 'privat'
-        WHEN a.nutzungsart_schutzzone = 2 
-        THEN 'privat_oeffentliches_Interesse'
-        WHEN a.nutzungsart_schutzzone = 1 
-        THEN 'oeffentlich'
-    END AS nutzungstyp, 
-    CASE 
-        WHEN a.verwendung = 1 
-        THEN 'Trinkwasser' 
-        WHEN a.verwendung = 2 
-        THEN 'Brauchwasser'
-        WHEN a.verwendung = 3
-        THEN 'Notbrunnen'
-    END AS verwendungszweck,
-    CASE 
-        WHEN a.nutzungsart_schutzzone = 3
-        THEN 'Gefasste Quelle mit privater Nutzung'
-        WHEN a.nutzungsart_schutzzone = 2
-        THEN 'Gefasste Quelle mit privater Nutzung von öffentlichem Interesse'
-        WHEN a.nutzungsart_schutzzone = 1
-        THEN 'Gefasste Quelle für die öffentliche Wasserversorgung'
-        WHEN a.nutzungsart_schutzzone IS NULL OR a.nutzungsart_schutzzone > 3 
-        THEN 'Gefasste Quelle'
-    END AS objekttyp_anzeige,
-    a.bezeichnung AS objektname, 
-    a.mobj_id AS objektnummer,
-    a.beschreibung AS technische_angabe,
-    a.bemerkung AS bemerkung, 
-    array_to_json(c.dokumente) AS dokumente, 
-    a.wkb_geometry AS geometrie
-FROM 
-    vegas.obj_quelle_gefasst a 
-LEFT JOIN 
-    (SELECT 
-         array_agg('https://geo.so.ch/docs/ch.so.afu.grundwasserbewirtschaftung/'||y.vegas_id||'_'||x.dokument_id||'.'||x.dateiendung) AS dokumente, 
-         y.vegas_id
-     FROM 
-         vegas.adm_dokument x, 
-         vegas.adm_objekt_dokument y 
-     WHERE x.dokument_id = y.dokument_id
-     GROUP BY y.vegas_id) c ON a.vegas_id = c.vegas_id
-WHERE a.archive = 0
-)
-UNION ALL 
-(SELECT 
-    FALSE AS gefasst, 
-    NULL AS eigentuemer, 
-    a.min_schuettung, 
-    a.max_schuettung, 
-    coalesce(a.schutzzone, FALSE) AS schutzzone,
-    NULL AS nutzungstyp, --Die nicht gefassten Quellen werden logischerweise auch nicht genutzt. 
-    NULL AS verwendungszweck, --Nicht gefasste Quellen werden nicht verwendet. 
-    'ungefasste Quelle' AS objekttyp_anzeige,
-    a.bezeichnung AS objektname, 
-    a.mobj_id AS objektnummer, 
-    a.beschreibung AS technische_angabe,
-    a.bemerkung AS bemerkung, 
-    array_to_json(c.dokumente) AS dokumente, 
-    a.wkb_geometry AS geometrie
- FROM 
-    vegas.obj_quelle a
-LEFT JOIN 
-    (SELECT 
-         array_agg('https://geo.so.ch/docs/ch.so.afu.grundwasserbewirtschaftung/'||y.vegas_id||'_'||x.dokument_id||'.'||x.dateiendung) AS dokumente, 
-         y.vegas_id
-     FROM 
-         vegas.adm_dokument x, 
-         vegas.adm_objekt_dokument y 
-     WHERE x.dokument_id = y.dokument_id
-     GROUP BY y.vegas_id) c ON a.vegas_id = c.vegas_id
-WHERE a.archive = 0
-);
+SELECT
+	 TRUE AS gefasst,
+	 NULL AS eigentuemer,
+	 minimale_schuettung AS min_schuettung,
+	 maximale_schuettung AS max_schuettung,
+	 schutzzone,
+	 CASE nutzungsart
+	 	WHEN 'Oeffentliche_Fassung' THEN 'oeffentlich'
+	 	WHEN 'Private_Fassung' THEN 'privat'
+	 	WHEN 'Private_Fassung_von_oeffentlichem_Interesse' THEN 'privat_oeffentliches_Interesse'
+	 	ELSE NULL
+	 END AS nutzungstyp,
+	 CASE verwendung 
+	 	WHEN 'Trinkwasser' THEN 'Trinkwasser'
+	 	WHEN 'Brauchwasser' THEN 'Brauchwasser'
+	 	WHEN 'Notbrunnen' THEN 'Notbrunnen'
+	 	ELSE NULL
+	 END AS verwendungszweck,
+	 CASE nutzungsart 
+	 	WHEN 'Oeffentliche_Fassung' THEN 'Gefasste Quelle für die öffentliche Wasserversorgung'
+	 	WHEN 'Private_Fassung' THEN 'Gefasste Quelle mit privater Nutzung'
+	 	WHEN 'Private_Fassung_von_oeffentlichem_Interesse' THEN 'Gefasste Quelle mit privater Nutzung von öffentlichem Interesse'
+	 	ELSE 'Gefasste Quelle'
+	 END AS objekttyp_anzeige,
+	 bezeichnung AS objektname,
+	 objekt_id AS objektnummer,
+	 beschreibung AS technische_angabe,
+	 bemerkung,
+	 geometrie
+FROM afu_wasserversorg_obj_v1.quelle_gefasst;

--- a/afu_wasserbewirtschaftung_pub/afu_wasserbewirtschaftung_trinkwasserobjekte_pub.sql
+++ b/afu_wasserbewirtschaftung_pub/afu_wasserbewirtschaftung_trinkwasserobjekte_pub.sql
@@ -1,136 +1,167 @@
-(SELECT 
-    'Kontrollschacht' AS trinkwasserobjektart,
-    'Kontrollschacht' AS objekttyp_anzeige,
-    kontrollschacht.bezeichnung AS objektname, 
-    kontrollschacht.mobj_id AS objektnummer,
-    kontrollschacht.beschreibung AS technische_angabe,
-    kontrollschacht.bemerkung AS bemerkung,   
-    array_to_json(dokumente.dokumente) AS dokumente, 
-    kontrollschacht.wkb_geometry AS geometrie
-FROM 
-    vegas.obj_kontrollschacht kontrollschacht
-LEFT JOIN 
-    (SELECT 
-         array_agg('https://geo.so.ch/docs/ch.so.afu.grundwasserbewirtschaftung/'||y.vegas_id||'_'||x.dokument_id||'.'||x.dateiendung) AS dokumente, 
-         y.vegas_id
-     FROM 
-         vegas.adm_dokument x, 
-         vegas.adm_objekt_dokument y 
-     WHERE x.dokument_id = y.dokument_id
-     GROUP BY y.vegas_id) dokumente ON kontrollschacht.vegas_id = dokumente.vegas_id
-WHERE archive = 0
-) 
-UNION ALL 
-(SELECT 
-    'Sammelbrunnenstube' AS trinkwasserobjektart,
-    'Sammelbrunnenstube' AS objekttyp_anzeige,
-    sammelbrunnenstube.bezeichnung AS objektname, 
-    sammelbrunnenstube.mobj_id AS objektnummer, 
-    sammelbrunnenstube.beschreibung AS technische_angabe,
-    sammelbrunnenstube.bemerkung AS bemerkung, 
-    array_to_json(dokumente.dokumente) AS dokumente,
-    sammelbrunnenstube.wkb_geometry AS geometrie
-FROM 
-    vegas.obj_sammelbrunnstube sammelbrunnenstube
-LEFT JOIN 
-    (SELECT 
-         array_agg('https://geo.so.ch/docs/ch.so.afu.grundwasserbewirtschaftung/'||y.vegas_id||'_'||x.dokument_id||'.'||x.dateiendung) AS dokumente, 
-         y.vegas_id
-     FROM 
-         vegas.adm_dokument x, 
-         vegas.adm_objekt_dokument y 
-     WHERE x.dokument_id = y.dokument_id
-     GROUP BY y.vegas_id) dokumente ON sammelbrunnenstube.vegas_id = dokumente.vegas_id
-WHERE archive = 0
-) 
-UNION ALL 
-(SELECT 
-    'Quellwasserbehaelter' AS trinkwasserobjektart,
-    'Quellwasserbehälter' AS objekttyp_anzeige,
-    quellwasserbehaelter.bezeichnung AS objektname, 
-    quellwasserbehaelter.mobj_id AS objektnummer, 
-    quellwasserbehaelter.beschreibung AS technische_angabe,
-    quellwasserbehaelter.bemerkung AS bemerkung, 
-    array_to_json(dokumente.dokumente) AS dokumente, 
-    quellwasserbehaelter.wkb_geometry AS geometrie
-FROM 
-    vegas.obj_quellwasserbehaelter quellwasserbehaelter
-LEFT JOIN 
-    (SELECT 
-         array_agg('https://geo.so.ch/docs/ch.so.afu.grundwasserbewirtschaftung/'||y.vegas_id||'_'||x.dokument_id||'.'||x.dateiendung) AS dokumente, 
-         y.vegas_id
-     FROM 
-         vegas.adm_dokument x, 
-         vegas.adm_objekt_dokument y 
-     WHERE x.dokument_id = y.dokument_id
-     GROUP BY y.vegas_id) dokumente ON Quellwasserbehaelter.vegas_id = dokumente.vegas_id
-WHERE archive = 0
-) 
-UNION ALL
-(SELECT 
-    'Netzmessstelle' AS trinkwasserobjektart,
-    'Netzmessstelle' AS objekttyp_anzeige,
-    netzmessstelle.bezeichnung AS objektname, 
-    netzmessstelle.mobj_id AS objektnummer, 
-    netzmessstelle.beschreibung AS technische_angabe,
-    netzmessstelle.bemerkung AS bemerkung, 
-    array_to_json(dokumente.dokumente) AS dokumente, 
-    netzmessstelle.wkb_geometry AS geometrie
-FROM 
-    vegas.obj_netzmessstelle netzmessstelle
-LEFT JOIN 
-    (SELECT 
-         array_agg('https://geo.so.ch/docs/ch.so.afu.grundwasserbewirtschaftung/'||y.vegas_id||'_'||x.dokument_id||'.'||x.dateiendung) AS dokumente, 
-         y.vegas_id
-     FROM 
-         vegas.adm_dokument x, 
-         vegas.adm_objekt_dokument y 
-     WHERE x.dokument_id = y.dokument_id
-     GROUP BY y.vegas_id) dokumente ON netzmessstelle.vegas_id = dokumente.vegas_id
-WHERE archive = 0
-) 
-UNION ALL 
-(SELECT 
-    'Pumpwerk' AS trinkwasserobjektart,
-    'Pumpwerk' AS objekttyp_anzeige,
-    pumpwerk.bezeichnung AS objektname, 
-    pumpwerk.mobj_id AS objektnummer, 
-    pumpwerk.beschreibung AS technische_angabe,
-    pumpwerk.bemerkung AS bemerkung, 
-    array_to_json(dokumente.dokumente) AS dokumente, 
-    pumpwerk.wkb_geometry AS geometrie
-FROM 
-    vegas.obj_pumpwerk pumpwerk
-LEFT JOIN 
-    (SELECT 
-         array_agg('https://geo.so.ch/docs/ch.so.afu.grundwasserbewirtschaftung/'||y.vegas_id||'_'||x.dokument_id||'.'||x.dateiendung) AS dokumente, 
-         y.vegas_id
-     FROM 
-         vegas.adm_dokument x, 
-         vegas.adm_objekt_dokument y 
-     WHERE x.dokument_id = y.dokument_id
-     GROUP BY y.vegas_id) dokumente ON pumpwerk.vegas_id = dokumente.vegas_id
-WHERE archive = 0
+WITH
+
+ dokument_new AS (
+ SELECT
+    d.dateiname,
+    fd.filterbrunnen_r,
+    kd.kontrollschacht_r,
+    pd.pumpwerk_r,
+    qgd.quelle_gefasst_r,
+    qd.quellwasserbehaelter_r,
+    rd.reservoir_r,
+    sd.sammelbrunnstube_r
+    FROM afu_wasserversorg_obj_v1.dokument d
+    LEFT JOIN afu_wasserversorg_obj_v1.filterbrunnen__dokument fd  ON d.t_id = fd.dokument_r
+    LEFT JOIN afu_wasserversorg_obj_v1.kontrollschacht__dokument kd  ON d.t_id = kd.dokument_r
+    LEFT JOIN afu_wasserversorg_obj_v1.pumpwerk__dokument pd ON d.t_id = pd.dokument_r
+    LEFT JOIN afu_wasserversorg_obj_v1.quelle_gefasst__dokument qgd  ON d.t_id = qgd.dokument_r
+    LEFT JOIN afu_wasserversorg_obj_v1.quellwasserbehaelter__dokument qd  ON d.t_id = qd.dokument_r
+    LEFT JOIN afu_wasserversorg_obj_v1.reservoir__dokument rd  ON d.t_id = rd.dokument_r
+    LEFT JOIN afu_wasserversorg_obj_v1.sammelbrunnstube__dokument sd ON d.t_id = sd.dokument_r
+),
+
+dokumente_filterbrunnen AS (
+SELECT
+	n.filterbrunnen_r,
+	concat('[',string_agg(concat('"',n.dateiname, '"'), ','),']') AS dokumente
+	FROM dokument_new n
+	GROUP BY n.filterbrunnen_r
+),
+
+dokumente_kontrollschacht AS (
+SELECT
+	n.kontrollschacht_r,
+	concat('[',string_agg(concat('"',n.dateiname, '"'), ','),']') AS dokumente
+	FROM dokument_new n
+	GROUP BY n.kontrollschacht_r
+),
+
+dokumente_pumpwerk AS (
+SELECT
+	n.pumpwerk_r,
+	concat('[',string_agg(concat('"',n.dateiname, '"'), ','),']') AS dokumente
+	FROM dokument_new n
+	GROUP BY n.pumpwerk_r
+),
+
+dokumente_quelle_gefasst AS (
+SELECT
+	n.quelle_gefasst_r,
+	concat('[',string_agg(concat('"',n.dateiname, '"'), ','),']') AS dokumente
+	FROM dokument_new n
+	GROUP BY n.quelle_gefasst_r
+),
+
+dokumente_quellwasserbehaelter AS (
+SELECT
+	n.quellwasserbehaelter_r,
+	concat('[',string_agg(concat('"',n.dateiname, '"'), ','),']') AS dokumente
+	FROM dokument_new n
+	GROUP BY n.quellwasserbehaelter_r
+),
+
+dokumente_reservoir AS (
+SELECT
+	n.reservoir_r,
+	concat('[',string_agg(concat('"',n.dateiname, '"'), ','),']') AS dokumente
+	FROM dokument_new n
+	GROUP BY n.reservoir_r
+),
+
+dokumente_sammelbrunnstube AS (
+SELECT
+	n.sammelbrunnstube_r,
+	concat('[',string_agg(concat('"',n.dateiname, '"'), ','),']') AS dokumente
+	FROM dokument_new n
+	GROUP BY n.sammelbrunnstube_r
+),
+
+pumpwerk AS (
+	SELECT 
+		'Pumpwerk' AS trinkwasserobjektart,
+		'Pumpwerk' AS objekttyp_anzeige,
+		bezeichnung AS objektname,
+		objekt_id AS objektnummer,
+		beschreibung AS technische_angabe,
+		bemerkung,
+		dp.dokumente,
+		geometrie
+	FROM
+		afu_wasserversorg_obj_v1.pumpwerk
+		LEFT JOIN dokumente_pumpwerk dp ON t_id = dp.pumpwerk_r
+),
+
+reservoir AS (
+	SELECT
+		'Reservoir' AS trinkwasserobjektart,
+		'Reservoir' AS objekttyp_anzeige,
+		bezeichnung AS objektname,
+		objekt_id AS objektnummer,
+		beschreibung AS technische_angabe,
+		bemerkung,
+		dr.dokumente,
+		geometrie
+	FROM
+		afu_wasserversorg_obj_v1.reservoir
+		LEFT JOIN dokumente_reservoir dr ON t_id = dr.reservoir_r
+),
+
+sammelbrunnstube AS (
+	SELECT
+		'Sammelbrunnstube' AS trinkwasserobjektart,
+		'Sammelbrunnstube' AS objekttyp_anzeige,
+		bezeichnung AS objektname,
+		objekt_id AS objektnummer,
+		beschreibung AS technische_angabe,
+		bemerkung,
+		ds.dokumente,
+		geometrie
+	FROM
+		afu_wasserversorg_obj_v1.sammelbrunnstube
+		LEFT JOIN dokumente_sammelbrunnstube ds ON t_id = ds.sammelbrunnstube_r
+),
+
+kontrollschacht AS (
+	SELECT
+		'Kontrollschacht' AS trinkwasserobjektart,
+		'Kontrollschacht' AS objekttyp_anzeige,
+		bezeichnung AS objektname,
+		objekt_id AS objektnummer,
+		beschreibung AS technische_angabe,
+		bemerkung,
+		dk.dokumente,
+		geometrie
+	FROM
+		afu_wasserversorg_obj_v1.kontrollschacht
+		LEFT JOIN dokumente_kontrollschacht dk ON t_id = dk.kontrollschacht_r
+),
+
+quellwasserbehaelter AS (
+	SELECT
+		'Quellwasserbehaelter' AS trinkwasserobjektart,
+		'Quellwasserbehälter' AS objekttyp_anzeige,
+		bezeichnung AS objektname,
+		objekt_id AS objektnummer,
+		beschreibung AS technische_angabe,
+		bemerkung,
+		dq.dokumente,
+		geometrie
+	FROM
+		afu_wasserversorg_obj_v1.quellwasserbehaelter
+		LEFT JOIN dokumente_quellwasserbehaelter dq ON t_id = dq.quellwasserbehaelter_r
+),
+
+trinkwasserversorgung AS (
+	SELECT * FROM pumpwerk
+	UNION ALL
+	SELECT * FROM reservoir
+	UNION ALL
+	SELECT * FROM sammelbrunnstube
+	UNION ALL
+	SELECT * FROM kontrollschacht
+	UNION ALL
+	SELECT * FROM quellwasserbehaelter
 )
-UNION ALL 
-(SELECT 
-    'Reservoir' AS trinkwasserobjektart,
-    'Reservoir' AS objekttyp_anzeige,
-    reservoir.bezeichnung AS objektname, 
-    reservoir.mobj_id AS objektnummer, 
-    reservoir.beschreibung AS technische_angabe,
-    reservoir.bemerkung AS bemerkung, 
-    array_to_json(dokumente.dokumente) AS dokumente, 
-    reservoir.wkb_geometry AS geometrie
-FROM 
-    vegas.obj_reservoir reservoir
-LEFT JOIN 
-    (SELECT 
-         array_agg('https://geo.so.ch/docs/ch.so.afu.grundwasserbewirtschaftung/'||y.vegas_id||'_'||x.dokument_id||'.'||x.dateiendung) AS dokumente, 
-         y.vegas_id
-     FROM 
-         vegas.adm_dokument x, 
-         vegas.adm_objekt_dokument y 
-     WHERE x.dokument_id = y.dokument_id
-     GROUP BY y.vegas_id) dokumente ON reservoir.vegas_id = dokumente.vegas_id
-WHERE archive = 0)
+
+SELECT * FROM trinkwasserversorgung;
+

--- a/afu_wasserbewirtschaftung_pub/build.gradle
+++ b/afu_wasserbewirtschaftung_pub/build.gradle
@@ -3,26 +3,20 @@ import ch.so.agi.gretl.api.TransferSet
 
 apply plugin: 'ch.so.agi.gretl'
 
-defaultTasks 'refreshSolr'
+defaultTasks 'transferAfuWasserbewirtschaftung'
 
 task transferAfuWasserbewirtschaftung(type: Db2Db){
-    sourceDb = [dbUriSogis, dbUserSogis, dbPwdSogis]
+    sourceDb = [dbUriEdit, dbUserEdit, dbPwdEdit]
     targetDb = [dbUriPub, dbUserPub, dbPwdPub]
     transferSets = [
             new TransferSet('afu_wasserbewirtschaftung_fassung_pub.sql', 'afu_wasserbewirtschaftung_pub_v1.wassrbwrtschftung_fassung', true),
             new TransferSet('afu_wasserbewirtschaftung_grundwassereinbauten_pub.sql', 'afu_wasserbewirtschaftung_pub_v1.wassrbwrtschftung_grundwassereinbau', true),
             new TransferSet('afu_wasserbewirtschaftung_grundwasserwaermepumpen_entnahmeschacht_pub.sql', 'afu_wasserbewirtschaftung_pub_v1.wassrbwrtschftung_grundwasserwaermepumpen_entnahmeschacht', true),
             new TransferSet('afu_wasserbewirtschaftung_quellen_pub.sql', 'afu_wasserbewirtschaftung_pub_v1.wassrbwrtschftung_quelle', true),
-            new TransferSet('afu_wasserbewirtschaftung_trinkwasserobjekte_pub.sql', 'afu_wasserbewirtschaftung_pub_v1.wassrbwrtschftung_trinkwasserversorgung', true), 
-            new TransferSet('afu_wasserbewirtschaftung_oberflaechenhydrometrie.sql', 'afu_wasserbewirtschaftung_pub_v1.wassrbwrtschftung_oberflaechenhydrometrie', true)
+            new TransferSet('afu_wasserbewirtschaftung_trinkwasserobjekte_pub.sql', 'afu_wasserbewirtschaftung_pub_v1.wassrbwrtschftung_trinkwasserversorgung', true)
     ];
 }
 
-task clean(type: SqlExecutor, dependsOn: transferAfuWasserbewirtschaftung) {
-    database = [dbUriPub, dbUserPub, dbPwdPub]
-    sqlFiles = ['clean.sql']
-}
-
-task refreshSolr(type:Exec, dependsOn:'clean') {
+task refreshSolr(type:Exec, dependsOn: transferAfuWasserbewirtschaftungean) {
 	commandLine 'curl', '-i', '--max-time', '20', solrIndexupdaterBaseUrl + '/queue?ds=ch.so.afu.gewaesserschutz.quellen,ch.so.afu.wasserbewirtschaftung.quellen,ch.so.afu.gewaesserschutz.fassungen,ch.so.afu.wasserbewirtschaftung.fassung,ch.so.afu.wasserbewirtschaftung.sondierung,ch.so.afu.wasserbewirtschaftung.versickerungsschacht,ch.so.afu.wasserbewirtschaftung.grundwasserwaermenutzung,ch.so.afu.wasserbewirtschaftung.trinkwasserversorgung_geschuetzt,ch.so.afu.wasserbewirtschaftung.weitere_einbauten_geschuetzt,ch.so.afu.wasserbewirtschaftung.quellen_geschuetzt,ch.so.afu.wasserbewirtschaftung.sondierung_geschuetzt,ch.so.afu.wasserbewirtschaftung.fassung_geschuetzt,ch.so.afu.wasserbewirtschaftung.versickerungsschacht_geschuetzt,ch.so.afu.wasserbewirtschaftung.grundwasserwaermenutzung_geschuetzt'
 }


### PR DESCRIPTION
Anpassung des pub-Schemas "afu_wasserbewirtschaftung_pub" auf die beiden edit-Schemas "afu_grundwasserschutz_obj_v1" und "afu_wasserversorg_obj_v1".

- Die Tabelle "afu_wasserbewirtschaftung_pub.wassrbwrtschftung_oberflaechenhydrometrie" konnte nicht angepasst werden, da die Attribute so nicht mehr existieren oder in einer anderen Form geführt werden. Einige Attribute können in der Tabelle "afu_hydro_messstationen_v1.messstationen" gefunden werden, aber längst nicht alle.
- > Muss mit afu abgeklärt werden
- Die Spalte "dokumente" für das pub-Schema wird testweise nur in der sql-Datei "afu_wasserbewirtschaftung_trinkwasserobjekte_pub.sql" befüllt. Bitte prüfen. Die Anpassungen werden anschliessend auch analog für die anderen sql-Dateien übernommen. 