### PR TITLE
Globally disable concurrent builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,6 @@
 pipeline {
     agent { label params.nodeLabel ?: 'gretl' }
     options {
-        disableConcurrentBuilds()
         timeout(time: 6, unit: 'HOURS')
     }
     stages {

--- a/afu_abbaustellen_pub/Jenkinsfile
+++ b/afu_abbaustellen_pub/Jenkinsfile
@@ -1,7 +1,6 @@
 pipeline {
     agent { label params.nodeLabel ?: 'gretl' }
     options {
-        disableConcurrentBuilds()
         timeout(time: 6, unit: 'HOURS')
     }
     stages {

--- a/afu_ewsabfrage_3d/Jenkinsfile
+++ b/afu_ewsabfrage_3d/Jenkinsfile
@@ -19,7 +19,6 @@ node('master') {
 pipeline {
     agent { label params.nodeLabel ?: 'gretl' }
     options {
-        disableConcurrentBuilds()
         timeout(time: 6, unit: 'HOURS')
     }
     stages {

--- a/afu_gefahrenkartierung_pub_export_ai/Jenkinsfile
+++ b/afu_gefahrenkartierung_pub_export_ai/Jenkinsfile
@@ -19,7 +19,6 @@ pipeline {
         }
     }
     options {
-        disableConcurrentBuilds()
         timeout(time: 6, unit: 'HOURS')
     }
     stages {

--- a/afu_gewaesserschutz_zonen_areale_pub/Jenkinsfile
+++ b/afu_gewaesserschutz_zonen_areale_pub/Jenkinsfile
@@ -1,7 +1,6 @@
 pipeline {
     agent none
     options {
-        disableConcurrentBuilds()
         timeout(time: 7, unit: 'DAYS')
     }
     stages {

--- a/afu_isboden_csv_import/Jenkinsfile
+++ b/afu_isboden_csv_import/Jenkinsfile
@@ -19,7 +19,6 @@ node('master') {
 pipeline {
     agent { label params.nodeLabel ?: 'gretl' }
     options {
-        disableConcurrentBuilds()
         timeout(time: 6, unit: 'HOURS')
     }
     stages {

--- a/afu_nabodat_import/Jenkinsfile
+++ b/afu_nabodat_import/Jenkinsfile
@@ -19,7 +19,6 @@ node('master') {
 pipeline {
     agent { label params.nodeLabel ?: 'gretl' }
     options {
-        disableConcurrentBuilds()
         timeout(time: 6, unit: 'HOURS')
     }
     stages {

--- a/afu_naturgefahren_pilot_import/Jenkinsfile
+++ b/afu_naturgefahren_pilot_import/Jenkinsfile
@@ -25,7 +25,6 @@ node('master') {
 pipeline {
     agent { label params.nodeLabel ?: 'gretl' }
     options {
-        disableConcurrentBuilds()
         timeout(time: 6, unit: 'HOURS')
     }
     stages {

--- a/afu_oekomorphologie_csvimport/Jenkinsfile
+++ b/afu_oekomorphologie_csvimport/Jenkinsfile
@@ -19,7 +19,6 @@ node('master') {
 pipeline {
     agent { label params.nodeLabel ?: 'gretl' }
     options {
-        disableConcurrentBuilds()
         timeout(time: 6, unit: 'HOURS')
     }
     stages {

--- a/agi_av_dm01_mopublic_pub/Jenkinsfile
+++ b/agi_av_dm01_mopublic_pub/Jenkinsfile
@@ -18,7 +18,6 @@ pipeline {
         }
     }
     options {
-        disableConcurrentBuilds()
         timeout(time: 6, unit: 'HOURS')
     }
     stages {

--- a/agi_av_export_ai/Jenkinsfile
+++ b/agi_av_export_ai/Jenkinsfile
@@ -1,7 +1,6 @@
 pipeline {
     agent { label params.nodeLabel ?: 'gretl' }
     options {
-        disableConcurrentBuilds()
         timeout(time: 6, unit: 'HOURS')
     }
     stages {

--- a/agi_av_export_jahresstand_ai/Jenkinsfile
+++ b/agi_av_export_jahresstand_ai/Jenkinsfile
@@ -1,7 +1,6 @@
 pipeline {
     agent { label 'master' }
     options {
-        disableConcurrentBuilds()
         timeout(time: 6, unit: 'HOURS')
     }
     stages {

--- a/agi_check_ili_export/Jenkinsfile
+++ b/agi_check_ili_export/Jenkinsfile
@@ -18,7 +18,6 @@ pipeline {
         }
     }
     options {
-        disableConcurrentBuilds()
         timeout(time: 6, unit: 'HOURS')
     }
     stages {

--- a/agi_layer_rollout/Jenkinsfile
+++ b/agi_layer_rollout/Jenkinsfile
@@ -1,7 +1,6 @@
 pipeline {
     agent { label params.nodeLabel ?: 'gretl' }
     options {
-        disableConcurrentBuilds()
         timeout(time: 6, unit: 'HOURS')
     }
     stages {

--- a/alw_fruchtfolgeflaechen/Jenkinsfile
+++ b/alw_fruchtfolgeflaechen/Jenkinsfile
@@ -1,6 +1,5 @@
 pipeline {
     options {
-        disableConcurrentBuilds()
         timeout(time: 1, unit: 'DAYS')
     }
     agent {

--- a/arp_mjpnl_auszahlung/Jenkinsfile
+++ b/arp_mjpnl_auszahlung/Jenkinsfile
@@ -1,7 +1,6 @@
 pipeline {
     agent { label params.nodeLabel ?: 'gretl' }
     options {
-        disableConcurrentBuilds()
         timeout(time: 6, unit: 'HOURS')
     }
     stages {

--- a/arp_mjpnl_initialisierung/Jenkinsfile
+++ b/arp_mjpnl_initialisierung/Jenkinsfile
@@ -19,7 +19,6 @@ node('master') {
 pipeline {
     agent { label params.nodeLabel ?: 'gretl' }
     options {
-        disableConcurrentBuilds()
         timeout(time: 6, unit: 'HOURS')
     }
     stages {

--- a/arp_mjpnl_zahlungslauf/Jenkinsfile
+++ b/arp_mjpnl_zahlungslauf/Jenkinsfile
@@ -1,7 +1,6 @@
 pipeline {
     agent { label params.nodeLabel ?: 'gretl' }
     options {
-        disableConcurrentBuilds()
         timeout(time: 6, unit: 'HOURS')
     }
     stages {

--- a/arp_naturreservate_pub/Jenkinsfile
+++ b/arp_naturreservate_pub/Jenkinsfile
@@ -1,7 +1,6 @@
 pipeline {
     agent none
     options {
-        disableConcurrentBuilds()
         timeout(time: 7, unit: 'DAYS')
     }
     stages {

--- a/arp_nutzungsplanung_delete_dataset/Jenkinsfile
+++ b/arp_nutzungsplanung_delete_dataset/Jenkinsfile
@@ -1,7 +1,6 @@
 pipeline {
     agent { label params.nodeLabel ?: 'gretl' }
     options {
-        disableConcurrentBuilds()
         timeout(time: 6, unit: 'HOURS')
     }
     stages {

--- a/arp_nutzungsplanung_import/Jenkinsfile
+++ b/arp_nutzungsplanung_import/Jenkinsfile
@@ -25,7 +25,6 @@ node('master') {
 pipeline {
     agent { label params.nodeLabel ?: 'gretl' }
     options {
-        disableConcurrentBuilds()
         timeout(time: 6, unit: 'HOURS')
     }
     stages {

--- a/arp_nutzungsplanung_import_ersterfassung/Jenkinsfile
+++ b/arp_nutzungsplanung_import_ersterfassung/Jenkinsfile
@@ -25,7 +25,6 @@ node('master') {
 pipeline {
     agent { label params.nodeLabel ?: 'gretl' }
     options {
-        disableConcurrentBuilds()
         timeout(time: 6, unit: 'HOURS')
     }
     stages {

--- a/arp_nutzungsplanung_kanton_pub/Jenkinsfile
+++ b/arp_nutzungsplanung_kanton_pub/Jenkinsfile
@@ -1,7 +1,6 @@
 pipeline {
     agent none
     options {
-        disableConcurrentBuilds()
         timeout(time: 7, unit: 'DAYS')
     }
     stages {

--- a/arp_nutzungsplanung_planregister_pub_alles/Jenkinsfile
+++ b/arp_nutzungsplanung_planregister_pub_alles/Jenkinsfile
@@ -1,7 +1,6 @@
 pipeline {
     agent { label params.nodeLabel ?: 'gretl' }
     options {
-        disableConcurrentBuilds()
         timeout(time: 6, unit: 'HOURS')
     }
     stages {

--- a/arp_nutzungsplanung_pub/Jenkinsfile
+++ b/arp_nutzungsplanung_pub/Jenkinsfile
@@ -1,7 +1,6 @@
 pipeline {
     agent none
     options {
-        disableConcurrentBuilds()
         timeout(time: 7, unit: 'DAYS')
     }
     stages {

--- a/arp_statent_import/Jenkinsfile
+++ b/arp_statent_import/Jenkinsfile
@@ -19,7 +19,6 @@ node('master') {
 pipeline {
     agent { label params.nodeLabel ?: 'gretl' }
     options {
-        disableConcurrentBuilds()
         timeout(time: 6, unit: 'HOURS')
     }
     stages {

--- a/arp_statpop_import/Jenkinsfile
+++ b/arp_statpop_import/Jenkinsfile
@@ -19,7 +19,6 @@ node('master') {
 pipeline {
     agent { label params.nodeLabel ?: 'gretl' }
     options {
-        disableConcurrentBuilds()
         timeout(time: 6, unit: 'HOURS')
     }
     stages {

--- a/arp_wanderwege_import_xtf/Jenkinsfile
+++ b/arp_wanderwege_import_xtf/Jenkinsfile
@@ -19,7 +19,6 @@ node('master') {
 pipeline {
     agent { label params.nodeLabel ?: 'gretl' }
     options {
-        disableConcurrentBuilds()
         timeout(time: 6, unit: 'HOURS')
     }
     stages {

--- a/avt_ausnahmetransportrouten_export_ai/Jenkinsfile
+++ b/avt_ausnahmetransportrouten_export_ai/Jenkinsfile
@@ -19,7 +19,6 @@ node('master') {
 pipeline {
     agent { label params.nodeLabel ?: 'gretl' }
     options {
-        disableConcurrentBuilds()
         timeout(time: 6, unit: 'HOURS')
     }
     stages {

--- a/avt_groblaermkataster_pub/Jenkinsfile
+++ b/avt_groblaermkataster_pub/Jenkinsfile
@@ -19,7 +19,6 @@ node('master') {
 pipeline {
     agent { label params.nodeLabel ?: 'gretl' }
     options {
-        disableConcurrentBuilds()
         timeout(time: 6, unit: 'HOURS')
     }
     stages {

--- a/avt_gvm_import/Jenkinsfile
+++ b/avt_gvm_import/Jenkinsfile
@@ -19,7 +19,6 @@ node('master') {
 pipeline {
     agent { label params.nodeLabel ?: 'gretl' }
     options {
-        disableConcurrentBuilds()
         timeout(time: 6, unit: 'HOURS')
     }
     stages {

--- a/avt_kantonsstrassen_pub/Jenkinsfile
+++ b/avt_kantonsstrassen_pub/Jenkinsfile
@@ -19,7 +19,6 @@ node('master') {
 pipeline {
     agent { label params.nodeLabel ?: 'gretl' }
     options {
-        disableConcurrentBuilds()
         timeout(time: 6, unit: 'HOURS')
     }
     stages {

--- a/avt_oev_gueteklassen_import/Jenkinsfile
+++ b/avt_oev_gueteklassen_import/Jenkinsfile
@@ -19,7 +19,6 @@ node('master') {
 pipeline {
     agent { label params.nodeLabel ?: 'gretl' }
     options {
-        disableConcurrentBuilds()
         timeout(time: 1, unit: 'DAYS')
     }
     stages {

--- a/awjf_biotopbaeume_import/Jenkinsfile
+++ b/awjf_biotopbaeume_import/Jenkinsfile
@@ -19,7 +19,6 @@ node('master') {
 pipeline {
     agent { label params.nodeLabel ?: 'gretl' }
     options {
-        disableConcurrentBuilds()
         timeout(time: 6, unit: 'HOURS')
     }
     stages {

--- a/awjf_gesuchsteller/Jenkinsfile
+++ b/awjf_gesuchsteller/Jenkinsfile
@@ -19,7 +19,6 @@ node('master') {
 pipeline {
     agent { label params.nodeLabel ?: 'gretl' }
     options {
-        disableConcurrentBuilds()
         timeout(time: 6, unit: 'HOURS')
     }
     stages {

--- a/awjf_statische_waldgrenze_pub/Jenkinsfile
+++ b/awjf_statische_waldgrenze_pub/Jenkinsfile
@@ -1,7 +1,6 @@
 pipeline {
     agent none
     options {
-        disableConcurrentBuilds()
         timeout(time: 7, unit: 'DAYS')
     }
     stages {

--- a/awjf_waldplan_bestandeskarte_import_shp/Jenkinsfile
+++ b/awjf_waldplan_bestandeskarte_import_shp/Jenkinsfile
@@ -19,7 +19,6 @@ node('master') {
 pipeline {
     agent { label params.nodeLabel ?: 'gretl' }
     options {
-        disableConcurrentBuilds()
         timeout(time: 6, unit: 'HOURS')
     }
     stages {

--- a/awjf_waldplan_bestandeskarte_staging/Jenkinsfile
+++ b/awjf_waldplan_bestandeskarte_staging/Jenkinsfile
@@ -1,7 +1,6 @@
 pipeline {
     agent { label params.nodeLabel ?: 'gretl' }
     options {
-        disableConcurrentBuilds()
         timeout(time: 6, unit: 'HOURS')
     }
     stages {

--- a/gretl_job_generator.groovy
+++ b/gretl_job_generator.groovy
@@ -54,6 +54,9 @@ for (jobFile in jobFiles) {
   def productionEnv = ("${PROJECT_NAME}" == 'agi-gretl-production')
 
   pipelineJob(jobName) {
+    properties {
+      disableConcurrentBuilds {}
+    }
     if (!productionEnv) { // we don't want the BRANCH parameter in production environment
       parameters {
         stringParam('BRANCH', 'main', 'Name of branch to check out')


### PR DESCRIPTION
Instead of disabling concurrent builds using the Jenkinsfile/Jenkinsfiles, disable it globally by defining the `disableConcurrentBuilds` property when _gretl_job_generator.groovy_ generates the job.