### PR TITLE
[arp_mjpnl_*] Jahreswechsel

### DIFF
--- a/arp_mjpnl_auszahlung/build.gradle
+++ b/arp_mjpnl_auszahlung/build.gradle
@@ -12,7 +12,7 @@ apply plugin: 'ch.so.agi.gretl'
 defaultTasks 'update_abrechnung_per_bewirtschafter'
 
 def DB_Schema_MJPNL = "arp_mjpnl_v1"
-def AUSZAHLUNGSJAHR = auszahlungsjahr ?: String.valueOf( Integer.valueOf(new SimpleDateFormat("yyyy").format(new Date()))-1 ) 
+def AUSZAHLUNGSJAHR = String.valueOf( Integer.valueOf(new SimpleDateFormat("yyyy").format(new Date()))-1 ) 
 
 task "update_abrechnung_per_leistung"(type: SqlExecutor) {
 

--- a/arp_mjpnl_auszahlung/build.gradle
+++ b/arp_mjpnl_auszahlung/build.gradle
@@ -5,12 +5,14 @@ Fragen an: Odile Bruggisser (ARP)
 """
 
 import ch.so.agi.gretl.tasks.*
+import java.text.SimpleDateFormat
+import java.util.Date
 
 apply plugin: 'ch.so.agi.gretl'
 defaultTasks 'update_abrechnung_per_bewirtschafter'
 
 def DB_Schema_MJPNL = "arp_mjpnl_v1"
-def AUSZAHLUNGSJAHR = auszahlungsjahr
+def AUSZAHLUNGSJAHR = auszahlungsjahr ?: String.valueOf( Integer.valueOf(new SimpleDateFormat("yyyy").format(new Date()))-1 ) 
 
 task "update_abrechnung_per_leistung"(type: SqlExecutor) {
 

--- a/arp_mjpnl_auszahlung/job.properties
+++ b/arp_mjpnl_auszahlung/job.properties
@@ -1,2 +1,3 @@
 parameters.stringParams=AUSZAHLUNGSJAHR;;'Year of payments (e.g.2024)' 
 authorization.permissions=gretl-users-barpa,exopesig,exopecam
+triggers.cron=H H(1-3) 15 1 *

--- a/arp_mjpnl_auszahlung/job.properties
+++ b/arp_mjpnl_auszahlung/job.properties
@@ -1,3 +1,2 @@
-parameters.stringParams=AUSZAHLUNGSJAHR;;'Year of payments (e.g.2024)' 
 authorization.permissions=gretl-users-barpa,exopesig,exopecam
 triggers.cron=H H(1-3) 15 1 *

--- a/arp_mjpnl_auszahlung/update_mjpnl_abrechnung_per_bewirtschafter.sql
+++ b/arp_mjpnl_auszahlung/update_mjpnl_abrechnung_per_bewirtschafter.sql
@@ -1,11 +1,12 @@
 /*
-Setzt Status der Abrechnungen pro Bewirtschafter auf ausbezahlt, sofern freigegeben.
+Setzt Status und Datum der Abrechnungen pro Bewirtschafter auf ausbezahlt, sofern freigegeben.
 */
 
 UPDATE
     ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_bewirtschafter
 SET
-    status_abrechnung = 'ausbezahlt'
+    status_abrechnung = 'ausbezahlt',
+    datum_abrechnung = (${AUSZAHLUNGSJAHR} || '-12-15')::date
 WHERE 
     auszahlungsjahr = ${AUSZAHLUNGSJAHR}::integer
     AND 

--- a/arp_mjpnl_auszahlung/update_mjpnl_abrechnung_per_leistung.sql
+++ b/arp_mjpnl_auszahlung/update_mjpnl_abrechnung_per_leistung.sql
@@ -1,11 +1,12 @@
 /*
-Setzt Status der Abrechnungen pro Leistung auf ausbezahlt, sofern freigegeben.
+Setzt Status und Datum der Abrechnungen pro Leistung auf ausbezahlt, sofern freigegeben.
 */
 
 UPDATE
     ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_leistung
 SET
-    status_abrechnung = 'ausbezahlt'
+    status_abrechnung = 'ausbezahlt',
+    datum_abrechnung = (${AUSZAHLUNGSJAHR} || '-12-15')::date
 WHERE 
     auszahlungsjahr = ${AUSZAHLUNGSJAHR}::integer
     AND 

--- a/arp_mjpnl_auszahlung/update_mjpnl_abrechnung_per_vereinbarung.sql
+++ b/arp_mjpnl_auszahlung/update_mjpnl_abrechnung_per_vereinbarung.sql
@@ -1,11 +1,12 @@
 /*
-Setzt Status der Abrechnungen pro Vereinbarung auf ausbezahlt, sofern freigegeben.
+Setzt Status und Datum der Abrechnungen pro Vereinbarung auf ausbezahlt, sofern freigegeben.
 */
 
 UPDATE
     ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_vereinbarung
 SET
-    status_abrechnung = 'ausbezahlt'
+    status_abrechnung = 'ausbezahlt',
+    datum_abrechnung = (${AUSZAHLUNGSJAHR} || '-12-15')::date
 WHERE 
     auszahlungsjahr = ${AUSZAHLUNGSJAHR}::integer
     AND 

--- a/arp_mjpnl_gelan_update/mjpnl_update_vereinbarungen_gelan_bewirtschafter.sql
+++ b/arp_mjpnl_gelan_update/mjpnl_update_vereinbarungen_gelan_bewirtschafter.sql
@@ -15,4 +15,7 @@ UPDATE
      )
  WHERE
   vbg.uebersteuerung_bewirtschafter IS FALSE
+  AND
+  -- nur wenn aktuelles Datum nicht zwischen dem 1. Dezember und dem 15. Januar liegt
+  (date_part('month',now()) NOT IN (1,12) OR (date_part('month',now())=1 AND date_part('day',now())>15))
 ;

--- a/arp_mjpnl_gelan_update/mjpnl_update_vereinbarungen_gelan_bewirtschaftungseinheiten.sql
+++ b/arp_mjpnl_gelan_update/mjpnl_update_vereinbarungen_gelan_bewirtschaftungseinheiten.sql
@@ -14,6 +14,9 @@ UPDATE ${DB_Schema_MJPNL}.mjpnl_vereinbarung AS vbg
       ORDER BY ST_Area(ST_Intersection(vbg.geometrie, bw.geometrie)) DESC
       LIMIT 1
     )
+    AND
+    -- nur wenn aktuelles Datum nicht zwischen dem 1. Dezember und dem 15. Januar liegt
+    (date_part('month',now()) NOT IN (1,12) OR (date_part('month',now())=1 AND date_part('day',now())>15))
 ;
 
 --GELAN Bewirtschaftungseinheit zuweisen
@@ -34,4 +37,7 @@ UPDATE
      )
  WHERE
   ST_IsValid(vbg.geometrie) = TRUE 
+  AND
+  -- nur wenn aktuelles Datum nicht zwischen dem 1. Dezember und dem 15. Januar liegt
+  (date_part('month',now()) NOT IN (1,12) OR (date_part('month',now())=1 AND date_part('day',now())>15))
 ;

--- a/arp_mjpnl_gelan_update/mjpnl_update_vereinbarungen_gelan_kulturflaechen.sql
+++ b/arp_mjpnl_gelan_update/mjpnl_update_vereinbarungen_gelan_kulturflaechen.sql
@@ -9,4 +9,7 @@ SET kultur_id=(
         ST_Intersects(kf.geometrie,vbg.geometrie)
         AND
         (ST_MaximumInscribedCircle(ST_Intersection(kf.geometrie,vbg.geometrie))).radius > 1
+WHERE
+    -- nur wenn aktuelles Datum nicht zwischen dem 1. Dezember und dem 15. Januar liegt
+    (date_part('month',now()) NOT IN (1,12) OR (date_part('month',now())=1 AND date_part('day',now())>15))
 );

--- a/arp_mjpnl_zahlungslauf/build.gradle
+++ b/arp_mjpnl_zahlungslauf/build.gradle
@@ -13,14 +13,16 @@ apply plugin: 'ch.so.agi.gretl'
 defaultTasks 'calculate_abrechnung_per_bewirtschafter'
 
 def DB_Schema_MJPNL = "arp_mjpnl_v1"
-def AUSZAHLUNGSJAHR = auszahlungsjahr ?: "2023" // new SimpleDateFormat("yyyy").format(new Date())
+/* Falls kein auszahlungsjahr übergeben wird, nimmt es bei aktuellem Datum kleiner 15. Januar noch das Vorjahr und sonst das aktuelle Jahr */
+def AUSZAHLUNGSJAHR = auszahlungsjahr ?: Integer.valueOf(new SimpleDateFormat("MM").format(new Date())) == 1 && Integer.valueOf(new SimpleDateFormat("DD").format(new Date())) < 15 ? String.valueOf( Integer.valueOf(new SimpleDateFormat("yyyy").format(new Date()))-1 ) : new SimpleDateFormat("yyyy").format(new Date())
+
 
 task "cleanup_abrechnung_per_leistung"(type: SqlExecutor) {
     description = "Löscht alle diesjährigen Leistungen (die nicht einmalig oder migriert sind) und setzt FKs auf NULL"
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     sqlParameters = [DB_Schema_MJPNL:DB_Schema_MJPNL,AUSZAHLUNGSJAHR:AUSZAHLUNGSJAHR]
     sqlFiles = ['cleanup_mjpnl_abrechnung_per_leistung.sql']
-}
+
 
 task "cleanup_abrechnung_per_leistung_orphans"(type: SqlExecutor,dependsOn: "cleanup_abrechnung_per_leistung") {
     description = "Löscht alle diesjährigen Leistungen, deren Vereinbarung manuell gelöscht wurden (was eigentlich nicht gemacht wird ausser bei Bereinigung nach Migration)"

--- a/arp_mjpnl_zahlungslauf/build.gradle
+++ b/arp_mjpnl_zahlungslauf/build.gradle
@@ -14,7 +14,7 @@ defaultTasks 'calculate_abrechnung_per_bewirtschafter'
 
 def DB_Schema_MJPNL = "arp_mjpnl_v1"
 /* Falls kein auszahlungsjahr übergeben wird, nimmt es bei aktuellem Datum kleiner 15. Januar noch das Vorjahr und sonst das aktuelle Jahr */
-def AUSZAHLUNGSJAHR = auszahlungsjahr ?: Integer.valueOf(new SimpleDateFormat("MM").format(new Date())) == 1 && Integer.valueOf(new SimpleDateFormat("DD").format(new Date())) < 15 ? String.valueOf( Integer.valueOf(new SimpleDateFormat("yyyy").format(new Date()))-1 ) : new SimpleDateFormat("yyyy").format(new Date())
+def AUSZAHLUNGSJAHR = Integer.valueOf(new SimpleDateFormat("MM").format(new Date())) == 1 && Integer.valueOf(new SimpleDateFormat("DD").format(new Date())) > 15 ? String.valueOf( Integer.valueOf(new SimpleDateFormat("yyyy").format(new Date()))+1 ) : new SimpleDateFormat("yyyy").format(new Date())
 
 
 task "cleanup_abrechnung_per_leistung"(type: SqlExecutor) {

--- a/arp_mjpnl_zahlungslauf/build.gradle
+++ b/arp_mjpnl_zahlungslauf/build.gradle
@@ -14,7 +14,7 @@ defaultTasks 'calculate_abrechnung_per_bewirtschafter'
 
 def DB_Schema_MJPNL = "arp_mjpnl_v1"
 /* Falls kein auszahlungsjahr übergeben wird, nimmt es bei aktuellem Datum kleiner 15. Januar noch das Vorjahr und sonst das aktuelle Jahr */
-def AUSZAHLUNGSJAHR = Integer.valueOf(new SimpleDateFormat("MM").format(new Date())) == 1 && Integer.valueOf(new SimpleDateFormat("DD").format(new Date())) > 15 ? String.valueOf( Integer.valueOf(new SimpleDateFormat("yyyy").format(new Date()))+1 ) : new SimpleDateFormat("yyyy").format(new Date())
+def AUSZAHLUNGSJAHR = Integer.valueOf(new SimpleDateFormat("MM").format(new Date())) == 1 && Integer.valueOf(new SimpleDateFormat("DD").format(new Date())) < 15 ? String.valueOf( Integer.valueOf(new SimpleDateFormat("yyyy").format(new Date()))-1 ) : new SimpleDateFormat("yyyy").format(new Date())
 
 
 task "cleanup_abrechnung_per_leistung"(type: SqlExecutor) {

--- a/arp_mjpnl_zahlungslauf/build.gradle
+++ b/arp_mjpnl_zahlungslauf/build.gradle
@@ -22,7 +22,7 @@ task "cleanup_abrechnung_per_leistung"(type: SqlExecutor) {
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     sqlParameters = [DB_Schema_MJPNL:DB_Schema_MJPNL,AUSZAHLUNGSJAHR:AUSZAHLUNGSJAHR]
     sqlFiles = ['cleanup_mjpnl_abrechnung_per_leistung.sql']
-
+}
 
 task "cleanup_abrechnung_per_leistung_orphans"(type: SqlExecutor,dependsOn: "cleanup_abrechnung_per_leistung") {
     description = "Löscht alle diesjährigen Leistungen, deren Vereinbarung manuell gelöscht wurden (was eigentlich nicht gemacht wird ausser bei Bereinigung nach Migration)"

--- a/arp_mjpnl_zahlungslauf/calc_mjpnl_abrechnung_per_leistung_hecke.sql
+++ b/arp_mjpnl_zahlungslauf/calc_mjpnl_abrechnung_per_leistung_hecke.sql
@@ -154,13 +154,16 @@ united_hecke_leistungen AS (
         beurteilung_t_basket AS t_basket,
         beurteilung_vereinbarung AS vereinbarung,
         /* Indiviuelle Werte */
-        left(('Hecke: Erschwernis (' ||
-            (SELECT CONCAT_WS(', ',
-                CASE WHEN erschwernis_massnahme1 THEN 'Massnahme 1: '||COALESCE(left(erschwernis_massnahme1_text,60),'') END,
-                CASE WHEN erschwernis_massnahme2 THEN 'Massnahme 2: '||COALESCE(left(erschwernis_massnahme2_text,60),'') END,
-                CASE WHEN erschwernis_massnahme3 THEN 'Massnahme 3: '||COALESCE(left(erschwernis_massnahme3_text,60),'') END
-            )) ||
-        ')'),255)
+        regexp_replace(
+            left(('Hecke: Erschwernis (' ||
+                (SELECT CONCAT_WS(', ',
+                    CASE WHEN erschwernis_massnahme1 THEN 'Massnahme 1: '||COALESCE(left(erschwernis_massnahme1_text,60),'') END,
+                    CASE WHEN erschwernis_massnahme2 THEN 'Massnahme 2: '||COALESCE(left(erschwernis_massnahme2_text,60),'') END,
+                    CASE WHEN erschwernis_massnahme3 THEN 'Massnahme 3: '||COALESCE(left(erschwernis_massnahme3_text,60),'') END
+                )) ||
+            ')'),255),
+            E'[\n\r]+', ' ', 'g' 
+        )
         AS leistung_beschrieb,
         'per_ha' AS abgeltungsart,
         erschwernis_abgeltung_ha AS betrag_per_einheit,

--- a/arp_mjpnl_zahlungslauf/calc_mjpnl_abrechnung_per_leistung_wbl_weide.sql
+++ b/arp_mjpnl_zahlungslauf/calc_mjpnl_abrechnung_per_leistung_wbl_weide.sql
@@ -104,12 +104,15 @@ united_wbl_weide_leistungen AS (
         beurteilung_t_basket AS t_basket,
         beurteilung_vereinbarung AS vereinbarung,
         /* Indiviuelle Werte */
-        left(('WBL Weide: Erschwernis (' ||
-            (SELECT CONCAT_WS(', ',
-                CASE WHEN erschwernis_massnahme1 THEN 'Massnahme 1: '||COALESCE(left(erschwernis_massnahme1_text,60),'') END,
-                CASE WHEN erschwernis_massnahme2 THEN 'Massnahme 2: '||COALESCE(left(erschwernis_massnahme2_text,60),'') END
-            )) ||
-        ')'),255)
+        regexp_replace(
+            left(('WBL Weide: Erschwernis (' ||
+                (SELECT CONCAT_WS(', ',
+                    CASE WHEN erschwernis_massnahme1 THEN 'Massnahme 1: '||COALESCE(left(erschwernis_massnahme1_text,60),'') END,
+                    CASE WHEN erschwernis_massnahme2 THEN 'Massnahme 2: '||COALESCE(left(erschwernis_massnahme2_text,60),'') END
+                )) ||
+            ')'),255),
+            E'[\n\r]+', ' ', 'g' 
+        )
         AS leistung_beschrieb,
         'per_ha' AS abgeltungsart,
         erschwernis_abgeltung_ha AS betrag_per_einheit,
@@ -127,13 +130,16 @@ united_wbl_weide_leistungen AS (
         beurteilung_t_basket AS t_basket,
         beurteilung_vereinbarung AS vereinbarung,
         /* Indiviuelle Werte */
-        left(('WBL Weide: Artenförderung (' ||
-            (SELECT CONCAT_WS(', ',
-                CASE WHEN artenfoerderung_ff_zielart1 IS NOT NULL THEN 'Massnahme für '||artenfoerderung_ff_zielart1||': '||COALESCE(left(artenfoerderung_ff_zielart1_massnahme,40),'') END,
-                CASE WHEN artenfoerderung_ff_zielart2 IS NOT NULL THEN 'Massnahme für '||artenfoerderung_ff_zielart2||': '||COALESCE(left(artenfoerderung_ff_zielart2_massnahme,40),'') END,
-                CASE WHEN artenfoerderung_ff_zielart3 IS NOT NULL THEN 'Massnahme für '||artenfoerderung_ff_zielart3||': '||COALESCE(left(artenfoerderung_ff_zielart3_massnahme,40),'') END
-            )) ||
-        ')'),255)
+        regexp_replace(
+            left(('WBL Weide: Artenförderung (' ||
+                (SELECT CONCAT_WS(', ',
+                    CASE WHEN artenfoerderung_ff_zielart1 IS NOT NULL THEN 'Massnahme für '||artenfoerderung_ff_zielart1||': '||COALESCE(left(artenfoerderung_ff_zielart1_massnahme,40),'') END,
+                    CASE WHEN artenfoerderung_ff_zielart2 IS NOT NULL THEN 'Massnahme für '||artenfoerderung_ff_zielart2||': '||COALESCE(left(artenfoerderung_ff_zielart2_massnahme,40),'') END,
+                    CASE WHEN artenfoerderung_ff_zielart3 IS NOT NULL THEN 'Massnahme für '||artenfoerderung_ff_zielart3||': '||COALESCE(left(artenfoerderung_ff_zielart3_massnahme,40),'') END
+                )) ||
+            ')'),255), 
+            E'[\n\r]+', ' ', 'g' 
+        )
         AS leistung_beschrieb,
         artenfoerderung_abgeltungsart AS abgeltungsart,
         artenfoerderung_abgeltung_total AS betrag_per_einheit,

--- a/arp_mjpnl_zahlungslauf/calc_mjpnl_abrechnung_per_leistung_wbl_wiese.sql
+++ b/arp_mjpnl_zahlungslauf/calc_mjpnl_abrechnung_per_leistung_wbl_wiese.sql
@@ -84,7 +84,11 @@ united_wbl_wiese_leistungen AS (
         beurteilung_t_basket AS t_basket,
         beurteilung_vereinbarung AS vereinbarung,
         /* Indiviuelle Werte */
-        left(('WBL Weide: Einstufung / Beurteilung Ist-Zustand (' || einstufungbeurteilungistzustand_wiesenkategorie || ')'),255) AS leistung_beschrieb,
+        regexp_replace(
+            left(('WBL Weide: Einstufung / Beurteilung Ist-Zustand (' || einstufungbeurteilungistzustand_wiesenkategorie || ')'),255),
+            E'[\n\r]+', ' ', 'g' 
+        )
+        AS leistung_beschrieb,
         'per_ha' AS abgeltungsart,
         einstufungbeurteilungistzustand_wiesenkategorie_abgeltung_ha AS betrag_per_einheit,
         flaeche AS anzahl_einheiten,
@@ -118,12 +122,15 @@ united_wbl_wiese_leistungen AS (
         beurteilung_t_basket AS t_basket,
         beurteilung_vereinbarung AS vereinbarung,
         /* Indiviuelle Werte */
-        left(('WBL Wiese: Erschwernis (' ||
-            (SELECT CONCAT_WS(', ',
-                CASE WHEN erschwernis_massnahme1 THEN 'Massnahme 1: '||COALESCE(left(erschwernis_massnahme1_text,60),'') END,
-                CASE WHEN erschwernis_massnahme2 THEN 'Massnahme 2: '||COALESCE(left(erschwernis_massnahme2_text,60),'') END
-            )) ||
-        ')'),255)
+        regexp_replace(
+            left(('WBL Wiese: Erschwernis (' ||
+                (SELECT CONCAT_WS(', ',
+                    CASE WHEN erschwernis_massnahme1 THEN 'Massnahme 1: '||COALESCE(left(erschwernis_massnahme1_text,60),'') END,
+                    CASE WHEN erschwernis_massnahme2 THEN 'Massnahme 2: '||COALESCE(left(erschwernis_massnahme2_text,60),'') END
+                )) ||
+            ')'),255),
+            E'[\n\r]+', ' ', 'g' 
+        )
         AS leistung_beschrieb,
         'per_ha' AS abgeltungsart,
         erschwernis_abgeltung_ha AS betrag_per_einheit,
@@ -141,13 +148,17 @@ united_wbl_wiese_leistungen AS (
         beurteilung_t_basket AS t_basket,
         beurteilung_vereinbarung AS vereinbarung,
         /* Indiviuelle Werte */
-        left(('WBL Wiese: Artenförderung (' ||
-            (SELECT CONCAT_WS(', ',
-                CASE WHEN artenfoerderung_ff_zielart1 IS NOT NULL THEN 'Massnahme für '||artenfoerderung_ff_zielart1||': '||COALESCE(left(artenfoerderung_ff_zielart1_massnahme,40),'') END,
-                CASE WHEN artenfoerderung_ff_zielart2 IS NOT NULL THEN 'Massnahme für '||artenfoerderung_ff_zielart2||': '||COALESCE(left(artenfoerderung_ff_zielart2_massnahme,40),'') END,
-                CASE WHEN artenfoerderung_ff_zielart3 IS NOT NULL THEN 'Massnahme für '||artenfoerderung_ff_zielart3||': '||COALESCE(left(artenfoerderung_ff_zielart3_massnahme,40),'') END
-            )) ||
-        ')'),255) AS leistung_beschrieb,
+        regexp_replace(
+            left(('WBL Wiese: Artenförderung (' ||
+                (SELECT CONCAT_WS(', ',
+                    CASE WHEN artenfoerderung_ff_zielart1 IS NOT NULL THEN 'Massnahme für '||artenfoerderung_ff_zielart1||': '||COALESCE(left(artenfoerderung_ff_zielart1_massnahme,40),'') END,
+                    CASE WHEN artenfoerderung_ff_zielart2 IS NOT NULL THEN 'Massnahme für '||artenfoerderung_ff_zielart2||': '||COALESCE(left(artenfoerderung_ff_zielart2_massnahme,40),'') END,
+                    CASE WHEN artenfoerderung_ff_zielart3 IS NOT NULL THEN 'Massnahme für '||artenfoerderung_ff_zielart3||': '||COALESCE(left(artenfoerderung_ff_zielart3_massnahme,40),'') END
+                )) ||
+            ')'),255),
+            E'[\n\r]+', ' ', 'g' 
+        )
+        AS leistung_beschrieb,
         artenfoerderung_abgeltungsart AS abgeltungsart,
         artenfoerderung_abgeltung_total AS betrag_per_einheit,
         CASE WHEN artenfoerderung_abgeltungsart = 'pauschal' THEN 1 ELSE flaeche END AS anzahl_einheiten,

--- a/arp_mjpnl_zahlungslauf/calc_mjpnl_abrechnung_per_leistung_weide_ln.sql
+++ b/arp_mjpnl_zahlungslauf/calc_mjpnl_abrechnung_per_leistung_weide_ln.sql
@@ -84,9 +84,12 @@ united_weide_ln_leistungen AS (
         beurteilung_t_basket AS t_basket,
         beurteilung_vereinbarung AS vereinbarung,
         /* Indiviuelle Werte */
-        left(('Weide LN: Einstufung / Beurteilung Ist-Zustand (' || einstufungbeurteilungistzustand_weidenkategorie ||
-            CASE WHEN einstufungbeurteilungistzustand_struktur_optimal_beibehalten THEN ' + Struktur optimal beibehalten' ELSE '' END ||
-        ')'), 255 )
+        regexp_replace(
+            left(('Weide LN: Einstufung / Beurteilung Ist-Zustand (' || einstufungbeurteilungistzustand_weidenkategorie ||
+                CASE WHEN einstufungbeurteilungistzustand_struktur_optimal_beibehalten THEN ' + Struktur optimal beibehalten' ELSE '' END ||
+            ')'), 255 ),
+            E'[\n\r]+', ' ', 'g' 
+        )
         AS leistung_beschrieb,
         'per_ha' AS abgeltungsart,
         einstufungbeurteilungistzustand_abgeltung_ha AS betrag_per_einheit,
@@ -104,12 +107,15 @@ united_weide_ln_leistungen AS (
         beurteilung_t_basket AS t_basket,
         beurteilung_vereinbarung AS vereinbarung,
         /* Indiviuelle Werte */
-        left(('Weide LN: Erschwernis (' ||
-            (SELECT CONCAT_WS(', ',
-                CASE WHEN erschwernis_massnahme1 THEN 'Massnahme 1: '||COALESCE(left(erschwernis_massnahme1_text,60),'') END,
-                CASE WHEN erschwernis_massnahme2 THEN 'Massnahme 2: '||COALESCE(left(erschwernis_massnahme2_text,60),'') END
-            )) ||
-        ')'),255)
+        regexp_replace(
+            left(('Weide LN: Erschwernis (' ||
+                (SELECT CONCAT_WS(', ',
+                    CASE WHEN erschwernis_massnahme1 THEN 'Massnahme 1: '||COALESCE(left(erschwernis_massnahme1_text,60),'') END,
+                    CASE WHEN erschwernis_massnahme2 THEN 'Massnahme 2: '||COALESCE(left(erschwernis_massnahme2_text,60),'') END
+                )) ||
+            ')'),255),
+            E'[\n\r]+', ' ', 'g' 
+        )
         AS leistung_beschrieb,
         'per_ha' AS abgeltungsart,
         erschwernis_abgeltung_ha AS betrag_per_einheit,
@@ -127,13 +133,16 @@ united_weide_ln_leistungen AS (
         beurteilung_t_basket AS t_basket,
         beurteilung_vereinbarung AS vereinbarung,
         /* Indiviuelle Werte */
-        left(('Weide LN: Artenförderung (' ||
-            (SELECT CONCAT_WS(', ',
-                CASE WHEN artenfoerderung_ff_zielart1 IS NOT NULL THEN 'Massnahme für '||artenfoerderung_ff_zielart1||': '||COALESCE(left(artenfoerderung_ff_zielart1_massnahme,40),'') END,
-                CASE WHEN artenfoerderung_ff_zielart2 IS NOT NULL THEN 'Massnahme für '||artenfoerderung_ff_zielart2||': '||COALESCE(left(artenfoerderung_ff_zielart2_massnahme,40),'') END,
-                CASE WHEN artenfoerderung_ff_zielart3 IS NOT NULL THEN 'Massnahme für '||artenfoerderung_ff_zielart3||': '||COALESCE(left(artenfoerderung_ff_zielart3_massnahme,40),'') END
-            )) ||
-        ')'),255)
+        regexp_replace(
+            left(('Weide LN: Artenförderung (' ||
+                (SELECT CONCAT_WS(', ',
+                    CASE WHEN artenfoerderung_ff_zielart1 IS NOT NULL THEN 'Massnahme für '||artenfoerderung_ff_zielart1||': '||COALESCE(left(artenfoerderung_ff_zielart1_massnahme,40),'') END,
+                    CASE WHEN artenfoerderung_ff_zielart2 IS NOT NULL THEN 'Massnahme für '||artenfoerderung_ff_zielart2||': '||COALESCE(left(artenfoerderung_ff_zielart2_massnahme,40),'') END,
+                    CASE WHEN artenfoerderung_ff_zielart3 IS NOT NULL THEN 'Massnahme für '||artenfoerderung_ff_zielart3||': '||COALESCE(left(artenfoerderung_ff_zielart3_massnahme,40),'') END
+                )) ||
+            ')'),255),
+            E'[\n\r]+', ' ', 'g' 
+        )
         AS leistung_beschrieb,
         artenfoerderung_abgeltungsart AS abgeltungsart,
         artenfoerderung_abgeltung_total AS betrag_per_einheit,

--- a/arp_mjpnl_zahlungslauf/calc_mjpnl_abrechnung_per_leistung_weide_soeg.sql
+++ b/arp_mjpnl_zahlungslauf/calc_mjpnl_abrechnung_per_leistung_weide_soeg.sql
@@ -84,9 +84,12 @@ united_weide_soeg_leistungen AS (
         beurteilung_t_basket AS t_basket,
         beurteilung_vereinbarung AS vereinbarung,
         /* Indiviuelle Werte */
-        left(('Weide SöG: Einstufung / Beurteilung Ist-Zustand (' || einstufungbeurteilungistzustand_weidenkategorie ||
-            CASE WHEN einstufungbeurteilungistzustand_struktur_optimal_beibehalten THEN ' + Struktur optimal beibehalten' ELSE '' END ||
-        ')'),255)
+        regexp_replace(
+            left(('Weide SöG: Einstufung / Beurteilung Ist-Zustand (' || einstufungbeurteilungistzustand_weidenkategorie ||
+                CASE WHEN einstufungbeurteilungistzustand_struktur_optimal_beibehalten THEN ' + Struktur optimal beibehalten' ELSE '' END ||
+            ')'),255),
+            E'[\n\r]+', ' ', 'g' 
+        )
         AS leistung_beschrieb,
         'per_ha' AS abgeltungsart,
         einstufungbeurteilungistzustand_abgeltung_ha AS betrag_per_einheit,
@@ -104,13 +107,16 @@ united_weide_soeg_leistungen AS (
         beurteilung_t_basket AS t_basket,
         beurteilung_vereinbarung AS vereinbarung,
         /* Indiviuelle Werte */
-        left(('Weide SöG: Erschwernis (' ||
-            (SELECT CONCAT_WS(', ',
-                CASE WHEN erschwernis_massnahme1 THEN 'Massnahme 1: '||COALESCE(left(erschwernis_massnahme1_text,60),'') END,
-                CASE WHEN erschwernis_massnahme2 THEN 'Massnahme 2: '||COALESCE(left(erschwernis_massnahme2_text,60),'') END,
-                CASE WHEN erschwernis_massnahme3 THEN 'Massnahme 3: '||COALESCE(left(erschwernis_massnahme3_text,60),'') END
-            )) ||
-        ')'),255)
+        regexp_replace(
+            left(('Weide SöG: Erschwernis (' ||
+                (SELECT CONCAT_WS(', ',
+                    CASE WHEN erschwernis_massnahme1 THEN 'Massnahme 1: '||COALESCE(left(erschwernis_massnahme1_text,60),'') END,
+                    CASE WHEN erschwernis_massnahme2 THEN 'Massnahme 2: '||COALESCE(left(erschwernis_massnahme2_text,60),'') END,
+                    CASE WHEN erschwernis_massnahme3 THEN 'Massnahme 3: '||COALESCE(left(erschwernis_massnahme3_text,60),'') END
+                )) ||
+            ')'),255),
+            E'[\n\r]+', ' ', 'g' 
+        )
         AS leistung_beschrieb,
         'per_ha' AS abgeltungsart,
         erschwernis_abgeltung_ha AS betrag_per_einheit,
@@ -128,13 +134,16 @@ united_weide_soeg_leistungen AS (
         beurteilung_t_basket AS t_basket,
         beurteilung_vereinbarung AS vereinbarung,
         /* Indiviuelle Werte */
-        left(('Weide SöG: Artenförderung (' ||
-            (SELECT CONCAT_WS(', ',
-                CASE WHEN artenfoerderung_ff_zielart1 IS NOT NULL THEN 'Massnahme für '||artenfoerderung_ff_zielart1||': '||COALESCE(left(artenfoerderung_ff_zielart1_massnahme,40),'') END,
-                CASE WHEN artenfoerderung_ff_zielart2 IS NOT NULL THEN 'Massnahme für '||artenfoerderung_ff_zielart2||': '||COALESCE(left(artenfoerderung_ff_zielart2_massnahme,40),'') END,
-                CASE WHEN artenfoerderung_ff_zielart3 IS NOT NULL THEN 'Massnahme für '||artenfoerderung_ff_zielart3||': '||COALESCE(left(artenfoerderung_ff_zielart3_massnahme,40),'') END
-            )) ||
-        ')'),255)
+        regexp_replace(
+            left(('Weide SöG: Artenförderung (' ||
+                (SELECT CONCAT_WS(', ',
+                    CASE WHEN artenfoerderung_ff_zielart1 IS NOT NULL THEN 'Massnahme für '||artenfoerderung_ff_zielart1||': '||COALESCE(left(artenfoerderung_ff_zielart1_massnahme,40),'') END,
+                    CASE WHEN artenfoerderung_ff_zielart2 IS NOT NULL THEN 'Massnahme für '||artenfoerderung_ff_zielart2||': '||COALESCE(left(artenfoerderung_ff_zielart2_massnahme,40),'') END,
+                    CASE WHEN artenfoerderung_ff_zielart3 IS NOT NULL THEN 'Massnahme für '||artenfoerderung_ff_zielart3||': '||COALESCE(left(artenfoerderung_ff_zielart3_massnahme,40),'') END
+                )) ||
+            ')'),255),
+            E'[\n\r]+', ' ', 'g' 
+        )
         AS leistung_beschrieb,
         artenfoerderung_abgeltungsart AS abgeltungsart,
         artenfoerderung_abgeltung_total AS betrag_per_einheit,

--- a/arp_mjpnl_zahlungslauf/calc_mjpnl_abrechnung_per_leistung_wiese.sql
+++ b/arp_mjpnl_zahlungslauf/calc_mjpnl_abrechnung_per_leistung_wiese.sql
@@ -84,7 +84,10 @@ united_wiese_leistungen AS (
         beurteilung_t_basket AS t_basket,
         beurteilung_vereinbarung AS vereinbarung,
         /* Indiviuelle Werte */
-        left(('Wiese: Einstufung / Beurteilung Ist-Zustand (' || einstufungbeurteilungistzustand_wiesenkategorie || ')'),255) AS leistung_beschrieb,
+        regexp_replace(
+            left(('Wiese: Einstufung / Beurteilung Ist-Zustand (' || einstufungbeurteilungistzustand_wiesenkategorie || ')'),255),
+            E'[\n\r]+', ' ', 'g' 
+        ) AS leistung_beschrieb,
         'per_ha' AS abgeltungsart,
         einstufungbeurteilungistzustand_wiesenkategorie_abgeltung_ha AS betrag_per_einheit,
         flaeche AS anzahl_einheiten,
@@ -118,12 +121,15 @@ united_wiese_leistungen AS (
         beurteilung_t_basket AS t_basket,
         beurteilung_vereinbarung AS vereinbarung,
         /* Indiviuelle Werte */
-        left(('Wiese: Erschwernis (' ||
-            (SELECT CONCAT_WS(', ',
-                CASE WHEN erschwernis_massnahme1 THEN 'Massnahme 1: '||COALESCE(left(erschwernis_massnahme1_text,60),'') END,
-                CASE WHEN erschwernis_massnahme2 THEN 'Massnahme 2: '||COALESCE(left(erschwernis_massnahme2_text,60),'') END
-            )) ||
-        ')'),255)
+        regexp_replace(
+            left(('Wiese: Erschwernis (' ||
+                (SELECT CONCAT_WS(', ',
+                    CASE WHEN erschwernis_massnahme1 THEN 'Massnahme 1: '||COALESCE(left(erschwernis_massnahme1_text,60),'') END,
+                    CASE WHEN erschwernis_massnahme2 THEN 'Massnahme 2: '||COALESCE(left(erschwernis_massnahme2_text,60),'') END
+                )) ||
+            ')'),255),
+            E'[\n\r]+', ' ', 'g' 
+        )
         AS leistung_beschrieb,
         'per_ha' AS abgeltungsart,
         erschwernis_abgeltung_ha AS betrag_per_einheit,
@@ -141,13 +147,16 @@ united_wiese_leistungen AS (
         beurteilung_t_basket AS t_basket,
         beurteilung_vereinbarung AS vereinbarung,
         /* Indiviuelle Werte */
-        left(('Wiese: Artenförderung (' ||
-            (SELECT CONCAT_WS(', ',
-                CASE WHEN artenfoerderung_ff_zielart1 IS NOT NULL THEN 'Massnahme für '||artenfoerderung_ff_zielart1||': '||COALESCE(left(artenfoerderung_ff_zielart1_massnahme,40),'') END,
-                CASE WHEN artenfoerderung_ff_zielart2 IS NOT NULL THEN 'Massnahme für '||artenfoerderung_ff_zielart2||': '||COALESCE(left(artenfoerderung_ff_zielart2_massnahme,40),'') END,
-                CASE WHEN artenfoerderung_ff_zielart3 IS NOT NULL THEN 'Massnahme für '||artenfoerderung_ff_zielart3||': '||COALESCE(left(artenfoerderung_ff_zielart3_massnahme,40),'') END
-            )) ||
-        ')'),255)
+        regexp_replace(
+            left(('Wiese: Artenförderung (' ||
+                (SELECT CONCAT_WS(', ',
+                    CASE WHEN artenfoerderung_ff_zielart1 IS NOT NULL THEN 'Massnahme für '||artenfoerderung_ff_zielart1||': '||COALESCE(left(artenfoerderung_ff_zielart1_massnahme,40),'') END,
+                    CASE WHEN artenfoerderung_ff_zielart2 IS NOT NULL THEN 'Massnahme für '||artenfoerderung_ff_zielart2||': '||COALESCE(left(artenfoerderung_ff_zielart2_massnahme,40),'') END,
+                    CASE WHEN artenfoerderung_ff_zielart3 IS NOT NULL THEN 'Massnahme für '||artenfoerderung_ff_zielart3||': '||COALESCE(left(artenfoerderung_ff_zielart3_massnahme,40),'') END
+                )) ||
+            ')'),255),
+            E'[\n\r]+', ' ', 'g' 
+        )
         AS leistung_beschrieb,
         artenfoerderung_abgeltungsart AS abgeltungsart,
         artenfoerderung_abgeltung_total AS betrag_per_einheit,

--- a/arp_mjpnl_zahlungslauf/job.properties
+++ b/arp_mjpnl_zahlungslauf/job.properties
@@ -1,4 +1,3 @@
-parameters.stringParams=AUSZAHLUNGSJAHR;;'Year of payments (e.g.2024)' 
 authorization.permissions=gretl-users-barpa,exopesig,exopecam
 logRotator.numToKeep=30
 triggers.cron=H H(1-3) * * *


### PR DESCRIPTION
Im Januar muss auf das nächste Jahr umgeschaltet werden. Einige Regeln wurden definiert:

### GELAN Update
- Mutationen an den Vereinbarungen werden zwischen 1.12 und 15.1 nicht gemacht, um die Auszahlung nicht zu verfälschen.

### Zahlungslauf
- Bis zum 14.1 wird noch das Vorjahr genommen. Am 15.1 das aktuelle Jahr für die Kalkulation des Zahlungslaufs.
- [x] Jahresparameter soll nach den Tests entfernt werden

### Auszahlung (Status Setzen)
- Zusätzlich wird jetzt auch das Auszahlungsdatum gesetzt (auf den 15.12 des Vorjahres)
- Es wird einmal per Cron Job ausgeführt (am 15.1)
- [x] Jahresparameter soll nach den Tests entfernt werden

## Dokumentation

Ende Jahr bzw. Anfang Folgejahr, muss das Jahr abgeschlossen werden. Der Zeitplan sieht folgendermassen aus:

- 1. Dezember: GELAN Update führt nicht mehr zu Bewirtschafterwechsel
- 1. Dezember bis 14. Januar: Wird der Auszahlungsbrief generiert, es können noch anpassungen gemacht werden. Täglich wird die Zahlungslaufkalkulation für das alte Jahr gemacht.
- 14. Januar: Idealerweise soll hier ein XTF Export des aktuellen Standes gemacht werden, allerdings sollten - abgesehen vom Auszahlungsstatus - mit den folgenden Aktionen keine Änderungen an den alten Daten gemacht werden.
- 15. Januar: Cron Job macht Auszahlungs-Prozess - also setzt Status aller freigegebener Leistungen und der Zusammenzüge auf "ausbezahlt" (die vorher freigegeben waren) und das "symbolische" Datum 15.12 des Vorjahres
- ab 15. Januar: Zahlungslaufkalkulation nutzt wieder das aktuelle Jahr (also das Folgejahr) und somit werden seither die neuen Leistungen berechnet. 

## Manueller Test

### Testumgebung

Ich habe den Status des Produktiven auf Test und Integration gespiegelt (mit XTF Export / Import des Files H:\BARPA_AGI\01_AIO_Projekte\13_MJPNL\06_QGIS\xtf_exports\produktion_MJPNL_20240131_0855.xtf

#### Zahlen vor Jahreswechsel

- `auszahlungsjahr = 2023 AND status_abrechnung = 'freigegeben'`
- `auszahlungsjahr = 2023 AND status_abrechnung = 'ausbezahlt'`
- `auszahlungsjahr = 2023 AND status_abrechnung != 'ausbezahlt' AND status_abrechnung != 'freigegeben'`

| 2023  | Leistung  |  _per_Vereinbarung | _per_Bewirtschafter:  |
|---|---|---|---|
| gesammt | 35093 | 14234 | 850 |
| 2023 | 8989 | 3686 | 850 |
| freigegeben | 8693 | 3672 | 848 |
| ausbezahlt  | 47 | 11 | 1 |
| andere | 249 | 3 | 1 |

| 2024 | Leistung  |  _per_Vereinbarung | _per_Bewirtschafter:  |
|---|---|---|---|
| gesammt | 35093 | 14234 | 850 |
| 2024 | 9 | 0 | 0 |
| freigegeben | 0 | 0 | 0 |
| ausbezahlt  | 9 | 0 | 0 |
| andere | 0 | 0 | 0 |

Es wurde offenbar schon mal manuell ein Zahlungslauf gestartet... Somit wurden diese 8 freigegebenen erstellt - offenbar aber aus inaktiven Vereinbarungen, weshalb wurden die kopiert?

![image](https://github.com/sogis/gretljobs/assets/28384354/65703459-f41e-4a5a-9643-46ab2ffc495d)

### Auszahlung vor Zahlungslauf (idealfall)
- Starte [arp_mjpnl_auszahlung] für diesen Branch (kein Jahr übergeben in Gretl - dies gäbe es gar nicht mehr im Job, aber Jenkins ist noch nicht geupdated, wenn nicht gmerged), es nimmt 2023 (Jahr-1)
  ![image](https://github.com/sogis/gretljobs/assets/28384354/0e9c4e6e-87f1-40be-af9e-7605d943c162)
- Prüfen
  | 2023  | Leistung  |  _per_Vereinbarung | _per_Bewirtschafter:  |
  |---|---|---|---|
  | gesammt | 43818| 14234 | 850 |
  | 2023 | 8989 | 3686 | 850 |
  | freigegeben | 0 | 0 | 0 |
  | ausbezahlt  | 8740 | 3683 | 849 |
  | andere | 249 | 3 | 1 |

  ![image](https://github.com/sogis/gretljobs/assets/28384354/2aee83c1-1cb0-41af-90ed-bc31e8f37912)

  - Sind alle freigegeben auf ausbezahlt mit Datum? - Ja, es haben alle das Datum 15.12.2023
  - Sind alle ausbezahlt noch da mit altem Datum? - Ja, 46 haben ein früheres Datum. Eines hat 31.12.2023 als Datum
  - Sind alle anderen noch da? - Ja, Anzahl unverändert.

- Starte [arp_mjpnl_zahlungslauf] für diesen Branch (kein Jahr übergeben in Gretl - es wird aktuelles Jahr 2024 genommen)
  ![image](https://github.com/sogis/gretljobs/assets/28384354/16f2bcf5-d2ad-486e-8104-3fc2fe26eac0)
  
  ![image](https://github.com/sogis/gretljobs/assets/28384354/fe1d9d12-dc41-4255-a368-9cdfb19bdb4d)

  - Wurde 2023 nicht tangiert? Nein, alles gut.
    | 2023  | Leistung  |  _per_Vereinbarung | _per_Bewirtschafter:  |
    |---|---|---|---|
    | gesammt | 43810 | 14234 | 850 |
    | 2023 | 8989 | 3686 | 850 |
    | freigegeben | 0 | 0 | 0 |
    | ausbezahlt  | 8740 | 3683 | 849 |
    | andere | 249 | 3 | 1 |

   - Sind die 2024er alle da?
      | 2024 | Leistung  |  _per_Vereinbarung | _per_Bewirtschafter:  |
      |---|---|---|---|
      | gesammt | 43818 | 14234 | 1696 |
      | 2024 | 8726 | 3680 | 846 |
      | freigegeben | 8717 | 3672 | 846 |
      | ausbezahlt  | 9 | 8 | 0 |
      | andere |0 |0 | 0 |

### Auszahlung 2023 dann erneut Zahlungslauf 2023 und dann Zahlungslauf 2024
- Dies würde nur geschehen, wenn man die Auszahlung vor dem 15.1 ausführt. Deshalb sollte dies nicht eintreten.

### Ermittlung des Jahres in gradle testen
- Getestet mit 7e6bd3630de2f7f4c3b98a65edc2c43852cc517b

## Manueller Jahreswechsel 2023/2024

### -1. Sind die Daten von Sandra geprüft?

### 0. Zahlungslauf 2023 ausführen (dazu diesen PR hier noch nicht mergen!)

... denn dieser PR #1632 enthält ein Fix, dass keine Steuerungszeichen in der Beschreibung der Leistungen sind.

### 1. Backup mit XTF-Export
![image](https://github.com/sogis/gretljobs/assets/28384354/bcbacd04-e89a-409c-a3c6-847259e3a226)

Falls noch immer Fehler kommen, fixe sie wenn möglich. Wenn nicht möglich, wähle "Run without validation"
![image](https://github.com/sogis/gretljobs/assets/28384354/d3aaab0c-495a-4f40-be97-6d76196fef9b)

### 2. Diesen Branch mergen

### 3. Auszahlung ausführen 

Es nimmt automatisch 2023...

Daten checken.

### 4. Zahlungslauf ausführen

Es nimmt automatisch 2024...

### Modelle anpassen (Jahre entfernen)