### PR TITLE
File upload: Switch to stashedFile parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Die Datei `job.properties` kann folgende Eigenschaften des GRETL-Jobs enthalten:
 ```java
 logRotator.numToKeep=30
 triggers.cron=H H(1-3) * * *
-parameters.fileParam=filename.xtf
+parameters.stashedFile=myfilename.xyz
 parameters.stringParams=parameterName;default value;parameter description
 triggers.upstream=other_job_name
 authorization.permissions=gretl-users-barpa
@@ -182,7 +182,10 @@ Falls man alle Ausführungen aufbewahren möchte, kann man hier den Wert `unlimi
 
 Mit `triggers.cron` kann eingestellt werden, zu welchem Zeitpunkt der Job automatisch gestartet werden soll. Im Beispiel `H H(1-3) * * *` wird der Job jeden Tag irgendwann zwischen 01:00 Uhr und 03:59 Uhr ausgeführt. (Dokumentation der Schreibweise siehe https://github.com/jenkinsci/jenkins/blob/master/core/src/main/resources/hudson/triggers/TimerTrigger/help-spec.jelly). Wenn man diese Einstellung weglässt, wird der Job nie automatisch gestartet, und er muss manuell gestartet werden.
 
-Mit `parameters.fileParam` kann erreicht werden, dass ein  Benutzer beim Starten des Jobs eine Datei hochladen muss, die dann vom GRETL-Job verarbeitet wird. Es wird ein Dateiname (z.B. `filename.xtf`) oder Pfad (z.B. `data/filename.xtf`) verlangt, mit welchem im GRETL-Job auf die Datei zugegriffen werden kann.
+Mit `parameters.stashedFile` kann konfiguriert werden,
+dass ein  Benutzer beim Starten des Jobs eine Datei hochladen muss.
+Man muss hier einen Dateinamen (z.B. `data.xtf`) angeben;
+unter diesem Dateinamen kann dann der GRETL-Job auf die Datei zugreifen.
 
 Mit `parameters.stringParams` können Parameter definiert werden,
 für welche der Benutzer beim manuellen Start des Jobs Werte übergeben kann.

--- a/afu_isboden_csv_import/Jenkinsfile
+++ b/afu_isboden_csv_import/Jenkinsfile
@@ -1,21 +1,3 @@
-// Start with a scripted pipeline part
-node('master') {
-    stage('Prepare') {
-        uploadDirName = 'upload'
-        uploadFileName = 'data'
-        // By default the uploaded file is stored in the following directory:
-        buildDir = "$JENKINS_HOME/jobs/$JOB_BASE_NAME/builds/$BUILD_NUMBER"
-        // Create a subdirectory for the uploaded file:
-        sh "mkdir $buildDir/$uploadDirName"
-        inputFile = input message: 'Datei hochladen', parameters: [file(name: "$uploadDirName/$uploadFileName", description: 'Hochzuladende Datei auswählen')]
-        dir(buildDir) {
-            stash name: 'uploadDir', includes: "upload/**"
-        }
-        sh "rm -r $buildDir/$uploadDirName"
-    }
-}
-
-// Declarative pipeline starts here
 pipeline {
     agent { label params.nodeLabel ?: 'gretl' }
     options {
@@ -27,7 +9,9 @@ pipeline {
                 git url: "${env.GIT_REPO_URL}", branch: "${params.BRANCH ?: 'main'}", changelog: false
                 container('gretl') {
                     dir(env.JOB_BASE_NAME) {
-                        unstash name: 'uploadDir'
+                        dir('upload') {
+                            unstash name: 'data'
+                        }
                         sh 'gretl'
                     }
                 }

--- a/afu_isboden_csv_import/job.properties
+++ b/afu_isboden_csv_import/job.properties
@@ -1,1 +1,2 @@
+parameters.stashedFile=data
 authorization.permissions=gretl-users-bdafu

--- a/gretl_job_generator.groovy
+++ b/gretl_job_generator.groovy
@@ -39,7 +39,7 @@ for (jobFile in jobFiles) {
   def jobProperties = new Properties([
     'authorization.permissions':'nobody',
     'logRotator.numToKeep':'15',
-    'parameters.fileParam':'none',
+    'parameters.stashedFile':'none',
     'parameters.stringParams':'none',
     'triggers.upstream':'none',
     'triggers.cron':''
@@ -62,9 +62,13 @@ for (jobFile in jobFiles) {
         stringParam('BRANCH', 'main', 'Name of branch to check out')
       }
     }
-    if (jobProperties.getProperty('parameters.fileParam') != 'none') {
+    if (jobProperties.getProperty('parameters.stashedFile') != 'none') {
       parameters {
-        fileParam(jobProperties.getProperty('parameters.fileParam'), 'Select file to upload')
+        // must be defined using the "Dynamic DSL" approach (https://github.com/jenkinsci/job-dsl-plugin/wiki/Dynamic-DSL):
+        stashedFile {
+          name(jobProperties.getProperty('parameters.stashedFile'))
+          description('Hochzuladende Datei auswählen')
+        }
       }
     }
     if (jobProperties.getProperty('parameters.stringParams') != 'none') {


### PR DESCRIPTION
There were changes to the file parameter functionality in the Jenkins Plugins, which require that we use the _file-parameters_ plugin for that. Which by the way solves file upload in a smarter and more secure way.

At the same time, implement this solution for the _afu_isboden_csv_import_ job. Other jobs will follow in a separate PR.