### PR TITLE
[arp_nutzungsplanung]

### DIFF
--- a/arp_nutzungsplanung_kanton_pub/insert_arp_nutzungsplanung_planregister_pub_kantonal.sql
+++ b/arp_nutzungsplanung_kanton_pub/insert_arp_nutzungsplanung_planregister_pub_kantonal.sql
@@ -83,7 +83,7 @@ SELECT
 
 SELECT 
     DISTINCT ON (plan.plan_t_id)
-    plan.plan_t_id AS t_id,
+    -- plan.plan_t_id AS t_id, automatisch beim Import
     'nutzungsplanung_kantonal' AS t_datasetname,
     plan.planungsinstrument,
     plan.bezeichnung,

--- a/arp_nutzungsplanung_pub/insert_arp_nutzungsplanung_planregister_pub_kommunal.sql
+++ b/arp_nutzungsplanung_pub/insert_arp_nutzungsplanung_planregister_pub_kommunal.sql
@@ -91,7 +91,7 @@ SELECT
 
 SELECT 
     DISTINCT ON (plan.plan_t_id)
-    plan.plan_t_id AS t_id,
+    -- plan.plan_t_id AS t_id, automatisch beim Import
     'nutzungsplanung_kommunal' || '_' || ${bfsnr_param} AS t_datasetname,
     plan.planungsinstrument,
     plan.bezeichnung,


### PR DESCRIPTION
 t_id ins Planregister nicht übernehmen . Bei arp_nutzungsplanung_planregister_pub_alles war es richtig.