### PR TITLE
[arp_mjpnl_zahlungslauf] Ignoriere nutzungsvereinbarungen

### DIFF
--- a/arp_mjpnl_zahlungslauf/calc_mjpnl_abrechnung_per_bewirtschafter.sql
+++ b/arp_mjpnl_zahlungslauf/calc_mjpnl_abrechnung_per_bewirtschafter.sql
@@ -21,7 +21,7 @@ FROM
      pers.pid_gelan IS NOT NULL AND pers.iban IS NOT NULL
      AND (
         -- aktive und geprüfte Vereinbarungen
-        (vbg.status_vereinbarung = 'aktiv' AND vbg.bewe_id_geprueft IS TRUE)
+        (vbg.status_vereinbarung = 'aktiv' AND vbg.bewe_id_geprueft IS TRUE AND vbg.ist_nutzungsvereinbarung IS NOT TRUE)
         OR
         -- mind. eine diesjährige Leistung, die bereits ausbezahlt ist
         (SELECT COUNT(*) FROM ${DB_Schema_MJPNL}.mjpnl_abrechnung_per_leistung l WHERE l.status_abrechnung IN ('ausbezahlt','intern_verrechnet') AND l.vereinbarung = vbg.t_id AND l.auszahlungsjahr = ${AUSZAHLUNGSJAHR}::integer) > 0 

--- a/arp_mjpnl_zahlungslauf/calc_mjpnl_abrechnung_per_leistung_alr_buntbrache.sql
+++ b/arp_mjpnl_zahlungslauf/calc_mjpnl_abrechnung_per_leistung_alr_buntbrache.sql
@@ -24,7 +24,7 @@ WITH alle_alr_buntbrache AS (
         alr_buntbrache.vereinbarung = vereinbarung.t_id
     WHERE
         alr_buntbrache.mit_bewirtschafter_besprochen IS TRUE
-        AND vereinbarung.status_vereinbarung = 'aktiv' AND vereinbarung.bewe_id_geprueft IS TRUE
+        AND vereinbarung.status_vereinbarung = 'aktiv' AND vereinbarung.bewe_id_geprueft IS TRUE AND vereinbarung.ist_nutzungsvereinbarung IS NOT TRUE
         -- und berücksichtige nur die neusten (sofern mehrere existieren)
         AND alr_buntbrache.beurteilungsdatum = (SELECT MAX(beurteilungsdatum) FROM ${DB_Schema_MJPNL}.mjpnl_beurteilung_alr_buntbrache b WHERE b.mit_bewirtschafter_besprochen IS TRUE AND b.vereinbarung = alr_buntbrache.vereinbarung)
 ),

--- a/arp_mjpnl_zahlungslauf/calc_mjpnl_abrechnung_per_leistung_alr_saum.sql
+++ b/arp_mjpnl_zahlungslauf/calc_mjpnl_abrechnung_per_leistung_alr_saum.sql
@@ -23,7 +23,7 @@ WITH alle_alr_saum AS (
         alr_saum.vereinbarung = vereinbarung.t_id
     WHERE
         alr_saum.mit_bewirtschafter_besprochen IS TRUE
-        AND vereinbarung.status_vereinbarung = 'aktiv' AND vereinbarung.bewe_id_geprueft IS TRUE
+        AND vereinbarung.status_vereinbarung = 'aktiv' AND vereinbarung.bewe_id_geprueft IS TRUE AND vereinbarung.ist_nutzungsvereinbarung IS NOT TRUE
         -- und berücksichtige nur die neusten (sofern mehrere existieren)
         AND alr_saum.beurteilungsdatum = (SELECT MAX(beurteilungsdatum) FROM ${DB_Schema_MJPNL}.mjpnl_beurteilung_alr_saum b WHERE b.mit_bewirtschafter_besprochen IS TRUE AND b.vereinbarung = alr_saum.vereinbarung)
 ),

--- a/arp_mjpnl_zahlungslauf/calc_mjpnl_abrechnung_per_leistung_hecke.sql
+++ b/arp_mjpnl_zahlungslauf/calc_mjpnl_abrechnung_per_leistung_hecke.sql
@@ -23,7 +23,7 @@ WITH alle_hecke AS (
         hecke.vereinbarung = vereinbarung.t_id
     WHERE
         hecke.mit_bewirtschafter_besprochen IS TRUE
-        AND vereinbarung.status_vereinbarung = 'aktiv' AND vereinbarung.bewe_id_geprueft IS TRUE
+        AND vereinbarung.status_vereinbarung = 'aktiv' AND vereinbarung.bewe_id_geprueft IS TRUE AND vereinbarung.ist_nutzungsvereinbarung IS NOT TRUE
         -- und berücksichtige nur die neusten (sofern mehrere existieren)
         AND hecke.beurteilungsdatum = (SELECT MAX(beurteilungsdatum) FROM ${DB_Schema_MJPNL}.mjpnl_beurteilung_hecke b WHERE b.mit_bewirtschafter_besprochen IS TRUE AND b.vereinbarung = hecke.vereinbarung)
 ),

--- a/arp_mjpnl_zahlungslauf/calc_mjpnl_abrechnung_per_leistung_hostet.sql
+++ b/arp_mjpnl_zahlungslauf/calc_mjpnl_abrechnung_per_leistung_hostet.sql
@@ -23,7 +23,7 @@ WITH alle_hostet AS (
         hostet.vereinbarung = vereinbarung.t_id
     WHERE
         hostet.mit_bewirtschafter_besprochen IS TRUE
-        AND vereinbarung.status_vereinbarung = 'aktiv' AND vereinbarung.bewe_id_geprueft IS TRUE
+        AND vereinbarung.status_vereinbarung = 'aktiv' AND vereinbarung.bewe_id_geprueft IS TRUE AND vereinbarung.ist_nutzungsvereinbarung IS NOT TRUE
         -- und berücksichtige nur die neusten (sofern mehrere existieren)
         AND hostet.beurteilungsdatum = (SELECT MAX(beurteilungsdatum) FROM ${DB_Schema_MJPNL}.mjpnl_beurteilung_hostet b WHERE b.mit_bewirtschafter_besprochen IS TRUE AND b.vereinbarung = hostet.vereinbarung)
 ),

--- a/arp_mjpnl_zahlungslauf/calc_mjpnl_abrechnung_per_leistung_obl.sql
+++ b/arp_mjpnl_zahlungslauf/calc_mjpnl_abrechnung_per_leistung_obl.sql
@@ -23,7 +23,7 @@ WITH alle_obl AS (
         obl.vereinbarung = vereinbarung.t_id
     WHERE
         obl.mit_bewirtschafter_besprochen IS TRUE
-        AND vereinbarung.status_vereinbarung = 'aktiv' AND vereinbarung.bewe_id_geprueft IS TRUE
+        AND vereinbarung.status_vereinbarung = 'aktiv' AND vereinbarung.bewe_id_geprueft IS TRUE AND vereinbarung.ist_nutzungsvereinbarung IS NOT TRUE
         -- und berücksichtige nur die neusten (sofern mehrere existieren)
         AND obl.beurteilungsdatum = (SELECT MAX(beurteilungsdatum) FROM ${DB_Schema_MJPNL}.mjpnl_beurteilung_obl b WHERE b.mit_bewirtschafter_besprochen IS TRUE AND b.vereinbarung = obl.vereinbarung)
 ),

--- a/arp_mjpnl_zahlungslauf/calc_mjpnl_abrechnung_per_leistung_wbl_weide.sql
+++ b/arp_mjpnl_zahlungslauf/calc_mjpnl_abrechnung_per_leistung_wbl_weide.sql
@@ -23,7 +23,7 @@ WITH alle_wbl_weide AS (
         wbl_weide.vereinbarung = vereinbarung.t_id
     WHERE
         wbl_weide.mit_bewirtschafter_besprochen IS TRUE
-        AND vereinbarung.status_vereinbarung = 'aktiv' AND vereinbarung.bewe_id_geprueft IS TRUE
+        AND vereinbarung.status_vereinbarung = 'aktiv' AND vereinbarung.bewe_id_geprueft IS TRUE AND vereinbarung.ist_nutzungsvereinbarung IS NOT TRUE
         -- und berücksichtige nur die neusten (sofern mehrere existieren)
         AND wbl_weide.beurteilungsdatum = (SELECT MAX(beurteilungsdatum) FROM ${DB_Schema_MJPNL}.mjpnl_beurteilung_wbl_weide b WHERE b.mit_bewirtschafter_besprochen IS TRUE AND b.vereinbarung = wbl_weide.vereinbarung)
 ),

--- a/arp_mjpnl_zahlungslauf/calc_mjpnl_abrechnung_per_leistung_wbl_wiese.sql
+++ b/arp_mjpnl_zahlungslauf/calc_mjpnl_abrechnung_per_leistung_wbl_wiese.sql
@@ -23,7 +23,7 @@ WITH alle_wbl_wiese AS (
         wbl_wiese.vereinbarung = vereinbarung.t_id
     WHERE
         wbl_wiese.mit_bewirtschafter_besprochen IS TRUE
-        AND vereinbarung.status_vereinbarung = 'aktiv' AND vereinbarung.bewe_id_geprueft IS TRUE
+        AND vereinbarung.status_vereinbarung = 'aktiv' AND vereinbarung.bewe_id_geprueft IS TRUE AND vereinbarung.ist_nutzungsvereinbarung IS NOT TRUE
         -- und berücksichtige nur die neusten (sofern mehrere existieren)
         AND wbl_wiese.beurteilungsdatum = (SELECT MAX(beurteilungsdatum) FROM ${DB_Schema_MJPNL}.mjpnl_beurteilung_wbl_wiese b WHERE b.mit_bewirtschafter_besprochen IS TRUE AND b.vereinbarung = wbl_wiese.vereinbarung)
 ),

--- a/arp_mjpnl_zahlungslauf/calc_mjpnl_abrechnung_per_leistung_weide_ln.sql
+++ b/arp_mjpnl_zahlungslauf/calc_mjpnl_abrechnung_per_leistung_weide_ln.sql
@@ -23,7 +23,7 @@ WITH alle_weide_ln AS (
         weide_ln.vereinbarung = vereinbarung.t_id
     WHERE
         weide_ln.mit_bewirtschafter_besprochen IS TRUE
-        AND vereinbarung.status_vereinbarung = 'aktiv' AND vereinbarung.bewe_id_geprueft IS TRUE
+        AND vereinbarung.status_vereinbarung = 'aktiv' AND vereinbarung.bewe_id_geprueft IS TRUE AND vereinbarung.ist_nutzungsvereinbarung IS NOT TRUE
         -- und berücksichtige nur die neusten (sofern mehrere existieren)
         AND weide_ln.beurteilungsdatum = (SELECT MAX(beurteilungsdatum) FROM ${DB_Schema_MJPNL}.mjpnl_beurteilung_weide_ln b WHERE b.mit_bewirtschafter_besprochen IS TRUE AND b.vereinbarung = weide_ln.vereinbarung)
 ),

--- a/arp_mjpnl_zahlungslauf/calc_mjpnl_abrechnung_per_leistung_weide_soeg.sql
+++ b/arp_mjpnl_zahlungslauf/calc_mjpnl_abrechnung_per_leistung_weide_soeg.sql
@@ -23,7 +23,7 @@ WITH alle_weide_soeg AS (
         weide_soeg.vereinbarung = vereinbarung.t_id
     WHERE
         weide_soeg.mit_bewirtschafter_besprochen IS TRUE
-        AND vereinbarung.status_vereinbarung = 'aktiv' AND vereinbarung.bewe_id_geprueft IS TRUE
+        AND vereinbarung.status_vereinbarung = 'aktiv' AND vereinbarung.bewe_id_geprueft IS TRUE AND vereinbarung.ist_nutzungsvereinbarung IS NOT TRUE
         -- und berücksichtige nur die neusten (sofern mehrere existieren)
         AND weide_soeg.beurteilungsdatum = (SELECT MAX(beurteilungsdatum) FROM ${DB_Schema_MJPNL}.mjpnl_beurteilung_weide_soeg b WHERE b.mit_bewirtschafter_besprochen IS TRUE AND b.vereinbarung = weide_soeg.vereinbarung)
 ),

--- a/arp_mjpnl_zahlungslauf/calc_mjpnl_abrechnung_per_leistung_wiese.sql
+++ b/arp_mjpnl_zahlungslauf/calc_mjpnl_abrechnung_per_leistung_wiese.sql
@@ -23,7 +23,7 @@ WITH alle_wiese AS (
         wiese.vereinbarung = vereinbarung.t_id
     WHERE
         wiese.mit_bewirtschafter_besprochen IS TRUE
-        AND vereinbarung.status_vereinbarung = 'aktiv' AND vereinbarung.bewe_id_geprueft IS TRUE
+        AND vereinbarung.status_vereinbarung = 'aktiv' AND vereinbarung.bewe_id_geprueft IS TRUE AND vereinbarung.ist_nutzungsvereinbarung IS NOT TRUE
         -- und berücksichtige nur die neusten (sofern mehrere existieren)
         AND wiese.beurteilungsdatum = (SELECT MAX(beurteilungsdatum) FROM ${DB_Schema_MJPNL}.mjpnl_beurteilung_wiese b WHERE b.mit_bewirtschafter_besprochen IS TRUE AND b.vereinbarung = wiese.vereinbarung)
 ),

--- a/arp_mjpnl_zahlungslauf/calc_mjpnl_abrechnung_per_vereinbarung.sql
+++ b/arp_mjpnl_zahlungslauf/calc_mjpnl_abrechnung_per_vereinbarung.sql
@@ -89,7 +89,7 @@ FROM
   WHERE
     vbg.t_id IS NOT NULL AND 
     (
-      ( vbg.status_vereinbarung = 'aktiv' AND vbg.bewe_id_geprueft IS TRUE )
+      ( vbg.status_vereinbarung = 'aktiv' AND vbg.bewe_id_geprueft IS TRUE AND vbg.ist_nutzungsvereinbarung IS NOT TRUE)
       OR
       lstg.status_abrechnung != 'freigegeben' -- freigegebene Leistungen werden nur für aktive und geprüfte Vereinbarungen miteinbezogen
     )

--- a/arp_mjpnl_zahlungslauf/cleanup_mjpnl_abrechnung_per_leistung_status.sql
+++ b/arp_mjpnl_zahlungslauf/cleanup_mjpnl_abrechnung_per_leistung_status.sql
@@ -6,8 +6,7 @@ FROM ${DB_Schema_MJPNL}.mjpnl_vereinbarung vbg
 WHERE 
     l.vereinbarung = vbg.t_id
     AND NOT (
-        vbg.status_vereinbarung = 'aktiv'
-        AND vbg.bewe_id_geprueft IS TRUE
+        vbg.status_vereinbarung = 'aktiv' AND vbg.bewe_id_geprueft IS TRUE AND vbg.ist_nutzungsvereinbarung IS NOT TRUE
     )
     AND l.auszahlungsjahr = ${AUSZAHLUNGSJAHR}::integer
     AND l.status_abrechnung = 'freigegeben'

--- a/arp_mjpnl_zahlungslauf/copy_mjpnl_abrechnung_per_leistung.sql
+++ b/arp_mjpnl_zahlungslauf/copy_mjpnl_abrechnung_per_leistung.sql
@@ -48,7 +48,7 @@ relevante_vereinbarungen AS (
   -- alle aktiven vereinbarungen mit nur unbesprochener oder gar keiner beurteilung
   SELECT * 
   FROM ${DB_Schema_MJPNL}.mjpnl_vereinbarung vbg
-  WHERE vbg.status_vereinbarung = 'aktiv' AND vbg.bewe_id_geprueft IS TRUE
+  WHERE vbg.status_vereinbarung = 'aktiv' AND vbg.bewe_id_geprueft IS TRUE AND vbg.ist_nutzungsvereinbarung IS NOT TRUE
   AND vbg.t_id NOT IN (SELECT vereinbarung FROM alle_beurteilungen WHERE mit_bewirtschafter_besprochen IS TRUE)
 )
 -- alle letztjährigen leistungen der vereinbarungen mit nur unbesprochener oder gar keiner beurteilung

--- a/arp_mjpnl_zahlungslauf/delete_mjpnl_migrierte_leistungen.sql
+++ b/arp_mjpnl_zahlungslauf/delete_mjpnl_migrierte_leistungen.sql
@@ -42,6 +42,6 @@ WHERE
         FROM ${DB_Schema_MJPNL}.mjpnl_vereinbarung vbg
         LEFT JOIN alle_beurteilungen be
             ON be.vereinbarung = vbg.t_id
-        WHERE vbg.status_vereinbarung = 'aktiv' AND vbg.bewe_id_geprueft IS TRUE
+        WHERE vbg.status_vereinbarung = 'aktiv' AND vbg.bewe_id_geprueft IS TRUE AND vbg.ist_nutzungsvereinbarung IS NOT TRUE
             AND be.mit_bewirtschafter_besprochen IS TRUE
     )


### PR DESCRIPTION
 Prüfe ist_nutzungsvereinbarung, wenn man die Leistungen kalkuliert. Nutzungsvereinbarungen werden analog inaktiven Vereinbarungen nicht behandelt