### PR TITLE
[arp_mjpnl_v2_gelan_update] Area check bei Überschneidung Vbg und Kultur

### DIFF
--- a/arp_mjpnl_v2_gelan_update/mjpnl_update_vereinbarungen_gelan_kulturflaechen.sql
+++ b/arp_mjpnl_v2_gelan_update/mjpnl_update_vereinbarungen_gelan_kulturflaechen.sql
@@ -8,6 +8,8 @@ SET kultur_id=(
         AND
         ST_Intersects(kf.geometrie,vbg.geometrie)
         AND
+        ST_Area(ST_Intersection(kf.geometrie,vbg.geometrie))>1
+        AND
         (ST_MaximumInscribedCircle(ST_Intersection(kf.geometrie,vbg.geometrie))).radius > 1
     )
 WHERE


### PR DESCRIPTION
Offenbar kann ST_MaximumInscribedCircle bei gewissen Geometrien nicht gemacht werden, obwohl sie überschneiden und valide sind. Bei Area >1 geht es in diesem Fall und es ist allgemein ein Check der Sinn macht, denn vorher wurden viele minimale überschneidungen genommen.