### PR TITLE
[agi_av_mocheckso] Set default modeldir

### DIFF
--- a/agi_av_mocheckso/build.gradle
+++ b/agi_av_mocheckso/build.gradle
@@ -31,6 +31,7 @@ task downloadCsv(type: FtpDownload){
 task validateCsv(type: CsvValidator, dependsOn: 'downloadCsv') {
     description = "Validiert die heruntergeladene CSV-Datei (Tabs ersetzt mit Semikolon)"
     models = "SO_AGI_MOCheckSO_20200715"
+    if (findProperty('ilivalidatorModeldir')) modeldir = ilivalidatorModeldir
     firstLineIsHeader = true
     valueDelimiter = null
     valueSeparator = ';'


### PR DESCRIPTION
This way the CsvValidator will look for the model in the SO repo first