### PR TITLE
[awjf_waldportal] nächtliche Ausführung temporär deaktiviert

### DIFF
--- a/awjf_waldportal/job.properties
+++ b/awjf_waldportal/job.properties
@@ -1,3 +1,1 @@
-logRotator.numToKeep=30
-triggers.cron=H H(1-3) * * *
 authorization.permissions=gretl-users-vkfaa


### PR DESCRIPTION
Gretljob läuft zurzeit infolge eines Geometriefehlers nicht durch.