### PR TITLE
Agi schema dump

### DIFF
--- a/agi_schema_dump/Jenkinsfile
+++ b/agi_schema_dump/Jenkinsfile
@@ -40,14 +40,12 @@ pipeline {
                 git url: "${env.GIT_REPO_URL}", branch: "${params.BRANCH ?: 'main'}", changelog: false
                 container('processing-db') {
                     sh "pg_dump -Fc -h geodb.rootso.org -d ${params.dbname} -f /tmp/schema.dump -U ${ORG_GRADLE_PROJECT_dbUserEdit} -n ${params.schemaname}"
+                    archiveArtifacts '/tmp/schema.dump'
                 }                
             }
         }
     }
     post {
-        always {
-            archiveArtifacts '/tmp/schema.dump'
-        }
         unsuccessful {
             emailext (
                 // If build was started by a user ("UserIdCause"), then set to user that started the build (the "requestor");

--- a/agi_schema_dump/Jenkinsfile
+++ b/agi_schema_dump/Jenkinsfile
@@ -25,7 +25,13 @@ pipeline {
                       value: processing
                     - name: PGDATA
                       value: /var/lib/postgresql/data/pgdata
+                  envFrom:
+                    - configMapRef:
+                        name: "gretl-resources"
                   volumeMounts:
+                    - name: "gretl-secrets-volume"
+                      mountPath: "/home/gradle/.gradle/gradle.properties"
+                      subPath: "gradle.properties"
                     - name: postgresql-data-volume
                       mountPath: /var/lib/postgresql/data
               volumes:

--- a/agi_schema_dump/Jenkinsfile
+++ b/agi_schema_dump/Jenkinsfile
@@ -1,7 +1,38 @@
 pipeline {
-    agent { label env.NODE_LABEL ?: 'gretl' }
     options {
         timeout(time: 6, unit: 'HOURS')
+    }
+    agent {
+        kubernetes {
+            inheritFrom env.NODE_LABEL ?: 'gretl'
+            yamlMergeStrategy merge()
+            yaml '''
+            spec:
+              containers:
+                - name: processing-db
+                  image: sogis/postgis:16-3.4-bookworm
+                  resources:
+                    requests:
+                      cpu: 300m
+                      memory: "2Gi"
+                    limits:
+                      cpu: "2"
+                      memory: "8Gi"
+                  env:
+                    - name: POSTGRES_USER
+                      value: processing
+                    - name: POSTGRES_PASSWORD
+                      value: processing
+                    - name: PGDATA
+                      value: /var/lib/postgresql/data/pgdata
+                  volumeMounts:
+                    - name: postgresql-data-volume
+                      mountPath: /var/lib/postgresql/data
+              volumes:
+                - name: postgresql-data-volume
+                  emptyDir: {}
+'''
+        }
     }
     stages {
         stage('Run GRETL job') {
@@ -12,6 +43,8 @@ pipeline {
                         sh 'gretl'
                     }
                 }
+
+                ${params.schemaname}
             }
         }
     }

--- a/agi_schema_dump/Jenkinsfile
+++ b/agi_schema_dump/Jenkinsfile
@@ -45,9 +45,11 @@ pipeline {
             steps {
                 git url: "${env.GIT_REPO_URL}", branch: "${params.BRANCH ?: 'main'}", changelog: false
                 container('processing-db') {
-                    sh "pg_dump -Fc -h geodb.rootso.org -d ${params.dbname} -f /tmp/schema.dump -U ${ORG_GRADLE_PROJECT_dbUserEdit} -n ${params.schemaname}"
-                    archiveArtifacts '/tmp/schema.dump'
-                }                
+                    dir(env.JOB_BASE_NAME) {
+                        sh "./create_dump.sh geodb.rootso.org ${params.dbname} ${params.schemaname}"
+                        archiveArtifacts 'schema.dump'
+                    }
+                }
             }
         }
     }

--- a/agi_schema_dump/Jenkinsfile
+++ b/agi_schema_dump/Jenkinsfile
@@ -1,0 +1,32 @@
+pipeline {
+    agent { label env.NODE_LABEL ?: 'gretl' }
+    options {
+        timeout(time: 6, unit: 'HOURS')
+    }
+    stages {
+        stage('Run GRETL job') {
+            steps {
+                git url: "${env.GIT_REPO_URL}", branch: "${params.BRANCH ?: 'main'}", changelog: false
+                container('gretl') {
+                    dir(env.JOB_BASE_NAME) {
+                        sh 'gretl'
+                    }
+                }
+            }
+        }
+    }
+    post {
+        unsuccessful {
+            emailext (
+                // If build was started by a user ("UserIdCause"), then set to user that started the build (the "requestor");
+                // otherweise set to $DEFAULT_RECIPIENTS
+                // Good to know: $DEFAULT_RECIPIENTS is not a variable,
+                // but rather a token which will be replaced by the Email Extension plugin
+                // Docs: https://plugins.jenkins.io/email-ext/#plugin-content-tokens
+                to: "${currentBuild.getBuildCauses()[0]._class == 'hudson.model.Cause$UserIdCause' ? emailextrecipients([requestor()]) : '$DEFAULT_RECIPIENTS'}",
+                subject: "GRETL-Job ${JOB_NAME} (${BUILD_DISPLAY_NAME}) ist fehlgeschlagen",
+                body: "Die Ausführung des GRETL-Jobs ${JOB_NAME} (${BUILD_DISPLAY_NAME}) war nicht erfolgreich. Details dazu finden Sie in den Log-Meldungen unter ${RUN_DISPLAY_URL}."
+            )
+        }
+    }
+}

--- a/agi_schema_dump/Jenkinsfile
+++ b/agi_schema_dump/Jenkinsfile
@@ -40,18 +40,20 @@ pipeline {
                 ORG_GRADLE_PROJECT_dbUriProcessing = 'jdbc:postgresql://127.0.0.1/processing'
                 ORG_GRADLE_PROJECT_dbUserProcessing = 'processing'
                 ORG_GRADLE_PROJECT_dbPwdProcessing = 'processing'
+                PGPASSWORD = "${ORG_GRADLE_PROJECT_dbPwdEdit}"
             }
             steps {
                 git url: "${env.GIT_REPO_URL}", branch: "${params.BRANCH ?: 'main'}", changelog: false
                 container('processing-db') {
-                    dir(env.JOB_BASE_NAME) {
-                        sh "pg_dump -Fc -h geodb.rootso.org -d ${params.dbname} -f /tmp/schema.dump -U gretl -n ${params.schemaname}"
-                    }
+                    sh "pg_dump -Fc -h geodb.rootso.org -d ${params.dbname} -f /tmp/schema.dump -U ${ORG_GRADLE_PROJECT_dbUserEdit} -n ${params.schemaname}"
                 }                
             }
         }
     }
     post {
+        always {
+            archiveArtifacts '/tmp/schema.dump'
+        }
         unsuccessful {
             emailext (
                 // If build was started by a user ("UserIdCause"), then set to user that started the build (the "requestor");

--- a/agi_schema_dump/Jenkinsfile
+++ b/agi_schema_dump/Jenkinsfile
@@ -35,16 +35,19 @@ pipeline {
         }
     }
     stages {
-        stage('Run GRETL job') {
+        stage('Run job') {
+            environment {
+                ORG_GRADLE_PROJECT_dbUriProcessing = 'jdbc:postgresql://127.0.0.1/processing'
+                ORG_GRADLE_PROJECT_dbUserProcessing = 'processing'
+                ORG_GRADLE_PROJECT_dbPwdProcessing = 'processing'
+            }
             steps {
                 git url: "${env.GIT_REPO_URL}", branch: "${params.BRANCH ?: 'main'}", changelog: false
-                container('gretl') {
+                container('processing-db') {
                     dir(env.JOB_BASE_NAME) {
-                        sh 'gretl'
+                        sh "pg_dump -Fc -h geodb.rootso.org -d ${params.dbname} -f /tmp/schema.dump -U gretl -n ${params.schemaname}"
                     }
-                }
-
-                ${params.schemaname}
+                }                
             }
         }
     }

--- a/agi_schema_dump/Jenkinsfile
+++ b/agi_schema_dump/Jenkinsfile
@@ -36,12 +36,6 @@ pipeline {
     }
     stages {
         stage('Run job') {
-            environment {
-                ORG_GRADLE_PROJECT_dbUriProcessing = 'jdbc:postgresql://127.0.0.1/processing'
-                ORG_GRADLE_PROJECT_dbUserProcessing = 'processing'
-                ORG_GRADLE_PROJECT_dbPwdProcessing = 'processing'
-                PGPASSWORD = "${ORG_GRADLE_PROJECT_dbPwdEdit}"
-            }
             steps {
                 git url: "${env.GIT_REPO_URL}", branch: "${params.BRANCH ?: 'main'}", changelog: false
                 container('processing-db') {

--- a/agi_schema_dump/build.gradle
+++ b/agi_schema_dump/build.gradle
@@ -1,1 +1,1 @@
-// Leeres build.gradle, damit dieser Job vom Job "Sauger" auch aufgenommen wird.
+// This empty build.gradle file is necessary for gretl-job-generator to find this job in the repo and create it in Jenkins

--- a/agi_schema_dump/build.gradle
+++ b/agi_schema_dump/build.gradle
@@ -1,0 +1,1 @@
+// Leeres build.gradle, damit dieser Job vom Job "Sauger" auch aufgenommen wird.

--- a/agi_schema_dump/create_dump.sh
+++ b/agi_schema_dump/create_dump.sh
@@ -8,7 +8,7 @@ DBSCHEMANAME=$3
 
 export PGHOST
 export PGDATABASE
-export PGUSER=`awk -F '=' '$1 == "dbUserEdit" { print $2 }' ${PROPERTYFILE}`
-export PGPASSWORD=`awk -F '=' '$1 == "dbPwdEdit" { print $2 }' ${PROPERTYFILE}`
+export PGUSER=`awk -F ' *[=|:] *' '$1 == "dbUserEdit" { print $2 }' ${PROPERTYFILE}`
+export PGPASSWORD=`awk -F ' *[=|:] *' '$1 == "dbPwdEdit" { print $2 }' ${PROPERTYFILE}`
 
 pg_dump -Fc -n ${DBSCHEMANAME} -f schema.dump

--- a/agi_schema_dump/create_dump.sh
+++ b/agi_schema_dump/create_dump.sh
@@ -8,7 +8,7 @@ DBSCHEMANAME=$3
 
 export PGHOST
 export PGDATABASE
-export PGUSER=`awk -F ' *[=|:] *' '$1 == "dbUserEdit" { print $2 }' ${PROPERTYFILE}`
-export PGPASSWORD=`awk -F ' *[=|:] *' '$1 == "dbPwdEdit" { print $2 }' ${PROPERTYFILE}`
+export PGUSER=`awk -F ' *[=|:] *' '$1 == "dbUserEditDdl" { print $2 }' ${PROPERTYFILE}`
+export PGPASSWORD=`awk -F ' *[=|:] *' '$1 == "dbPwdEditDdl" { print $2 }' ${PROPERTYFILE}`
 
 pg_dump -Fc -n ${DBSCHEMANAME} -f schema.dump

--- a/agi_schema_dump/create_dump.sh
+++ b/agi_schema_dump/create_dump.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+PROPERTYFILE=/home/gradle/.gradle/gradle.properties
+
+PGHOST=$1
+PGDATABASE=$2
+DBSCHEMANAME=$3
+
+export PGHOST
+export PGDATABASE
+export PGUSER=`awk -F '=' '$1 == "dbUserEdit" { print $2 }' ${PROPERTYFILE}`
+export PGPASSWORD=`awk -F '=' '$1 == "dbPwdEdit" { print $2 }' ${PROPERTYFILE}`
+
+pg_dump -Fc -n ${DBSCHEMANAME} -f schema.dump

--- a/agi_schema_dump/job.properties
+++ b/agi_schema_dump/job.properties
@@ -1,4 +1,4 @@
 logRotator.numToKeep=2
-parameters.stringParams=parameterName;default value;parameter description
-parameters.stringParams=schemaname;mySchema;Name des Schemas, welches in den Dump exportiert werden soll.
+parameters.stringParams=dbname;edit;Name der Datenbank, aus der exportiert wird (edit oder pub)@\
+                        schemaname;mySchema;Name des Schemas, welches in den Dump exportiert werden soll.
 authorization.permissions=gretl-users-barpa

--- a/agi_schema_dump/job.properties
+++ b/agi_schema_dump/job.properties
@@ -1,0 +1,4 @@
+logRotator.numToKeep=2
+parameters.stringParams=parameterName;default value;parameter description
+parameters.stringParams=schemaname;mySchema;Name des Schemas, welches in den Dump exportiert werden soll.
+authorization.permissions=gretl-users-barpa

--- a/agi_schema_dump/job.properties
+++ b/agi_schema_dump/job.properties
@@ -1,4 +1,3 @@
 logRotator.numToKeep=2
 parameters.stringParams=dbname;edit;Name der Datenbank, aus der exportiert wird (edit oder pub)@\
-                        schemaname;mySchema;Name des Schemas, welches in den Dump exportiert werden soll.
-authorization.permissions=gretl-users-barpa
+                        schemaname;mySchema;Name des Schemas, welches in den Dump exportiert werden soll


### PR DESCRIPTION
@schmandr Wie besprochen.

Bemerkungen / Fragen:

- Verwenden von ORG_GRADLE_PROJECT_dbUserEdit / dbPwdEdit auch für die Pub-Db sollte in Ordnung sein, oder?
- archiveArtifacts '/tmp/schema.dump' wird wahrscheinlich noch nicht funktionieren, da wohl kein volume Mount auf /tmp existiert und da  gemäss Jenkins Dok "archiveArtifacts" nur auf den Inhalt des "Workspace-Ordners" (und darunter) zugreifen kann - also wohl nicht auf /tmp
- geodb.rootso.org ist noch hardcodiert, da ich nicht weiss, ob eine entsprechende env existiert für die hosts 
- pg_dump sollte nicht nach dem Passwort "promten", da die env PGPASSWORD gesetzt ist - funktioniert beim lokalen ausprobieren.

Falls dies noch zu viele Fragezeichen sind: Vertragen und beispielsweise Sandra bitten, einen Dump des Edit-Schemas agi_av_gb_abgleich_import zu ziehen.

