### PR TITLE
[docker-compose] Avoid permission issues

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,10 +19,8 @@ services:
         source: ${TMP:-/tmp}
         target: /gretl-share
       - type: bind
-        source: /tmp/gradlecaches
+        source: ${TMP:-/tmp}
         target: /home/gradle/.gradle/caches
-        bind:
-          create_host_path: true
   edit-db:
     image: postgis/postgis:16-3.4
     environment:


### PR DESCRIPTION
Avoid permission issues by using an existing directory as source