### PR TITLE
[agi_av_kaso_abgleich] reference new edit schema

### DIFF
--- a/agi_av_kaso_abgleich_pub/agi_av_kaso_abgleich_import_differenzen_staging.sql
+++ b/agi_av_kaso_abgleich_pub/agi_av_kaso_abgleich_import_differenzen_staging.sql
@@ -1,4 +1,4 @@
-DELETE FROM agi_av_kaso_abgleich_import.differenzen_staging
+DELETE FROM agi_av_kaso_abgleich_v1.differenzen_staging
 ;
 
 WITH 
@@ -127,12 +127,12 @@ av_projektierte_grundstuecke AS (
             kaso.gb_flaeche AS kaso_flaeche,
             kaso.gb_gueltigbis AS kaso_historisiert
         FROM
-            agi_av_kaso_abgleich_import.kaso_daten AS kaso
+            agi_av_kaso_abgleich_v1.kaso_daten AS kaso
             JOIN grundbuchkreise AS grundbuchamt
                 ON grundbuchamt.gb_gemnr = kaso.geb_bfsnr::integer
       )
 
-INSERT INTO agi_av_kaso_abgleich_import.differenzen_staging (
+INSERT INTO agi_av_kaso_abgleich_v1.differenzen_staging (
     geometrie,
     av_lieferdatum,
     av_gem_bfs,

--- a/agi_av_kaso_abgleich_pub/agi_av_kaso_abgleich_import_uebersicht_des_vergleichs_staging.sql
+++ b/agi_av_kaso_abgleich_pub/agi_av_kaso_abgleich_import_uebersicht_des_vergleichs_staging.sql
@@ -1,4 +1,4 @@
-DELETE FROM agi_av_kaso_abgleich_import.uebersicht_des_vergleichs_staging
+DELETE FROM agi_av_kaso_abgleich_v1.uebersicht_des_vergleichs_staging
 ;
 
 WITH 
@@ -18,7 +18,7 @@ WITH
             av.av_gem_bfs, 
             count(av.av_gem_bfs) AS anzahl
         FROM 
-            agi_av_kaso_abgleich_import.differenzen_staging AS av
+            agi_av_kaso_abgleich_v1.differenzen_staging AS av
         WHERE 
             av.av_gem_bfs IS NOT NULL 
             AND 
@@ -31,7 +31,7 @@ WITH
             kaso.kaso_bfs_nr, 
             count(kaso.kaso_bfs_nr) AS anzahl
         FROM 
-            agi_av_kaso_abgleich_import.differenzen_staging AS kaso
+            agi_av_kaso_abgleich_v1.differenzen_staging AS kaso
         WHERE 
             kaso.kaso_bfs_nr IS NOT NULL 
             AND 
@@ -40,7 +40,7 @@ WITH
             kaso.kaso_bfs_nr
     )
     
-INSERT INTO agi_av_kaso_abgleich_import.uebersicht_des_vergleichs_staging (
+INSERT INTO agi_av_kaso_abgleich_v1.uebersicht_des_vergleichs_staging (
     t_id,
     geometrie,
     gem_bfs,

--- a/agi_av_kaso_abgleich_pub/agi_av_kaso_abgleich_pub_differenzen.sql
+++ b/agi_av_kaso_abgleich_pub/agi_av_kaso_abgleich_pub_differenzen.sql
@@ -19,5 +19,5 @@ SELECT
     fehlerart,
     fehlerart_text
 FROM
-    agi_av_kaso_abgleich_import.differenzen_staging
+    agi_av_kaso_abgleich_v1.differenzen_staging
 ;

--- a/agi_av_kaso_abgleich_pub/agi_av_kaso_abgleich_pub_uebersicht_des_vergleichs.sql
+++ b/agi_av_kaso_abgleich_pub/agi_av_kaso_abgleich_pub_uebersicht_des_vergleichs.sql
@@ -5,5 +5,5 @@ SELECT
     aname,
     anzahl_differenzen
 FROM
-    agi_av_kaso_abgleich_import.uebersicht_des_vergleichs_staging
+    agi_av_kaso_abgleich_v1.uebersicht_des_vergleichs_staging
 ;

--- a/agi_av_kaso_abgleich_pub/build.gradle
+++ b/agi_av_kaso_abgleich_pub/build.gradle
@@ -9,7 +9,7 @@ task transferKasoData(type: Db2Db){
     sourceDb = [dbUriKaso, dbUserKaso, dbPwdKaso]
     targetDb = [dbUriEdit, dbUserEdit, dbPwdEdit]
     transferSets = [
-            new TransferSet('agi_av_kaso_abgleich_import_kaso_daten.sql', 'agi_av_kaso_abgleich_import.kaso_daten', true)
+            new TransferSet('agi_av_kaso_abgleich_import_kaso_daten.sql', 'agi_av_kaso_abgleich_v1.kaso_daten', true)
     ];
 }
 

--- a/agi_av_kaso_abgleich_pub/delete_from_agi_av_kaso_abgleich_import.sql
+++ b/agi_av_kaso_abgleich_pub/delete_from_agi_av_kaso_abgleich_import.sql
@@ -1,6 +1,6 @@
-DELETE FROM agi_av_kaso_abgleich_import.kaso_daten
+DELETE FROM agi_av_kaso_abgleich_v1.kaso_daten
 ;
-DELETE FROM agi_av_kaso_abgleich_import.differenzen_staging
+DELETE FROM agi_av_kaso_abgleich_v1.differenzen_staging
 ;
-DELETE FROM agi_av_kaso_abgleich_import.uebersicht_des_vergleichs_staging
+DELETE FROM agi_av_kaso_abgleich_v1.uebersicht_des_vergleichs_staging
 ;


### PR DESCRIPTION
**Hintergrund**:

Auftrag: https://sogis.openproject.com/projects/task/work_packages/2660
Das Edit Schema des Topics agi_av_kaso_abgleich wird auf Basis eines bestehenden Modells neu durch einen Schema Job angelegt (bisher manuell), siehe https://github.com/sogis/schema-jobs/commit/5a50af47b2d10e4d925aa0eadbd792eb53d8cfdd. Der alte Schema Name ist `agi_av_kaso_abgleich_import`, der neue, standardkonforme ist `agi_av_kaso_abgleich_v1`.

**Änderung**:

Dieser Pull Request betrifft den Daten-Job, der neu das Edit Schema `agi_av_kaso_abgleich_v1` referenziert (anstatt ...`_import`).

**Testbericht**:

Der Change wurde auf TEST und INT erfolgreich getestet (Schema-Job und Daten-Job fehlerfrei ausgeführt). Das neue Schema DDL unterscheidet sich einzig durch zusätzliche Constraints vom alten, und ein paar Attribute wurden von ili2pg als int8 anstatt wie bisher als int4 umgesetzt, was m.E. keine Einschränkung bedeuten sollte.