### PR TITLE
[afu_hydro_messstationen_pub]Coalesce bei Gemeindenamen

### DIFF
--- a/afu_hydro_messstationen_pub/messstationen.sql
+++ b/afu_hydro_messstationen_pub/messstationen.sql
@@ -2,7 +2,7 @@ SELECT
     typ, 
     '' AS typ_txt, 
     aname, 
-    gemeindegrenzen.gemeindename AS gemeinde, 
+    COALESCE(gemeindegrenzen.gemeindename,'ausserhalb Kanton SO') AS gemeinde, 
     stationsnummer, 
     st_x(messstation.geometrie) AS x, 
     st_y(messstation.geometrie) AS y, 


### PR DESCRIPTION
Es gibt auch Messstationen ausserhalb des Kantons. Diese dürfen bei der Publikation nicht zu einem Fehler führen. 