### PR TITLE
Upgrade to PostgreSQL 17

### DIFF
--- a/agi_schema_dump/Jenkinsfile
+++ b/agi_schema_dump/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
             spec:
               containers:
                 - name: processing-db
-                  image: sogis/postgis:16-3.4-bookworm
+                  image: postgis/postgis:17-3.5-alpine
                   resources:
                     requests:
                       cpu: 300m

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
         source: ${TMP:-/tmp}
         target: /home/gradle/.gradle/caches
   edit-db:
-    image: postgis/postgis:16-3.4
+    image: postgis/postgis:17-3.5
     environment:
       POSTGRES_DB: edit
       POSTGRES_PASSWORD: secret
@@ -43,7 +43,7 @@ services:
         source: pgdata_edit
         target: /var/lib/postgresql/data
   pub-db:
-    image: postgis/postgis:16-3.4
+    image: postgis/postgis:17-3.5
     environment:
       POSTGRES_DB: pub
       POSTGRES_PASSWORD: secret
@@ -77,7 +77,7 @@ services:
         target: /var/lib/postgresql/data
   db-tools:
     profiles: ["tools"]
-    image: postgis/postgis:16-3.4
+    image: postgis/postgis:17-3.5
     environment:
       PGPASSWORD: ddluser
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,7 +65,7 @@ services:
         target: /var/lib/postgresql/data
   processing-db:
     profiles: ["processing"]
-    image: sogis/postgis:16-3.4-bookworm
+    image: postgis/postgis:17-3.5-alpine
     environment:
       POSTGRES_USER: processing
       POSTGRES_PASSWORD: processing


### PR DESCRIPTION
And switch processing DB images to Alpine (postgis/postgis: 17-3.5-alpine) at the same time. This way maintenance of the sogis/postgis:16-3.4-bookworm image isn't needed anymore:
* https://github.com/sogis/docker-postgis/tree/main/16-3.4-bookworm
* https://hub.docker.com/r/sogis/postgis/tags?name=bookworm