### PR TITLE
[afu_naturgefahren_produkte] Upgrade processing DB to tag 17-3.5-alpine

### DIFF
--- a/afu_naturgefahren_produkte/Jenkinsfile
+++ b/afu_naturgefahren_produkte/Jenkinsfile
@@ -7,7 +7,7 @@ pipeline {
             spec:
               containers:
                 - name: processing-db
-                  image: sogis/postgis:16-3.4-bookworm
+                  image: postgis/postgis:17-3.5-alpine
                   resources:
                     requests:
                       cpu: 300m


### PR DESCRIPTION
And switch to Alpine image postgis/postgis:17-3.5-alpine at the same time.