### PR TITLE
[alw_fruchtfolgeflaechen] Upgrade processing DB to tag 17-3.5-alpine

### DIFF
--- a/alw_fruchtfolgeflaechen/Jenkinsfile
+++ b/alw_fruchtfolgeflaechen/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
             spec:
               containers:
                 - name: processing-db
-                  image: sogis/postgis:16-3.4-bookworm
+                  image: postgis/postgis:17-3.5-alpine
                   resources:
                     requests:
                       cpu: 300m


### PR DESCRIPTION
And switch to Alpine image postgis/postgis:17-3.5-alpine at the same time.