### PR TITLE
[arp_mjpnl_v2_ggelan_update] remove cron job 

### DIFF
--- a/arp_mjpnl_v2_gelan_update/job.properties
+++ b/arp_mjpnl_v2_gelan_update/job.properties
@@ -1,3 +1,2 @@
 authorization.permissions=gretl-users-barpa,exopesig,exopecam
 logRotator.numToKeep=30
-triggers.cron=H H(1-3) * * *


### PR DESCRIPTION
because of empty gelan data risk