### PR TITLE
[arp_mjpnatur_gelan_export]Anpassungen gemäss David Signer vom 8. Apr…

### DIFF
--- a/arp_mjpnatur_gelan_export/arp_mjpnatur_gelan.sql
+++ b/arp_mjpnatur_gelan_export/arp_mjpnatur_gelan.sql
@@ -2,6 +2,7 @@ DELETE FROM arp_mjpnl_gelan_v1.mehrjahresprgramm_vereinbarungensflaechen
 ;
 
 INSERT INTO arp_mjpnl_gelan_v1.mehrjahresprgramm_vereinbarungensflaechen (
+    t_ili_tid,
     geometrie, 
     artcode, 
     ueberlagernd, 
@@ -12,6 +13,7 @@ INSERT INTO arp_mjpnl_gelan_v1.mehrjahresprgramm_vereinbarungensflaechen (
 )
 
 SELECT 
+    vereinbarung.t_ili_tid,
     vereinbarung.geometrie,
     CASE 
         WHEN vereinbarungsart IN ('Wiese', 'WBL_Wiese') THEN 42055 --Wiesen


### PR DESCRIPTION
Anpassungen gemäss David Signer vom 8. April 2026
t_ili_tid wird jetzt von den Vereinbarungen übernommen. Dies ermöglicht eine besseren Fehlersuche z.B. bei Geometriefehlern. 