### PR TITLE
[agi_av_gb_administrative_einteilungen_pub]  Anpassung auf neue DMAV Modell

### DIFF
--- a/agi_av_gb_administrative_einteilungen_pub/build.gradle
+++ b/agi_av_gb_administrative_einteilungen_pub/build.gradle
@@ -22,7 +22,7 @@ task exportDataEdit (type: Ili2pgExport, dependsOn:'transferDMAV') {
     description = "Exportiert die Daten dem Schema agi_dmav_untereinheit_grundbuch_v1 in eine INTERLIS-Datei."
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     dbschema = 'agi_dmav_untereinheit_grundbuch_v1'
-    models = 'DMAVSUP_UntereinheitGrundbuch_V1_0'
+    models = 'DMAVSUP_UntereinheitGrundbuch_V1_1'
     dataFile = file("ch.so.agi.dmav.relational.untereinheitgrundbuch.xtf")
     disableValidation = true
 }
@@ -37,7 +37,7 @@ task validateDataEdit(type: IliValidator, dependsOn:'exportDataEdit') {
 
 task publiedit(type: Publisher, dependsOn:'validateDataEdit'){
     dataIdent = "ch.so.agi.dmav.relational.untereinheitgrundbuch"
-    modelsToPublish = "DMAVSUP_UntereinheitGrundbuch_V1_0"
+    modelsToPublish = "DMAVSUP_UntereinheitGrundbuch_V1_1"
     userFormats = false
     sourcePath = file("ch.so.agi.dmav.relational.untereinheitgrundbuch.xtf")
     if (findProperty('ilivalidatorModeldir')) modeldir = ilivalidatorModeldir

--- a/agi_av_gb_administrative_einteilungen_pub/dmav_transfer.sql
+++ b/agi_av_gb_administrative_einteilungen_pub/dmav_transfer.sql
@@ -24,7 +24,8 @@ WITH grundbucheinheit AS (
         kreis.nbident,
         kreis.aname,
         kreis.nbident AS egris_subkreis,
-        kreis.grundbuchkreisnummer AS egris_los
+        kreis.grundbuchkreisnummer AS egris_los,
+        kreis.perimeter AS geometrie
      FROM
         agi_av_gb_administrative_einteilungen_v2.grundbuchkreise_grundbuchkreis AS kreis
     )
@@ -58,7 +59,8 @@ WITH grundbucheinheit AS (
         kreis.nbident,
         kreis.aname,
         kreis.nbident AS egris_subkreis,
-        kreis.grundbuchkreisnummer AS egris_los
+        kreis.grundbuchkreisnummer AS egris_los,
+        kreis.perimeter AS geometrie
      FROM
         agi_av_gb_administrative_einteilungen_v2.grundbuchkreise_grundbuchkreis AS kreis
     )
@@ -73,7 +75,8 @@ SELECT
     kreis.nbident,
     kreis.aname,
     kreis.egris_subkreis,
-    kreis.egris_los
+    kreis.egris_los,
+    kreis.geometrie
 FROM
    grundbucheinheit AS kreis
     LEFT JOIN

--- a/agi_av_gb_administrative_einteilungen_pub/dmav_transfer.sql
+++ b/agi_av_gb_administrative_einteilungen_pub/dmav_transfer.sql
@@ -43,7 +43,7 @@ INSERT INTO agi_dmav_untereinheit_grundbuch_v1.t_ili2db_basket
 SELECT
     nextval('agi_dmav_untereinheit_grundbuch_v1.t_ili2db_seq'::regclass) AS t_id,
     dataset.t_id AS dataset,
-    'DMAVSUP_UntereinheitGrundbuch_V1_0.UntereinheitGrundbuch' AS topic,
+    'DMAVSUP_UntereinheitGrundbuch_V1_1.UntereinheitGrundbuch' AS topic,
     'dmav_untereinheit_grundbuch_' || dataset.datasetname AS t_ili_tid,
     dataset.datasetname AS attachmentkey,
     NULL AS domains


### PR DESCRIPTION
Der Bund hat Anpassungen vorgenommen an den Datenmodellen (Kreisschreiben AV 2026 / 01 Modelldokumentation «Geodatenmodell der amtlichen Vermessung DMAV Version 1.0 – Änderung vom 1. Februar 2026»)